### PR TITLE
Make sure generated doc items have stable ordering.

### DIFF
--- a/doc/autogen/types/bytes.rst
+++ b/doc/autogen/types/bytes.rst
@@ -66,19 +66,19 @@
     If *side* is given, it indicates which side of the value should be
     stripped; ``Side::Both`` is the default if not given.
 
-.. spicy:method:: bytes::sub bytes sub False bytes (inout end: iterator<bytes>)
+.. spicy:method:: bytes::sub bytes sub False bytes (begin: uint<64>, end: uint<64>)
 
-    Returns the subsequence from the value's beginning to (but not
-    including) *end*.
+    Returns the subsequence from offset *begin* to (but not including)
+    offset *end*.
 
 .. spicy:method:: bytes::sub bytes sub False bytes (inout begin: iterator<bytes>, inout end: iterator<bytes>)
 
     Returns the subsequence from *begin* to (but not including) *end*.
 
-.. spicy:method:: bytes::sub bytes sub False bytes (begin: uint<64>, end: uint<64>)
+.. spicy:method:: bytes::sub bytes sub False bytes (inout end: iterator<bytes>)
 
-    Returns the subsequence from offset *begin* to (but not including)
-    offset *end*.
+    Returns the subsequence from the value's beginning to (but not
+    including) *end*.
 
 .. spicy:method:: bytes::to_int bytes to_int False int<64> ([ base: uint<64> ])
 

--- a/doc/autogen/types/enum.rst
+++ b/doc/autogen/types/enum.rst
@@ -6,6 +6,11 @@
     value does *not* need to correspond to any of the type's enumerator
     labels.
 
+.. spicy:operator:: enum_::Cast enum cast<uint>(type<enum~{~~}>)
+
+    Casts an unsigned integer value to an enum instance. The value does
+    *not* need to correspond to any of the type's enumerator labels
+
 .. spicy:operator:: enum_::Cast int cast<enum~{~~}>(type<int>)
 
     Casts an enum value into a signed integer. If the enum value is
@@ -15,11 +20,6 @@
 
     Casts an enum value into a unsigned integer. This will throw an
     exception if the enum value is ``Undef``.
-
-.. spicy:operator:: enum_::Cast enum cast<uint>(type<enum~{~~}>)
-
-    Casts an unsigned integer value to an enum instance. The value does
-    *not* need to correspond to any of the type's enumerator labels
 
 .. spicy:operator:: enum_::Equal bool t:enum~{~~} <sp> op:== <sp> t:enum
 

--- a/doc/autogen/types/integer.rst
+++ b/doc/autogen/types/integer.rst
@@ -12,27 +12,27 @@
 
     Computes the bit-wise 'xor' of the two integers.
 
-.. spicy:operator:: integer::Cast real cast<int>(type<real>)
-
-    Converts the value into a real, accepting any loss of information.
-
 .. spicy:operator:: integer::Cast int cast<int>(type<int>)
 
     Converts the value to another signed integer type, accepting any loss
     of information.
 
-.. spicy:operator:: integer::Cast uint cast<int>(type<uint>)
+.. spicy:operator:: integer::Cast int cast<uint>(type<int>)
 
-    Converts the value to an unsigned integer type, accepting any loss of
+    Converts the value to signed integer type, accepting any loss of
     information.
+
+.. spicy:operator:: integer::Cast real cast<int>(type<real>)
+
+    Converts the value into a real, accepting any loss of information.
 
 .. spicy:operator:: integer::Cast real cast<uint>(type<real>)
 
     Converts the value into a real, accepting any loss of information.
 
-.. spicy:operator:: integer::Cast int cast<uint>(type<int>)
+.. spicy:operator:: integer::Cast uint cast<int>(type<uint>)
 
-    Converts the value to signed integer type, accepting any loss of
+    Converts the value to an unsigned integer type, accepting any loss of
     information.
 
 .. spicy:operator:: integer::Cast uint cast<uint>(type<uint>)
