### PR TITLE
Ignore package links in documentation linkcheck.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,3 +67,6 @@ html_static_path = ['_static']
 html_theme_options = {
     "style_external_links": True
 }
+
+linkcheck_ignore = [
+    r'https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/.*']


### PR DESCRIPTION
We check links during the `build` phase, but generate package artifacts
in a follow-up step. If for some reason package artifacts are absent in
Cirrus CI's artifact cache, this can lead to situations where the link
check fails and we never repopulate the artifacts.

For now just ignore links to the artifacts when performing the
documentation link check.