### PR TITLE
Suppress any output from doc's `make check` by default.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -25,6 +25,6 @@ autogen-docs:
 	(cd $(BUILDDIR)/.. && ./doc/scripts/autogen-docs)
 
 check:
-	@$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
+	@$(SPHINXBUILD) -q -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
 
 .PHONY: Makefile autogen-docs check


### PR DESCRIPTION
Sphinx' linkcheck can be pretty noisy in that it outputs all checked
links alongside their status. This can make it hard to quickly grap what
might be an issue, especially since error log lines might already be off
the screen.

This patch makes the command silent by default only showing errors, but
not warnings.