@@ -58,11 +58,11 @@
 
 .. spicy:operator:: integer::Difference uint t:uint <sp> op:- <sp> t:uint
 
-    Returns the difference between the two integers.
+    Computes the difference between the two integers.
 
 .. spicy:operator:: integer::Difference uint t:uint <sp> op:- <sp> t:uint
 
-    Computes the difference between the two integers.
+    Returns the difference between the two integers.
 
 .. spicy:operator:: integer::DifferenceAssign int t:int <sp> op:+= <sp> t:int
 
@@ -158,11 +158,11 @@
 
 .. spicy:operator:: integer::Sum uint t:uint <sp> op:+ <sp> t:uint
 
-    Returns the sum of the integers.
+    Computes the sum of the integers.
 
 .. spicy:operator:: integer::Sum uint t:uint <sp> op:+ <sp> t:uint
 
-    Computes the sum of the integers.
+    Returns the sum of the integers.
 
 .. spicy:operator:: integer::SumAssign int t:int <sp> op:+= <sp> t:int
 

--- a/doc/autogen/types/sink.rst
+++ b/doc/autogen/types/sink.rst
@@ -123,14 +123,14 @@
 
 .. rubric:: Operators
 
+.. spicy:operator:: sink::Size uint<64> op:| t:sink op:|
+
+    Returns the number of bytes written into the sink so far. If the sink
+    has filters attached, this returns the value after filtering.
+
 .. spicy:operator:: sink::Size uint<64> op:| t:strong_ref<sink> op:|
 
     Returns the number of bytes written into the referenced sink so far.
     If the sink has filters attached, this returns the value after
     filtering.
-
-.. spicy:operator:: sink::Size uint<64> op:| t:sink op:|
-
-    Returns the number of bytes written into the sink so far. If the sink
-    has filters attached, this returns the value after filtering.
 

--- a/doc/autogen/types/stream-view.rst
+++ b/doc/autogen/types/stream-view.rst
@@ -1,16 +1,16 @@
 .. rubric:: View Methods
 
+.. spicy:method:: stream::view::advance view<stream> advance False view<stream> (i: uint<64>)
+
+    Advances the view's starting position by *i* stream, returning the new
+    view.
+
 .. spicy:method:: stream::view::advance view<stream> advance False view<stream> (inout i: iterator<stream>)
 
     Advances the view's starting position to a given iterator *i*,
     returning the new view. The iterator must be referring to the same
     stream values as the view, and it must be equal or ahead of the view's
     starting position.
-
-.. spicy:method:: stream::view::advance view<stream> advance False view<stream> (i: uint<64>)
-
-    Advances the view's starting position by *i* stream, returning the new
-    view.
 
 .. spicy:method:: stream::view::at view<stream> at False iterator<stream> (i: uint<64>)
 
@@ -46,21 +46,21 @@
 
     Returns true if the view starts with *b*.
 
-.. spicy:method:: stream::view::sub view<stream> sub False view<stream> (inout end: iterator<stream>)
+.. spicy:method:: stream::view::sub view<stream> sub False view<stream> (begin: uint<64>, end: uint<64>)
 
-    Returns a new view of the subsequence from *begin* to (but not
-    including) *end*.
+    Returns a new view of the subsequence from offset *begin* to (but not
+    including) offset *end*. The offsets are relative to the beginning of
+    the view.
 
 .. spicy:method:: stream::view::sub view<stream> sub False view<stream> (inout begin: iterator<stream>, inout end: iterator<stream>)
 
     Returns a new view of the subsequence from *begin* to (but not
     including) *end*.
 
-.. spicy:method:: stream::view::sub view<stream> sub False view<stream> (begin: uint<64>, end: uint<64>)
+.. spicy:method:: stream::view::sub view<stream> sub False view<stream> (inout end: iterator<stream>)
 
