### PR TITLE
Preserve parentheses inside expressions.

### DIFF
--- a/hilti/include/ast/expressions/all.h
+++ b/hilti/include/ast/expressions/all.h
@@ -6,6 +6,7 @@
 #include <hilti/ast/expressions/coerced.h>
 #include <hilti/ast/expressions/ctor.h>
 #include <hilti/ast/expressions/deferred.h>
+#include <hilti/ast/expressions/grouping.h>
 #include <hilti/ast/expressions/id.h>
 #include <hilti/ast/expressions/keyword.h>
 #include <hilti/ast/expressions/list-comprehension.h>

--- a/hilti/include/ast/expressions/grouping.h
+++ b/hilti/include/ast/expressions/grouping.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <utility>
+
+#include <hilti/ast/expression.h>
+
+namespace hilti {
+namespace expression {
+
+/** AST node for grouping another expression inside parentheses. */
+class Grouping : public NodeBase, public trait::isExpression {
+public:
+    Grouping(Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
+
+    auto expression() const { return child<Expression>(0); }
+
+    bool operator==(const Grouping& other) const { return expression() == other.expression(); }
+
+    /** Implements `Expression` interface. */
+    bool isLhs() const { return expression().isLhs(); }
+    /** Implements `Expression` interface. */
+    bool isTemporary() const { return expression().isTemporary(); }
+    /** Implements `Expression` interface. */
+    auto type() const { return type::effectiveType(expression().type()); }
+    /** Implements `Expression` interface. */
+    auto isConstant() const { return expression().isConstant(); }
+    /** Implements `Expression` interface. */
+    auto isEqual(const Expression& other) const { return node::isEqual(this, other); }
+
+    /** Implements `Node` interface. */
+    auto properties() const { return node::Properties{}; }
+};
+
+} // namespace expression
+} // namespace hilti

--- a/hilti/include/ast/nodes.decl
+++ b/hilti/include/ast/nodes.decl
@@ -69,11 +69,12 @@ hilti::declaration::Type : isDeclaration
 
 hilti::expression::Assign : isExpression
 hilti::expression::Coerced : isExpression
-hilti::expression::PendingCoerced : isExpression
 hilti::expression::Ctor : isExpression
 hilti::expression::Deferred : isExpression
+hilti::expression::Grouping : isExpression
 hilti::expression::Keyword : isExpression
 hilti::expression::ListComprehension : isExpression
+hilti::expression::PendingCoerced : isExpression
 hilti::expression::LogicalAnd : isExpression
 hilti::expression::LogicalOr : isExpression
 hilti::expression::LogicalNot : isExpression

--- a/hilti/include/rt/compiler-setup.h
+++ b/hilti/include/rt/compiler-setup.h
@@ -8,6 +8,7 @@
 #if __clang__
 // Clang-specific options.
 #pragma clang diagnostic ignored "-Wunused-comparison"
+#pragma clang diagnostic ignored "-Wunused-value"
 #endif
 
 #if __GNUC__

--- a/hilti/src/compiler/codegen/expressions.cc
+++ b/hilti/src/compiler/codegen/expressions.cc
@@ -58,6 +58,8 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
             return fmt("hilti::rt::DeferredExpression<%s>([=]() -> %s { return %s; })", type, type, value);
     }
 
+    result_t operator()(const expression::Grouping& n) { return fmt("(%s)", cg->compile(n.expression())); }
+
     result_t operator()(const expression::Keyword& n) {
         switch ( n.kind() ) {
             case expression::keyword::Kind::Self: return cg->self();

--- a/hilti/src/compiler/parser/parser.yy
+++ b/hilti/src/compiler/parser/parser.yy
@@ -712,7 +712,7 @@ expr_f        : ctor                             { $$ = hilti::expression::Ctor(
                                                  { $$ = hilti::expression::ListComprehension(std::move($6), std::move($2), std::move($4), std::move($8),  __loc__); }
               | expr_g
 
-expr_g        : '(' expr ')'                     { $$ = std::move($2); }
+expr_g        : '(' expr ')'                     { $$ = hilti::expression::Grouping(std::move($2)); }
               | scoped_id                        { $$ = hilti::expression::UnresolvedID(std::move($1), __loc__); }
 
 

--- a/hilti/src/compiler/visitors/printer.cc
+++ b/hilti/src/compiler/visitors/printer.cc
@@ -397,6 +397,8 @@ struct Visitor : visitor::PreOrder<void, Visitor> {
 
     void operator()(const expression::Ctor& n) { out << n.ctor(); }
 
+    void operator()(const expression::Grouping& n) { out << '(' << n.expression() << ')'; }
+
     result_t operator()(const expression::Keyword& n) {
         switch ( n.kind() ) {
             case expression::keyword::Kind::Self: out << "self";

--- a/spicy/src/compiler/parser/parser.yy
+++ b/spicy/src/compiler/parser/parser.yy
@@ -849,7 +849,7 @@ expr_f        : ctor                             { $$ = hilti::expression::Ctor(
                                                  { $$ = hilti::expression::ListComprehension(std::move($6), std::move($2), std::move($4), std::move($8),  __loc__); }
               | expr_g
 
-expr_g        : '(' expr ')'                     { $$ = std::move($2); }
+expr_g        : '(' expr ')'                     { $$ = hilti::expression::Grouping(std::move($2)); }
               | scoped_id                        { $$ = hilti::expression::UnresolvedID(std::move($1), __loc__); }
               | DOLLARDOLLAR                     { $$ = hilti::expression::Keyword(hilti::expression::keyword::Kind::DollarDollar, __loc__); }
 

--- a/tests/Baseline/hilti.ast.validation/output
+++ b/tests/Baseline/hilti.ast.validation/output
@@ -1,10 +1,10 @@
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:11: integer type's width must be one of 8/16/32/64, but is 65
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:12: integer type's width must be one of 8/16/32/64, but is 0
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:12-14: type 'void' cannot be used for variable declaration
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:15-16: type 'void' cannot be used for variable declaration
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:19: function must return a value
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:23: cannot coerce expression '42' of type 'uint<64>' to type 'void'
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:23: void function cannot return a value
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:31: cannot coerce expression '"1" == "2"' of type 'bool' to type 'real'
-[error] /home/robin/work/spicy/diagnostics/tests/.tmp/hilti.ast.validation/validation.hlt:32: cannot resolve operator: <string> == <uint<64>>
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:11: integer type's width must be one of 8/16/32/64, but is 65
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:12: integer type's width must be one of 8/16/32/64, but is 0
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:12-14: type 'void' cannot be used for variable declaration
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:15-16: type 'void' cannot be used for variable declaration
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:19: function must return a value
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:23: cannot coerce expression '42' of type 'uint<64>' to type 'void'
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:23: void function cannot return a value
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:31: cannot coerce expression '("1" == "2")' of type 'bool' to type 'real'
+[error] /home/robin/work/spicy/topic/tests/.tmp/hilti.ast.validation/validation.hlt:32: cannot resolve operator: <string> == <uint<64>>
 [error] hiltic: aborting after errors


### PR DESCRIPTION
While so far we did capture the priority of subexpressions inside the
AST, the generated C++ would roll them out flat without considering
C++ operator precendence. Now we pass parentheses through from the
source code to the generated code to preserve priorities.

Closes #225.