### PR TITLE
Tweak docs so they can be built without a build tree

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ clean:
 html: Makefile autogen-docs
 	@rm -f "$(BUILDDIR)/doc-root" && ln -s "../doc" "$(BUILDDIR)/doc-root"
 	@  # The RTD theme might be producing RemovedInSphinx30Warning
-	@PYTHONWARNINGS="ignore" SPICY_BUILD_DIRECTORY=$(BUILDDIR) $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
+	@PYTHONWARNINGS="ignore" $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
 	@echo Built documentation in $(DESTDIR)/html/index.html
 
 autogen-docs:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,9 +18,6 @@ import subprocess
 
 sys.path.insert(0, os.path.abspath('scripts'))
 
-os.environ["PATH"] = "%s/bin:%s" % (
-    os.environ["SPICY_BUILD_DIRECTORY"], os.environ["PATH"])
-
 # -- Project information -----------------------------------------------------
 
 project = u'Spicy'

--- a/doc/zeek.rst
+++ b/doc/zeek.rst
@@ -436,7 +436,7 @@ The Spicy plugin provides a set of script-level options to tune its
 behavior, similar to what the :ref:`spicy-driver` provides as
 command-line arguments:
 
-.. literalinclude:: /../../zeek/plugin/scripts/base/spicy/main.zeek
+.. literalinclude:: /../zeek/plugin/scripts/base/spicy/main.zeek
     :language: bro
     :start-after: doc-start
     :end-before:  doc-end

--- a/hilti/src/base/util.cc
+++ b/hilti/src/base/util.cc
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
 
+#include <unistd.h>
+
 #include <sys/errno.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
These changes are required for e.g., building the docs with readthedocs.