### PR TITLE
Add clang-format to pre-commit config.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,24 @@ repos:
 - repo: local
   hooks:
   - id: checkbashisms
-    name: check for bashisms in /bin/sh scripts
+    name: Check for bashisms in /bin/sh scripts
     entry: ./tests/Scripts/3rdparty/checkbashisms.pl
     language: script
     files: '.*\.sh'
+
   - id: autogen-docs
     name: Check that generated documentation is up-to-date
     entry: ./scripts/autogen-docs
     language: script
+
     pass_filenames: false
+  - id: clang-format
+    name: Run clang-format on code
+    entry: ./scripts/run-clang-format
+    args: ["--pre-commit-hook"]
+    files: ^(hilti|spicy|zeek)/.*\.(c|h|C|H|cpp|hpp|cc|hh|c\+\+|h\+\+|cxx|hxx)$
+    language: script
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.5.0
   hooks:

--- a/scripts/run-clang-format
+++ b/scripts/run-clang-format
@@ -4,39 +4,62 @@
 
 base=$(dirname $0)
 fix=0
+pre_commit_hook=0
+
+# Directories to run on by default. When changing, adapt .pre-commit-config.yam
+# as well.
+files="hilti spicy zeek"
+
+error() {
+    test "${pre_commit_hook}" = 0 && echo "$@" >&2 && exit 1
+    exit 0
+}
 
 if [ $# != 0 ]; then
-    if [ "$1" = "--fixit" ]; then
-        fix=1
-    else
-        echo "usage: $(basename $0) [--fixit]"
-        exit 1
-    fi
+    case "$1" in
+        --fixit)
+            shift
+            fix=1
+            ;;
+
+        --pre-commit-hook)
+            shift
+            fix=1
+            pre_commit_hook=1
+            ;;
+
+        -*)
+            echo "usage: $(basename $0) [--fixit | --pre-commit-hook] [<files>]"
+            exit 1
+    esac
 fi
+
+test $# != 0 && files="$@"
 
 if [ -z "${CLANG_FORMAT}" ]; then
     CLANG_FORMAT=$(which clang-format 2>/dev/null)
 fi
 
 if [ -z "${CLANG_FORMAT}" -o ! -x "${CLANG_FORMAT}" ]; then
-    echo "Cannot find clang-format. If not in PATH, set CLANG_FORMAT."
-    exit 1
+    error "Cannot find clang-format. If not in PATH, set CLANG_FORMAT."
 fi
 
 if ! (cd / && ${CLANG_FORMAT} -dump-config | grep -q SpacesInConditionalStatement); then
-    echo "${CLANG_FORMAT} does not support SpacesInConditionalStatement. Install custom version and put it into PATH, or point CLANG_FORMAT to it."
-    exit 1
+    error "${CLANG_FORMAT} does not support SpacesInConditionalStatement. Install custom version and put it into PATH, or point CLANG_FORMAT to it."
 fi
 
 if [ ! -e .clang-format ]; then
-   echo "Must execute in top-level directory."
-   exit 1
+    error "Must execute in top-level directory."
 fi
 
-cmd="${base}/3rdparty/run-clang-format/run-clang-format.py -r --clang-format-executable ${CLANG_FORMAT} --exclude '*/3rdparty/*' hilti spicy zeek"
+cmd="${base}/3rdparty/run-clang-format/run-clang-format.py -r --clang-format-executable ${CLANG_FORMAT} --exclude '*/3rdparty/*' ${files}"
+tmp=/tmp/$(basename $0).$$.tmp
+trap "rm -f ${tmp}" EXIT
+eval "${cmd}" >"${tmp}"
 
-if [ ${fix} = 1 ]; then
-    eval ${cmd} | git apply -p0
+if [ "${fix}" = 1 ]; then
+    test -s "${tmp}" && cat "${tmp}" | git apply -p0
+    true
 else
-    eval ${cmd}
+    cat "${tmp}"
 fi


### PR DESCRIPTION
This includes:

    - Add new "--pre-commit-hook" option to the "run-clang-format"
      script. This implicitly enables --fixit but will fail silently
      (and without any error exit code), if the script can't find a
      suitable clang-format, hence allowing usage from a pre-commit
      hook without forcing everybody to have the right clang-format
      available.

    - Support specifying individual files to run-clang-format for
      processing. The default remains scanning everything inside the
      main code directories.

    - Fix existing bug in run-clang-format where with --fixit it would
      complain if there actually wasn't anything to fix.

    - Add run-clang-format to .pre-commit-config.yaml.