### PR TITLE
Build documentation from original doc folder

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Spicy
 BUILDDIR      = $(PWD)/../build
-SOURCEDIR     = $(BUILDDIR)/doc-root
+SOURCEDIR     = $(PWD)
 DESTDIR       = $(BUILDDIR)/html
 
 all: html


### PR DESCRIPTION
This fixes the build task on `gcc9_ubuntu_release_no_jit_task`.