### PR TITLE
Fix generation of escaped C++ string literals.

### DIFF
--- a/hilti/include/base/util.h
+++ b/hilti/include/base/util.h
@@ -409,6 +409,15 @@ using hilti::rt::escapeUTF8;
 using hilti::rt::expandEscapes;
 
 /**
+ * Wrapper for `escapeBytes` that produces a valid C++ string literal.
+ *
+ * @param s string to escape
+ * @return escaped std::string
+ *
+ */
+inline std::string escapeBytesForCxx(std::string_view s) { return escapeBytes(std::move(s), true, true, true); }
+
+/**
  * Turns an arbitrary string into something that can be used as C-level
  * identifier.
  *

--- a/hilti/include/rt/util.h
+++ b/hilti/include/rt/util.h
@@ -229,9 +229,13 @@ std::string expandEscapes(std::string s);
  * @param str string to escape
  * @param escape_quotes if true, also escapes quotes characters
  * @param escape_control if false, do not escape control characters
+ * @param use_octal use `\NNN` instead of `\XX` (needed for C++)
  * @return escaped string
+ *
+ * \todo This is getting messy; should use enums instead of booleans.
  */
-std::string escapeBytes(std::string_view s, bool escape_quotes = false, bool escape_control = true);
+std::string escapeBytes(std::string_view s, bool escape_quotes = false, bool escape_control = true,
+                        bool use_octal = false);
 
 /*
  * Escapes non-printable and control characters in an UTF8 string. This
@@ -242,6 +246,8 @@ std::string escapeBytes(std::string_view s, bool escape_quotes = false, bool esc
  * @param escape_control if false, do not escape control characters
  * @param keep_hex if true, do not escape our custom "\xYY" escape codes
  * @return escaped std::string
+ *
+ * \todo This is getting messy; should use enums instead of booleans.
  */
 std::string escapeUTF8(std::string_view s, bool escape_quotes = false, bool escape_control = true,
                        bool keep_hex = false);

--- a/hilti/src/compiler/codegen/ctors.cc
+++ b/hilti/src/compiler/codegen/ctors.cc
@@ -22,7 +22,7 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const ctor::Bool& n) { return n.value() ? "true" : "false"; }
 
-    result_t operator()(const ctor::Bytes& n) { return fmt("\"%s\"_b", util::escapeBytes(n.value(), true)); }
+    result_t operator()(const ctor::Bytes& n) { return fmt("\"%s\"_b", util::escapeBytesForCxx(n.value())); }
 
     result_t operator()(const ctor::Coerced& n) { return cg->compile(n.coercedCtor()); }
 
@@ -137,7 +137,7 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
     }
 
     result_t operator()(const ctor::Stream& n) {
-        return fmt("hilti::rt::Stream(\"%s\"_b)", util::escapeBytes(n.value(), true));
+        return fmt("hilti::rt::Stream(\"%s\"_b)", util::escapeBytesForCxx(n.value()));
     }
 
     result_t operator()(const ctor::String& n) { return fmt("std::string(\"%s\")", util::escapeUTF8(n.value(), true)); }

--- a/hilti/src/rt/util.cc
+++ b/hilti/src/rt/util.cc
@@ -260,7 +260,7 @@ std::string hilti::rt::escapeUTF8(std::string_view s, bool escape_quotes, bool e
     return esc;
 }
 
-std::string hilti::rt::escapeBytes(std::string_view s, bool escape_quotes, bool escape_control) {
+std::string hilti::rt::escapeBytes(std::string_view s, bool escape_quotes, bool escape_control, bool use_octal) {
     auto p = s.data();
     auto e = p + s.size();
 
@@ -276,6 +276,8 @@ std::string hilti::rt::escapeBytes(std::string_view s, bool escape_quotes, bool 
         else if ( isprint(*p) )
             esc += *p;
 
+        else if ( use_octal )
+            esc += fmt("\\%03o", static_cast<uint8_t>(*p));
         else
             esc += fmt("\\x%02x", static_cast<uint8_t>(*p));
 

--- a/hilti/tests/util.cc
+++ b/hilti/tests/util.cc
@@ -28,3 +28,15 @@ TEST_CASE("enum string conversion") {
     CHECK(from_string("ccc") == Foo::CCC);
     CHECK_THROWS_AS(from_string("xxx"), std::out_of_range); // NOLINT
 }
+
+TEST_CASE("C++ bytes escaping") {
+    CHECK(util::escapeBytesForCxx("aaa") == "aaa");
+    CHECK(util::escapeBytesForCxx("\xff") == "\\377");
+    CHECK(util::escapeBytesForCxx("\x02"
+                                  "\x10"
+                                  "\x32"
+                                  "\x41"
+                                  "\x15"
+                                  "\x01"
+                                  "\x0A") == "\\002\\0202A\\025\\001\\012");
+}


### PR DESCRIPTION
Turns out we can't just encode non-printable characters as \xNN
because C++ compilers look for more than 2 digits when decoding
"\x...". Now using octal \NNN instead, that's always 3 digits.

Closes #217.