-    Returns a new view of the subsequence from offset *begin* to (but not
-    including) offset *end*. The offsets are relative to the beginning of
-    the view.
+    Returns a new view of the subsequence from *begin* to (but not
+    including) *end*.
 
 .. rubric:: View Operators
 
@@ -72,15 +72,15 @@
 
     Compares the views lexicographically.
 
-.. spicy:operator:: stream::view::In bool t:view<stream> <sp> op:in <sp> t:bytes
-
-    Returns true if the right-hand-side view contains the left-hand-side
-    bytes as a subsequence.
-
 .. spicy:operator:: stream::view::In bool t:bytes <sp> op:in <sp> t:view<stream>
 
     Returns true if the right-hand-side bytes contains the left-hand-side
     view as a subsequence.
+
+.. spicy:operator:: stream::view::In bool t:view<stream> <sp> op:in <sp> t:bytes
+
+    Returns true if the right-hand-side view contains the left-hand-side
+    bytes as a subsequence.
 
 .. spicy:operator:: stream::view::Size uint<64> op:| t:view<stream> op:|
 

--- a/doc/scripts/spicy-doc-to-rst
+++ b/doc/scripts/spicy-doc-to-rst
@@ -11,7 +11,7 @@ import re
 import sys
 import textwrap
 
-from typing import Dict, List
+from typing import Dict, List, Set
 
 
 def fatalError(message: str):
@@ -182,6 +182,7 @@ class Operand:
         x = "{}{}".format(prefix, x)
         return "[ {} ]".format(x) if self.optional else x
 
+
 class Operator:
     def __init__(self, m):
         self.doc = m.get("doc")
@@ -211,7 +212,9 @@ class Operator:
                 doc=fmtDoc(self.doc))
 
     def __lt__(self, other):
-        return self.kind < other.kind
+        # Sort by string representation to make sure
+        # the rendered output has a fixed order.
+        return self.rst() < other.rst()
 
 
 class Method:
@@ -249,7 +252,9 @@ class Method:
         return sig
 
     def __lt__(self, other):
-        return self.id < other.id
+        # Sort by string representation to make sure
+        # the rendered output has a fixed order.
+        return self.rst() < other.rst()
 
 # Main
 
@@ -300,7 +305,7 @@ if args.types:
             if i.startswith(k):
                 keys.add(i)
 
-for ns in keys:
+for ns in sorted(keys):
     if args.dir:
         fname = namespace(ns)
 
@@ -324,11 +329,11 @@ for ns in keys:
 
     # In the following we remove duplicate entries where multiple items end up
     # turning into the same reST rendering. This happens when the difference is
-    # only in typing issues that we don't track in the documentation. An example
-    # is the vector's index operators for constant and non-constant instances,
-    # respectively. Other duplications are coming from joining namspaces for
-    # integers.
-    already_recorded = set()
+    # only in typing issues that we don't track in the documentation. An
+    # example is the vector's index operators for constant and non-constant
+    # instances, respectively. Other duplications are coming from joining
+    # namspaces for integers.
+    already_recorded: Set[str] = set()
 
     def print_unique(s):
         if s not in already_recorded:
@@ -339,14 +344,14 @@ for ns in keys:
     if x1:
         print(".. rubric:: %sMethods\n" % prefix, file=out)
 
-        for method in x1:
+        for method in sorted(x1):
             print_unique(method.rst())
 
     x2 = sorted(operators.get(ns, []))
     if x2:
         print(".. rubric:: %sOperators\n" % prefix, file=out)
 
-        for operator in x2:
+        for operator in sorted(x2):
             print_unique(operator.rst())
 
     if args.dir:


### PR DESCRIPTION
When generating type operator and method documentation entries we
previously sorted by `id`. This could lead to non-stable ordering if
`id` was not unique.

We now sort entries by their string representation. This ensures that
the entries generated documentation always have a stable order.