### PR TITLE
Fix broken doc links

### DIFF
--- a/ci/run-ci
+++ b/ci/run-ci
@@ -195,7 +195,7 @@ function run_build {
     (cd ${build} && ninja -j5) || exit 1
 
     log_stage "Building docs ..."
-    (cd ${root}/doc && make BUILDDIR=${build} DESTDIR=${artifacts}/doc) || exit 1
+    (cd ${root}/doc && make BUILDDIR=${build} DESTDIR=${artifacts}/doc html check) || exit 1
 }
 
 function run_install {

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,4 +24,7 @@ autogen-docs:
 	@echo Auto-generating reference documentation ...
 	(cd $(BUILDDIR)/.. && ./doc/scripts/autogen-docs)
 
-.PHONY: Makefile autogen-docs
+check:
+	@$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
+
+.PHONY: Makefile autogen-docs check

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,7 +52,7 @@ todo_include_todos = True
 # Extlinks extension
 extlinks = {
     "repo":  ("https://github.com/zeek/spicy/blob/master/%s", "#"),
-    "issue": ("https://github.com/zeek/spicy/issues/issues/%s", "#"),
+    "issue": ("https://github.com/zeek/spicy/issues/%s", "#"),
     "pr":    ("https://github.com/zeek/spicy/pulls/%s", "#"),
 }
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,10 +70,10 @@ like to hear from you!
 
     - Ask the ``#spicy`` channel on `Zeek's Slack <https://zeekorg.slack.com>`_.
 
-    - Subscribe to the `Spicy mailing list <http://mailman.icsi.berkeley.edu/mailman/spicy>`_.
+    - Subscribe to the `Spicy mailing list <http://mailman.icsi.berkeley.edu/mailman/listinfo/spicy>`_.
 
     - To follow development, subscribe to the `commits mailing list
-      <http://mailman.icsi.berkeley.edu/mailman/spicy-commits>`_ (it
+      <http://mailman.icsi.berkeley.edu/mailman/listinfo/spicy-commits>`_ (it
       can be noisy).
 
 Documentation

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,11 +34,11 @@ ubuntu-19.10
     `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.ubuntu-19.10>`__
 
 alpine-3.11
-    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_alpine_3_11_task/packages/build/spicy-linux.tar.gz>`,
+    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_alpine_3_11/packages/build/spicy-linux.tar.gz>`,
     `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.alpine-3.11>`__
 
 centos-8
-    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_centos_8_task/packages/build/spicy-linux.tar.gz>`,
+    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_centos_8/packages/build/spicy-linux.tar.gz>`,
     `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.centos-8>`__
 
 .. _prebuilt_macos:


### PR DESCRIPTION
This PR fixes broken links in documentation and a `check` target to `doc/Makefile`. We execute `check` when building documentation in CI.