### PR TITLE
Fix AST inconsistency with how modules were stored in scopes.

### DIFF
--- a/hilti/include/ast/declarations/all.h
+++ b/hilti/include/ast/declarations/all.h
@@ -9,6 +9,7 @@
 #include <hilti/ast/declarations/global-variable.h>
 #include <hilti/ast/declarations/imported-module.h>
 #include <hilti/ast/declarations/local-variable.h>
+#include <hilti/ast/declarations/module.h>
 #include <hilti/ast/declarations/parameter.h>
 #include <hilti/ast/declarations/property.h>
 #include <hilti/ast/declarations/type.h>

--- a/hilti/include/ast/declarations/imported-module.h
+++ b/hilti/include/ast/declarations/imported-module.h
@@ -32,9 +32,9 @@ public:
     ImportedModule(ID id, std::filesystem::path path, Meta m = Meta())
         : NodeBase({std::move(id)}, std::move(m)), _path(std::move(path)) {}
 
-    Result<Module> module() const {
+    Result<hilti::Module> module() const {
         if ( _module )
-            return _module->template as<Module>();
+            return _module->template as<hilti::Module>();
 
         return result::Error("module reference not initialized yet");
     }

--- a/hilti/include/ast/declarations/module.h
+++ b/hilti/include/ast/declarations/module.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <utility>
+
+
+#include <hilti/ast/declaration.h>
+#include <hilti/ast/expression.h>
+#include <hilti/ast/id.h>
+#include <hilti/ast/meta.h>
+#include <hilti/ast/module.h>
+#include <hilti/ast/node.h>
+#include <hilti/ast/node_ref.h>
+#include <hilti/base/result.h>
+#include <hilti/base/type_erase.h>
+
+namespace hilti {
+namespace declaration {
+
+/** AST node for an AST's top-level module declaration. */
+class Module : public NodeBase, public hilti::trait::isDeclaration {
+public:
+    /**
+     * Constructor.
+     *
+     * @param root reference to root node of module's AST; must be a ``Module`` node.
+     */
+    Module(NodeRef root, Meta m = Meta()) : NodeBase(std::move(m)), _root(std::move(root)) {
+        assert(_root && _root->isA<hilti::Module>());
+    }
+
+    Node& root() const { return *_root; }
+
+    bool operator==(const Module& other) const { return id() == other.id(); }
+
+    /** Implements `Declaration` interface. */
+    bool isConstant() const { return true; }
+    /** Implements `Declaration` interface. */
+    ID id() const { return _root->as<hilti::Module>().id(); }
+    /** Implements `Declaration` interface. */
+    Linkage linkage() const { return Linkage::Public; }
+    /** Implements `Declaration` interface. */
+    std::string displayName() const { return "module"; };
+    /** Implements `Declaration` interface. */
+    auto isEqual(const Declaration& other) const { return node::isEqual(this, other); }
+
+    /** Implements `Node` interface. */
+    auto properties() const { return node::Properties{{"id", id()}}; }
+
+private:
+    NodeRef _root;
+};
+
+} // namespace declaration
+} // namespace hilti

--- a/hilti/include/ast/nodes.decl
+++ b/hilti/include/ast/nodes.decl
@@ -63,6 +63,7 @@ hilti::declaration::Function : isDeclaration
 hilti::declaration::GlobalVariable : isDeclaration
 hilti::declaration::ImportedModule : isDeclaration
 hilti::declaration::LocalVariable : isDeclaration
+hilti::declaration::Module : isDeclaration
 hilti::declaration::Parameter : isDeclaration
 hilti::declaration::Property : isDeclaration
 hilti::declaration::Type : isDeclaration

--- a/hilti/src/ast/scope.cc
+++ b/hilti/src/ast/scope.cc
@@ -4,6 +4,7 @@
 
 #include <hilti/ast/declarations/expression.h>
 #include <hilti/ast/declarations/imported-module.h>
+#include <hilti/ast/declarations/module.h>
 #include <hilti/ast/id.h>
 #include <hilti/ast/scope.h>
 
@@ -63,9 +64,14 @@ std::vector<Scope::Referee> Scope::_findID(const Scope* scope, const ID& id, boo
                 return createRefs(i->second, h, external);
 
             for ( const auto& v : (*i).second ) {
+                Scope* scope = (*v).scope().get();
+
+                if ( auto m = v->tryAs<declaration::Module>() )
+                    scope = m->root().scope().get();
+
                 auto e = v->isA<declaration::ImportedModule>();
 
-                if ( auto x = _findID((*v).scope().get(), ID(t), external || e); ! x.empty() )
+                if ( auto x = _findID(scope, ID(t), external || e); ! x.empty() )
                     return createRefs(x, h, external);
             }
 

--- a/hilti/src/compiler/unit.cc
+++ b/hilti/src/compiler/unit.cc
@@ -498,11 +498,12 @@ void Unit::_determineCompilationRequirements(const Node& module) {
         void operator()(const declaration::ImportedModule& n, const_position_t p) {
             for ( const auto& i : p.node.scope()->items() ) {
                 for ( const auto& m : i.second ) {
-                    if ( ! m->template isA<Module>() )
+                    auto md = m->tryAs<declaration::Module>();
+                    if ( ! md )
                         continue;
 
                     auto v = VisitorModule();
-                    for ( auto i : v.walk(*m) ) {
+                    for ( auto i : v.walk(md->root()) ) {
                         if ( auto x = v.dispatch(i); ! (x && *x) )
                             continue;
 

--- a/hilti/src/compiler/visitors/scope-builder.cc
+++ b/hilti/src/compiler/visitors/scope-builder.cc
@@ -20,7 +20,10 @@ struct VisitorPass1 : public visitor::PostOrder<void, VisitorPass1> {
     explicit VisitorPass1(Unit* unit) : unit(unit) {}
     Unit* unit;
 
-    void operator()(const Module& m, position_t p) { p.node.scope()->insert(m.id(), NodeRef(p.node)); }
+    void operator()(const Module& m, position_t p) {
+        Node d = Declaration(declaration::Module(NodeRef(p.node), m.meta()));
+        p.node.scope()->insert(m.id(), std::move(d));
+    }
 
     void operator()(const declaration::ImportedModule& m, position_t p) {
         auto& other = unit->imported(m.id());

--- a/hilti/src/compiler/visitors/validator.cc
+++ b/hilti/src/compiler/visitors/validator.cc
@@ -51,7 +51,7 @@ struct Visitor : public visitor::PostOrder<void, Visitor> {
                 if ( node->isA<declaration::Function>() && node->typeid_() == firstNode->typeid_() )
                     continue;
                 else if ( node->isA<declaration::ImportedModule>() &&
-                          (node->typeid_() == firstNode->typeid_() || firstNode->isA<Module>()) )
+                          (node->typeid_() == firstNode->typeid_() || firstNode->isA<declaration::Module>()) )
                     continue;
 
                 // TODO: Should make preDispatch() recevie a non-const node

--- a/hilti/src/global.cc
+++ b/hilti/src/global.cc
@@ -5,6 +5,7 @@
 
 #include <hilti/ast/ctors/enum.h>
 #include <hilti/ast/declarations/constant.h>
+#include <hilti/ast/declarations/module.h>
 #include <hilti/ast/declarations/type.h>
 #include <hilti/compiler/detail/visitors.h>
 #include <hilti/global.h>
@@ -51,6 +52,11 @@ std::pair<bool, Result<std::pair<NodeRef, ID>>> hilti::detail::lookupID(const ID
         }
 
         if ( auto d = r.node->template tryAs<Declaration>() ) {
+            if ( auto c = d->tryAs<declaration::Module>() ) {
+                auto err = result::Error(util::fmt("cannot use module '%s' as an ID", id));
+                return std::make_pair(true, std::move(err));
+            }
+
             if ( r.external && d->linkage() != declaration::Linkage::Public ) {
                 bool ok = false;
 

--- a/tests/Baseline/hilti.ast.basic-module/output
+++ b/tests/Baseline/hilti.ast.basic-module/output
@@ -1,5 +1,5 @@
-[debug/compiler] parsing file "/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.basic-module/basic-module.hlt"
-[debug/compiler] registering AST for module Foo ("/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.basic-module/basic-module.hlt")
+[debug/compiler] parsing file "/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.basic-module/basic-module.hlt"
+[debug/compiler] registering AST for module Foo ("/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.basic-module/basic-module.hlt")
 [debug/compiler]   processing AST, round 1
 [debug/compiler]     performing missing imports for module Foo
 [debug/compiler]       updated cached AST for module Foo (final: no, requires_compilation: yes, dependencies: (none))
@@ -22,16 +22,16 @@
 [debug/compiler]   validating module Foo (post-transform)
 [debug/ast-final] # Foo: Final AST
 [debug/ast-final]   - Module %1 (basic-module.hlt:5:1-11:2)
-[debug/ast-final]       | Foo -> Module %1
-[debug/ast-final]       | X -> declaration::Type %3 <linkage="private">
-[debug/ast-final]       | foo -> declaration::Function %4 <linkage="private">
+[debug/ast-final]       | Foo -> declaration::Module %6 <id="Foo">
+[debug/ast-final]       | X -> declaration::Type %4 <linkage="private">
+[debug/ast-final]       | foo -> declaration::Function %5 <linkage="private">
 [debug/ast-final]     - ID <name="Foo"> (basic-module.hlt:5:8)
 [debug/ast-final]     - statement::Block (basic-module.hlt:5:1-11:2)
-[debug/ast-final]     - declaration::Type %3 <linkage="private"> (basic-module.hlt:5:13-7:15)
+[debug/ast-final]     - declaration::Type %4 <linkage="private"> (basic-module.hlt:5:13-7:15)
 [debug/ast-final]       - ID <name="X"> (basic-module.hlt:7:6)
 [debug/ast-final]       - type::Bool (basic-module.hlt:7:10) (non-const) (type-id: Foo::X)
 [debug/ast-final]       - node::None (basic-module.hlt:5:13-7:15)
-[debug/ast-final]     - declaration::Function %4 <linkage="private"> (basic-module.hlt:9:1)
+[debug/ast-final]     - declaration::Function %5 <linkage="private"> (basic-module.hlt:9:1)
 [debug/ast-final]       - Function <cc="<standard>"> (basic-module.hlt:9:8)
 [debug/ast-final]           | bar -> declaration::Parameter %2 <is_struct_param="false" kind="in">
 [debug/ast-final]         - ID <name="foo"> (basic-module.hlt:9:16)
@@ -47,7 +47,7 @@
 [debug/compiler]   updated cached AST for module Foo (final: yes, requires_compilation: yes, dependencies: (none))
 [debug/compiler]   compiling module Foo to C++
 [debug/compiler]     finalizing module Foo
-// Begin of Foo (from "/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.basic-module/basic-module.hlt")
+// Begin of Foo (from "/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.basic-module/basic-module.hlt")
 // Compiled by HILTI version 0.4.0-branch
 
 #include <hilti/rt/compiler-setup.h>
@@ -63,6 +63,6 @@ HILTI_PRE_INIT(__hlt::Foo::__register_module)
 extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule({ "Foo", nullptr, nullptr, nullptr}); }
 
 /* __HILTI_LINKER_V1__
-{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.basic-module/basic-module.hlt","version":1}
+{"module":"Foo","namespace":"__hlt::Foo","path":"/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.basic-module/basic-module.hlt","version":1}
 */
 

--- a/tests/Baseline/hilti.ast.coercion/output
+++ b/tests/Baseline/hilti.ast.coercion/output
@@ -1,44 +1,44 @@
 [debug/ast-final] # Foo: Final AST
 [debug/ast-final]   - Module %1 (coercion.hlt:5:1-31:2)
-[debug/ast-final]       | A -> declaration::GlobalVariable %2 <linkage="private">
-[debug/ast-final]       | B -> declaration::GlobalVariable %3 <linkage="private">
-[debug/ast-final]       | C -> declaration::GlobalVariable %4 <linkage="private">
-[debug/ast-final]       | D -> declaration::GlobalVariable %5 <linkage="private">
-[debug/ast-final]       | E -> declaration::GlobalVariable %10 <linkage="private">
-[debug/ast-final]       | Foo -> Module %1
-[debug/ast-final]       | x -> declaration::Function %6 <linkage="private">
-[debug/ast-final]       | y -> declaration::Function %7 <linkage="private">
-[debug/ast-final]       | z -> declaration::Function %8 <linkage="private">
-[debug/ast-final]       | z2 -> declaration::Function %9 <linkage="private">
+[debug/ast-final]       | A -> declaration::GlobalVariable %3 <linkage="private">
+[debug/ast-final]       | B -> declaration::GlobalVariable %4 <linkage="private">
+[debug/ast-final]       | C -> declaration::GlobalVariable %5 <linkage="private">
+[debug/ast-final]       | D -> declaration::GlobalVariable %6 <linkage="private">
+[debug/ast-final]       | E -> declaration::GlobalVariable %11 <linkage="private">
+[debug/ast-final]       | Foo -> declaration::Module %12 <id="Foo">
+[debug/ast-final]       | x -> declaration::Function %7 <linkage="private">
+[debug/ast-final]       | y -> declaration::Function %8 <linkage="private">
+[debug/ast-final]       | z -> declaration::Function %9 <linkage="private">
+[debug/ast-final]       | z2 -> declaration::Function %10 <linkage="private">
 [debug/ast-final]     - ID <name="Foo"> (coercion.hlt:5:8)
 [debug/ast-final]     - statement::Block (coercion.hlt:5:1-31:2)
-[debug/ast-final]     - declaration::GlobalVariable %2 <linkage="private"> (coercion.hlt:5:13-7:19)
+[debug/ast-final]     - declaration::GlobalVariable %3 <linkage="private"> (coercion.hlt:5:13-7:19)
 [debug/ast-final]       - ID <name="A"> (coercion.hlt:7:13)
 [debug/ast-final]       - type::Real (coercion.hlt:7:8) (non-const)
 [debug/ast-final]       - expression::Ctor (coercion.hlt:7:17)
 [debug/ast-final]         - ctor::Coerced (coercion.hlt:7:17)
 [debug/ast-final]           - ctor::UnsignedInteger <value="3" width="64"> (coercion.hlt:7:17)
 [debug/ast-final]           - ctor::Real <value="3.000000"> (coercion.hlt:7:17)
-[debug/ast-final]     - declaration::GlobalVariable %3 <linkage="private"> (coercion.hlt:7:19-8:20)
+[debug/ast-final]     - declaration::GlobalVariable %4 <linkage="private"> (coercion.hlt:7:19-8:20)
 [debug/ast-final]       - ID <name="B"> (coercion.hlt:8:13)
 [debug/ast-final]       - type::Real (coercion.hlt:8:8) (non-const)
 [debug/ast-final]       - expression::Ctor (coercion.hlt:8:17)
 [debug/ast-final]         - ctor::Coerced (coercion.hlt:8:17)
 [debug/ast-final]           - ctor::SignedInteger <value="-5" width="64"> (coercion.hlt:8:17)
 [debug/ast-final]           - ctor::Real <value="-5.000000"> (coercion.hlt:8:17)
-[debug/ast-final]     - declaration::GlobalVariable %4 <linkage="private"> (coercion.hlt:8:20-9:24)
+[debug/ast-final]     - declaration::GlobalVariable %5 <linkage="private"> (coercion.hlt:8:20-9:24)
 [debug/ast-final]       - ID <name="C"> (coercion.hlt:9:15)
 [debug/ast-final]       - type::Stream (coercion.hlt:9:8) (non-const)
 [debug/ast-final]       - expression::Coerced (coercion.hlt:9:19)
 [debug/ast-final]         - expression::Ctor (coercion.hlt:9:19)
 [debug/ast-final]           - ctor::Bytes <value="X"> (coercion.hlt:9:19)
 [debug/ast-final]         - type::Stream (coercion.hlt:9:8) (non-const)
-[debug/ast-final]     - declaration::GlobalVariable %5 <linkage="private"> (coercion.hlt:9:24-10:24)
+[debug/ast-final]     - declaration::GlobalVariable %6 <linkage="private"> (coercion.hlt:9:24-10:24)
 [debug/ast-final]       - ID <name="D"> (coercion.hlt:10:15)
 [debug/ast-final]       - type::String (coercion.hlt:10:8) (non-const)
 [debug/ast-final]       - expression::Ctor (coercion.hlt:10:19)
 [debug/ast-final]         - ctor::String <value="42"> (coercion.hlt:10:19)
-[debug/ast-final]     - declaration::Function %6 <linkage="private"> (coercion.hlt:10:24-14:2)
+[debug/ast-final]     - declaration::Function %7 <linkage="private"> (coercion.hlt:10:24-14:2)
 [debug/ast-final]       - Function <cc="<standard>"> (coercion.hlt:12:9-14:2)
 [debug/ast-final]         - ID <name="x"> (coercion.hlt:12:15)
 [debug/ast-final]         - type::Function <flavor="standard"> (coercion.hlt:12:9-14:2) (non-const)
@@ -49,7 +49,7 @@
 [debug/ast-final]             - expression::Ctor (coercion.hlt:13:12)
 [debug/ast-final]               - ctor::Bool <value="true"> (coercion.hlt:13:12)
 [debug/ast-final]         - node::None (coercion.hlt:12:9-14:2)
-[debug/ast-final]     - declaration::Function %7 <linkage="private"> (coercion.hlt:14:2-18:2)
+[debug/ast-final]     - declaration::Function %8 <linkage="private"> (coercion.hlt:14:2-18:2)
 [debug/ast-final]       - Function <cc="<standard>"> (coercion.hlt:16:9-18:2)
 [debug/ast-final]         - ID <name="y"> (coercion.hlt:16:15)
 [debug/ast-final]         - type::Function <flavor="standard"> (coercion.hlt:16:9-18:2) (non-const)
@@ -62,7 +62,7 @@
 [debug/ast-final]                 - ctor::UnsignedInteger <value="1" width="64"> (coercion.hlt:17:12)
 [debug/ast-final]                 - ctor::Real <value="1.000000"> (coercion.hlt:17:12)
 [debug/ast-final]         - node::None (coercion.hlt:12:9-14:2)
-[debug/ast-final]     - declaration::Function %8 <linkage="private"> (coercion.hlt:18:2-22:2)
+[debug/ast-final]     - declaration::Function %9 <linkage="private"> (coercion.hlt:18:2-22:2)
 [debug/ast-final]       - Function <cc="<standard>"> (coercion.hlt:20:9-22:2)
 [debug/ast-final]         - ID <name="z"> (coercion.hlt:20:23)
 [debug/ast-final]         - type::Function <flavor="standard"> (coercion.hlt:20:9-22:2) (non-const)
@@ -72,12 +72,12 @@
 [debug/ast-final]         - statement::Block (coercion.hlt:20:27-22:2)
 [debug/ast-final]           - statement::Return (coercion.hlt:21:5)
 [debug/ast-final]             - expression::Coerced (coercion.hlt:21:12)
-[debug/ast-final]               - expression::ResolvedID <resolved="%4"> (type: stream) (coercion.hlt:21:12)
+[debug/ast-final]               - expression::ResolvedID <resolved="%5"> (type: stream) (coercion.hlt:21:12)
 [debug/ast-final]                 - ID <name="Foo::C"> (coercion.hlt:21:12)
 [debug/ast-final]               - type::stream::View (coercion.hlt:20:15) (non-const)
 [debug/ast-final]                 - type::Stream (coercion.hlt:20:15)
 [debug/ast-final]         - node::None (coercion.hlt:12:9-14:2)
-[debug/ast-final]     - declaration::Function %9 <linkage="private"> (coercion.hlt:22:2-26:2)
+[debug/ast-final]     - declaration::Function %10 <linkage="private"> (coercion.hlt:22:2-26:2)
 [debug/ast-final]       - Function <cc="<standard>"> (coercion.hlt:24:9-26:2)
 [debug/ast-final]         - ID <name="z2"> (coercion.hlt:24:15)
 [debug/ast-final]         - type::Function <flavor="standard"> (coercion.hlt:24:9-26:2) (non-const)
@@ -86,7 +86,7 @@
 [debug/ast-final]         - statement::Block (coercion.hlt:24:20-26:2)
 [debug/ast-final]           - statement::Return (coercion.hlt:25:5)
 [debug/ast-final]         - node::None (coercion.hlt:12:9-14:2)
-[debug/ast-final]     - declaration::GlobalVariable %10 <linkage="private"> (coercion.hlt:26:2-28:55)
+[debug/ast-final]     - declaration::GlobalVariable %11 <linkage="private"> (coercion.hlt:26:2-28:55)
 [debug/ast-final]       - ID <name="E"> (coercion.hlt:28:37)
 [debug/ast-final]       - type::Tuple <wildcard="false"> (coercion.hlt:28:8) (non-const)
 [debug/ast-final]         - ID <name=""> (coercion.hlt:28:8)

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -1,10 +1,10 @@
 [debug/compiler] parsing file "foo.hlt"
-[debug/compiler] registering AST for module Foo ("/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.imported-id/foo.hlt")
+[debug/compiler] registering AST for module Foo ("/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.imported-id/foo.hlt")
 [debug/compiler]   processing AST, round 1
 [debug/compiler]     performing missing imports for module Foo
 [debug/compiler]       parsing file "./bar.hlt"
 [debug/compiler]       loaded module Bar from "./bar.hlt"
-[debug/compiler]       registering AST for module Bar ("/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.imported-id/bar.hlt")
+[debug/compiler]       registering AST for module Bar ("/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.imported-id/bar.hlt")
 [debug/compiler]       updated cached AST for module Bar (final: no, requires_compilation: no, dependencies: Foo)
 [debug/compiler]       updated cached AST for module Foo (final: no, requires_compilation: yes, dependencies: Bar)
 [debug/compiler]     performing missing imports for module Bar
@@ -15,30 +15,30 @@
 [debug/compiler]     building scopes for all module modules
 [debug/ast-scopes] # Bar: AST with scopes (round 1)
 [debug/ast-scopes]   - Module %2 (bar.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> Module %2
-[debug/ast-scopes]       | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]       | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]       | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::Module %5 <id="Bar">
+[debug/ast-scopes]       | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]       | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]       | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]     - ID <name="Bar"> (bar.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (bar.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %7 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
-[debug/ast-scopes]         | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | Foo -> Module %1
-[debug/ast-scopes]         | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]         | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]         | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %9 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | Foo -> declaration::Module %8 <id="Foo">
+[debug/ast-scopes]         | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]         | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]         | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]       - ID <name="Foo"> (bar.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Bar1"> (bar.hlt:6:13)
 [debug/ast-scopes]       - type::String (bar.hlt:6:20) (non-const)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %9 <linkage="public"> (bar.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %11 <linkage="public"> (bar.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Bar2"> (bar.hlt:7:13)
 [debug/ast-scopes]       - type::UnresolvedID (bar.hlt:7:1) (non-const)
 [debug/ast-scopes]         - ID <name="Foo::Foo1"> (bar.hlt:7:20)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %10 <linkage="private"> (bar.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %12 <linkage="private"> (bar.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (bar.hlt:9:8)
 [debug/ast-scopes]           | bar -> declaration::Parameter %3 <is_struct_param="false" kind="in">
 [debug/ast-scopes]           | foo -> declaration::Parameter %4 <is_struct_param="false" kind="in">
@@ -60,43 +60,43 @@
 [debug/ast-scopes]         - node::None (foo.hlt:6:1)
 [debug/ast-scopes] # Foo: AST with scopes (round 1)
 [debug/ast-scopes]   - Module %1 (foo.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | Foo -> Module %1
-[debug/ast-scopes]       | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]       | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]       | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | Foo -> declaration::Module %8 <id="Foo">
+[debug/ast-scopes]       | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]       | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]       | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]     - ID <name="Foo"> (foo.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (foo.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %11 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
-[debug/ast-scopes]         | Bar -> Module %2
-[debug/ast-scopes]         | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]         | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]         | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %13 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::Module %5 <id="Bar">
+[debug/ast-scopes]         | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]         | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]         | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]       - ID <name="Bar"> (foo.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Foo1"> (foo.hlt:6:13)
 [debug/ast-scopes]       - type::Bool (foo.hlt:6:20) (non-const)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %13 <linkage="public"> (foo.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %15 <linkage="public"> (foo.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Foo2"> (foo.hlt:7:13)
 [debug/ast-scopes]       - type::UnresolvedID (foo.hlt:7:1) (non-const)
 [debug/ast-scopes]         - ID <name="Bar::Bar1"> (foo.hlt:7:20)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %14 <linkage="private"> (foo.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %16 <linkage="private"> (foo.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (foo.hlt:9:8)
-[debug/ast-scopes]           | bar -> declaration::Parameter %6 <is_struct_param="false" kind="in">
-[debug/ast-scopes]           | foo -> declaration::Parameter %5 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | bar -> declaration::Parameter %7 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | foo -> declaration::Parameter %6 <is_struct_param="false" kind="in">
 [debug/ast-scopes]         - ID <name="foo"> (foo.hlt:9:16)
 [debug/ast-scopes]         - type::Function <flavor="standard"> (foo.hlt:9:8) (non-const)
 [debug/ast-scopes]           - type::function::Result (foo.hlt:9:9)
 [debug/ast-scopes]             - type::String (foo.hlt:9:9) (non-const)
-[debug/ast-scopes]           - declaration::Parameter %5 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
+[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
 [debug/ast-scopes]             - ID <name="foo"> (foo.hlt:9:25)
 [debug/ast-scopes]             - type::UnresolvedID (foo.hlt:9:20) (non-const)
 [debug/ast-scopes]               - ID <name="Foo1"> (foo.hlt:9:20)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
-[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
+[debug/ast-scopes]           - declaration::Parameter %7 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
 [debug/ast-scopes]             - ID <name="bar"> (foo.hlt:9:40)
 [debug/ast-scopes]             - type::UnresolvedID (foo.hlt:9:29) (non-const)
 [debug/ast-scopes]               - ID <name="Bar::Bar1"> (foo.hlt:9:30)
@@ -104,14 +104,14 @@
 [debug/ast-scopes]         - node::None (foo.hlt:9:8)
 [debug/ast-scopes]         - node::None (foo.hlt:6:1)
 [debug/compiler]     resolving IDs in module Bar
-[debug/resolver] resolved ID Foo::Foo1 (./bar.hlt:7:20) to declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
-[debug/resolver] resolved ID Bar1 (./bar.hlt:9:20) to declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
-[debug/resolver] resolved ID Foo::Foo1 (./bar.hlt:9:30) to declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
+[debug/resolver] resolved ID Foo::Foo1 (./bar.hlt:7:20) to declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
+[debug/resolver] resolved ID Bar1 (./bar.hlt:9:20) to declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
+[debug/resolver] resolved ID Foo::Foo1 (./bar.hlt:9:30) to declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
 [debug/compiler]       -> modified
 [debug/compiler]     resolving IDs in module Foo
-[debug/resolver] resolved ID Bar::Bar1 (foo.hlt:7:20) to declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
-[debug/resolver] resolved ID Foo1 (foo.hlt:9:20) to declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
-[debug/resolver] resolved ID Bar::Bar1 (foo.hlt:9:30) to declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
+[debug/resolver] resolved ID Bar::Bar1 (foo.hlt:7:20) to declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
+[debug/resolver] resolved ID Foo1 (foo.hlt:9:20) to declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
+[debug/resolver] resolved ID Bar::Bar1 (foo.hlt:9:30) to declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
 [debug/compiler]       -> modified
 [debug/compiler]     resolving operators in module Bar
 [debug/compiler]     resolving operators in module Foo
@@ -128,30 +128,30 @@
 [debug/compiler]     building scopes for all module modules
 [debug/ast-scopes] # Bar: AST with scopes (round 2)
 [debug/ast-scopes]   - Module %2 (bar.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> Module %2
-[debug/ast-scopes]       | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]       | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]       | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::Module %17 <id="Bar">
+[debug/ast-scopes]       | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]       | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]       | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]     - ID <name="Bar"> (bar.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (bar.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %7 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
-[debug/ast-scopes]         | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | Foo -> Module %1
-[debug/ast-scopes]         | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]         | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]         | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %9 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | Foo -> declaration::Module %18 <id="Foo">
+[debug/ast-scopes]         | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]         | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]         | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]       - ID <name="Foo"> (bar.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Bar1"> (bar.hlt:6:13)
 [debug/ast-scopes]       - type::String (bar.hlt:6:20) (non-const) (type-id: Bar::Bar1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %9 <linkage="public"> (bar.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %11 <linkage="public"> (bar.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Bar2"> (bar.hlt:7:13)
-[debug/ast-scopes]       - type::ResolvedID <resolved="%12"> (type: bool) (bar.hlt:7:1) (non-const)
+[debug/ast-scopes]       - type::ResolvedID <resolved="%14"> (type: bool) (bar.hlt:7:1) (non-const)
 [debug/ast-scopes]         - ID <name="Foo::Foo1"> (bar.hlt:7:1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %10 <linkage="private"> (bar.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %12 <linkage="private"> (bar.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (bar.hlt:9:8)
 [debug/ast-scopes]           | bar -> declaration::Parameter %3 <is_struct_param="false" kind="in">
 [debug/ast-scopes]           | foo -> declaration::Parameter %4 <is_struct_param="false" kind="in">
@@ -161,57 +161,57 @@
 [debug/ast-scopes]             - type::String (bar.hlt:9:9) (non-const)
 [debug/ast-scopes]           - declaration::Parameter %3 <is_struct_param="false" kind="in"> (bar.hlt:9:20)
 [debug/ast-scopes]             - ID <name="bar"> (bar.hlt:9:25)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%8"> (type: string) (bar.hlt:9:20) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%10"> (type: string) (bar.hlt:9:20) (non-const)
 [debug/ast-scopes]               - ID <name="Bar::Bar1"> (bar.hlt:9:20)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]           - declaration::Parameter %4 <is_struct_param="false" kind="in"> (bar.hlt:9:29)
 [debug/ast-scopes]             - ID <name="foo"> (bar.hlt:9:40)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%12"> (type: bool) (bar.hlt:9:29) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%14"> (type: bool) (bar.hlt:9:29) (non-const)
 [debug/ast-scopes]               - ID <name="Foo::Foo1"> (bar.hlt:9:29)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]         - node::None (foo.hlt:9:8)
 [debug/ast-scopes]         - node::None (foo.hlt:6:1)
 [debug/ast-scopes] # Foo: AST with scopes (round 2)
 [debug/ast-scopes]   - Module %1 (foo.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | Foo -> Module %1
-[debug/ast-scopes]       | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]       | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]       | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | Foo -> declaration::Module %18 <id="Foo">
+[debug/ast-scopes]       | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]       | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]       | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]     - ID <name="Foo"> (foo.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (foo.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %11 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
-[debug/ast-scopes]         | Bar -> Module %2
-[debug/ast-scopes]         | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]         | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]         | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %13 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::Module %17 <id="Bar">
+[debug/ast-scopes]         | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]         | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]         | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]       - ID <name="Bar"> (foo.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Foo1"> (foo.hlt:6:13)
 [debug/ast-scopes]       - type::Bool (foo.hlt:6:20) (non-const) (type-id: Foo::Foo1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %13 <linkage="public"> (foo.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %15 <linkage="public"> (foo.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Foo2"> (foo.hlt:7:13)
-[debug/ast-scopes]       - type::ResolvedID <resolved="%8"> (type: string) (foo.hlt:7:1) (non-const)
+[debug/ast-scopes]       - type::ResolvedID <resolved="%10"> (type: string) (foo.hlt:7:1) (non-const)
 [debug/ast-scopes]         - ID <name="Bar::Bar1"> (foo.hlt:7:1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %14 <linkage="private"> (foo.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %16 <linkage="private"> (foo.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (foo.hlt:9:8)
-[debug/ast-scopes]           | bar -> declaration::Parameter %6 <is_struct_param="false" kind="in">
-[debug/ast-scopes]           | foo -> declaration::Parameter %5 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | bar -> declaration::Parameter %7 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | foo -> declaration::Parameter %6 <is_struct_param="false" kind="in">
 [debug/ast-scopes]         - ID <name="foo"> (foo.hlt:9:16)
 [debug/ast-scopes]         - type::Function <flavor="standard"> (foo.hlt:9:8) (non-const)
 [debug/ast-scopes]           - type::function::Result (foo.hlt:9:9)
 [debug/ast-scopes]             - type::String (foo.hlt:9:9) (non-const)
-[debug/ast-scopes]           - declaration::Parameter %5 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
+[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
 [debug/ast-scopes]             - ID <name="foo"> (foo.hlt:9:25)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%12"> (type: bool) (foo.hlt:9:20) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%14"> (type: bool) (foo.hlt:9:20) (non-const)
 [debug/ast-scopes]               - ID <name="Foo::Foo1"> (foo.hlt:9:20)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
-[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
+[debug/ast-scopes]           - declaration::Parameter %7 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
 [debug/ast-scopes]             - ID <name="bar"> (foo.hlt:9:40)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%8"> (type: string) (foo.hlt:9:29) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%10"> (type: string) (foo.hlt:9:29) (non-const)
 [debug/ast-scopes]               - ID <name="Bar::Bar1"> (foo.hlt:9:29)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]         - node::None (foo.hlt:9:8)
@@ -235,29 +235,29 @@
 [debug/compiler]     building scopes for all module modules
 [debug/ast-scopes] # Bar: AST with scopes (round 3)
 [debug/ast-scopes]   - Module %2 (bar.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> Module %2
-[debug/ast-scopes]       | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]       | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]       | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::Module %19 <id="Bar">
+[debug/ast-scopes]       | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]       | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]       | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]     - ID <name="Bar"> (bar.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (bar.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %7 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
-[debug/ast-scopes]         | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | Foo -> Module %1
-[debug/ast-scopes]         | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]         | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]         | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %9 <extension=".hlt" path="" scope="-"> (bar.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | Foo -> declaration::Module %20 <id="Foo">
+[debug/ast-scopes]         | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]         | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]         | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]       - ID <name="Foo"> (bar.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %8 <linkage="public"> (bar.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %10 <linkage="public"> (bar.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Bar1"> (bar.hlt:6:13)
 [debug/ast-scopes]       - type::String (bar.hlt:6:20) (non-const) (type-id: Bar::Bar1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %9 <linkage="public"> (bar.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %11 <linkage="public"> (bar.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Bar2"> (bar.hlt:7:13)
 [debug/ast-scopes]       - type::Bool (foo.hlt:6:20) (non-const) (type-id: Bar::Bar2)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %10 <linkage="private"> (bar.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %12 <linkage="private"> (bar.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (bar.hlt:9:8)
 [debug/ast-scopes]           | bar -> declaration::Parameter %3 <is_struct_param="false" kind="in">
 [debug/ast-scopes]           | foo -> declaration::Parameter %4 <is_struct_param="false" kind="in">
@@ -267,56 +267,56 @@
 [debug/ast-scopes]             - type::String (bar.hlt:9:9) (non-const)
 [debug/ast-scopes]           - declaration::Parameter %3 <is_struct_param="false" kind="in"> (bar.hlt:9:20)
 [debug/ast-scopes]             - ID <name="bar"> (bar.hlt:9:25)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%8"> (type: string) (bar.hlt:9:20) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%10"> (type: string) (bar.hlt:9:20) (non-const)
 [debug/ast-scopes]               - ID <name="Bar::Bar1"> (bar.hlt:9:20)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]           - declaration::Parameter %4 <is_struct_param="false" kind="in"> (bar.hlt:9:29)
 [debug/ast-scopes]             - ID <name="foo"> (bar.hlt:9:40)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%12"> (type: bool) (bar.hlt:9:29) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%14"> (type: bool) (bar.hlt:9:29) (non-const)
 [debug/ast-scopes]               - ID <name="Foo::Foo1"> (bar.hlt:9:29)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]         - node::None (foo.hlt:9:8)
 [debug/ast-scopes]         - node::None (foo.hlt:6:1)
 [debug/ast-scopes] # Foo: AST with scopes (round 3)
 [debug/ast-scopes]   - Module %1 (foo.hlt:2:1-11:2)
-[debug/ast-scopes]       | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]       | Foo -> Module %1
-[debug/ast-scopes]       | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-scopes]       | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-scopes]       | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-scopes]       | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]       | Foo -> declaration::Module %20 <id="Foo">
+[debug/ast-scopes]       | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-scopes]       | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-scopes]       | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-scopes]     - ID <name="Foo"> (foo.hlt:2:8)
 [debug/ast-scopes]     - statement::Block (foo.hlt:2:1-11:2)
-[debug/ast-scopes]     - declaration::ImportedModule %11 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
-[debug/ast-scopes]         | Bar -> Module %2
-[debug/ast-scopes]         | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-scopes]         | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-scopes]         | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-scopes]         | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-scopes]     - declaration::ImportedModule %13 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
+[debug/ast-scopes]         | Bar -> declaration::Module %19 <id="Bar">
+[debug/ast-scopes]         | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-scopes]         | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-scopes]         | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-scopes]         | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-scopes]       - ID <name="Bar"> (foo.hlt:4:8)
-[debug/ast-scopes]     - declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
+[debug/ast-scopes]     - declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
 [debug/ast-scopes]       - ID <name="Foo1"> (foo.hlt:6:13)
 [debug/ast-scopes]       - type::Bool (foo.hlt:6:20) (non-const) (type-id: Foo::Foo1)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Type %13 <linkage="public"> (foo.hlt:7:1)
+[debug/ast-scopes]     - declaration::Type %15 <linkage="public"> (foo.hlt:7:1)
 [debug/ast-scopes]       - ID <name="Foo2"> (foo.hlt:7:13)
 [debug/ast-scopes]       - type::String (bar.hlt:6:20) (non-const) (type-id: Foo::Foo2)
 [debug/ast-scopes]       - node::None (foo.hlt:6:1)
-[debug/ast-scopes]     - declaration::Function %14 <linkage="private"> (foo.hlt:9:1)
+[debug/ast-scopes]     - declaration::Function %16 <linkage="private"> (foo.hlt:9:1)
 [debug/ast-scopes]       - Function <cc="<standard>"> (foo.hlt:9:8)
-[debug/ast-scopes]           | bar -> declaration::Parameter %6 <is_struct_param="false" kind="in">
-[debug/ast-scopes]           | foo -> declaration::Parameter %5 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | bar -> declaration::Parameter %7 <is_struct_param="false" kind="in">
+[debug/ast-scopes]           | foo -> declaration::Parameter %6 <is_struct_param="false" kind="in">
 [debug/ast-scopes]         - ID <name="foo"> (foo.hlt:9:16)
 [debug/ast-scopes]         - type::Function <flavor="standard"> (foo.hlt:9:8) (non-const)
 [debug/ast-scopes]           - type::function::Result (foo.hlt:9:9)
 [debug/ast-scopes]             - type::String (foo.hlt:9:9) (non-const)
-[debug/ast-scopes]           - declaration::Parameter %5 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
+[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
 [debug/ast-scopes]             - ID <name="foo"> (foo.hlt:9:25)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%12"> (type: bool) (foo.hlt:9:20) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%14"> (type: bool) (foo.hlt:9:20) (non-const)
 [debug/ast-scopes]               - ID <name="Foo::Foo1"> (foo.hlt:9:20)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
-[debug/ast-scopes]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
+[debug/ast-scopes]           - declaration::Parameter %7 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
 [debug/ast-scopes]             - ID <name="bar"> (foo.hlt:9:40)
-[debug/ast-scopes]             - type::ResolvedID <resolved="%8"> (type: string) (foo.hlt:9:29) (non-const)
+[debug/ast-scopes]             - type::ResolvedID <resolved="%10"> (type: string) (foo.hlt:9:29) (non-const)
 [debug/ast-scopes]               - ID <name="Bar::Bar1"> (foo.hlt:9:29)
 [debug/ast-scopes]             - node::None (foo.hlt:9:20)
 [debug/ast-scopes]         - node::None (foo.hlt:9:8)
@@ -331,44 +331,44 @@
 [debug/compiler]   validating module Foo (post-transform)
 [debug/ast-final] # Foo: Final AST
 [debug/ast-final]   - Module %1 (foo.hlt:2:1-11:2)
-[debug/ast-final]       | Bar -> declaration::ImportedModule %11 <extension=".hlt" path="" scope="-">
-[debug/ast-final]       | Foo -> Module %1
-[debug/ast-final]       | Foo1 -> declaration::Type %12 <linkage="public">
-[debug/ast-final]       | Foo2 -> declaration::Type %13 <linkage="public">
-[debug/ast-final]       | foo -> declaration::Function %14 <linkage="private">
+[debug/ast-final]       | Bar -> declaration::ImportedModule %13 <extension=".hlt" path="" scope="-">
+[debug/ast-final]       | Foo -> declaration::Module %20 <id="Foo">
+[debug/ast-final]       | Foo1 -> declaration::Type %14 <linkage="public">
+[debug/ast-final]       | Foo2 -> declaration::Type %15 <linkage="public">
+[debug/ast-final]       | foo -> declaration::Function %16 <linkage="private">
 [debug/ast-final]     - ID <name="Foo"> (foo.hlt:2:8)
 [debug/ast-final]     - statement::Block (foo.hlt:2:1-11:2)
-[debug/ast-final]     - declaration::ImportedModule %11 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
-[debug/ast-final]         | Bar -> Module %2
-[debug/ast-final]         | Bar1 -> declaration::Type %8 <linkage="public">
-[debug/ast-final]         | Bar2 -> declaration::Type %9 <linkage="public">
-[debug/ast-final]         | Foo -> declaration::ImportedModule %7 <extension=".hlt" path="" scope="-">
-[debug/ast-final]         | bar -> declaration::Function %10 <linkage="private">
+[debug/ast-final]     - declaration::ImportedModule %13 <extension=".hlt" path="" scope="-"> (foo.hlt:4:1)
+[debug/ast-final]         | Bar -> declaration::Module %19 <id="Bar">
+[debug/ast-final]         | Bar1 -> declaration::Type %10 <linkage="public">
+[debug/ast-final]         | Bar2 -> declaration::Type %11 <linkage="public">
+[debug/ast-final]         | Foo -> declaration::ImportedModule %9 <extension=".hlt" path="" scope="-">
+[debug/ast-final]         | bar -> declaration::Function %12 <linkage="private">
 [debug/ast-final]       - ID <name="Bar"> (foo.hlt:4:8)
-[debug/ast-final]     - declaration::Type %12 <linkage="public"> (foo.hlt:6:1)
+[debug/ast-final]     - declaration::Type %14 <linkage="public"> (foo.hlt:6:1)
 [debug/ast-final]       - ID <name="Foo1"> (foo.hlt:6:13)
 [debug/ast-final]       - type::Bool (foo.hlt:6:20) (non-const) (type-id: Foo::Foo1)
 [debug/ast-final]       - node::None (foo.hlt:6:1)
-[debug/ast-final]     - declaration::Type %13 <linkage="public"> (foo.hlt:7:1)
+[debug/ast-final]     - declaration::Type %15 <linkage="public"> (foo.hlt:7:1)
 [debug/ast-final]       - ID <name="Foo2"> (foo.hlt:7:13)
 [debug/ast-final]       - type::String (bar.hlt:6:20) (non-const) (type-id: Foo::Foo2)
 [debug/ast-final]       - node::None (foo.hlt:6:1)
-[debug/ast-final]     - declaration::Function %14 <linkage="private"> (foo.hlt:9:1)
+[debug/ast-final]     - declaration::Function %16 <linkage="private"> (foo.hlt:9:1)
 [debug/ast-final]       - Function <cc="<standard>"> (foo.hlt:9:8)
-[debug/ast-final]           | bar -> declaration::Parameter %6 <is_struct_param="false" kind="in">
-[debug/ast-final]           | foo -> declaration::Parameter %5 <is_struct_param="false" kind="in">
+[debug/ast-final]           | bar -> declaration::Parameter %7 <is_struct_param="false" kind="in">
+[debug/ast-final]           | foo -> declaration::Parameter %6 <is_struct_param="false" kind="in">
 [debug/ast-final]         - ID <name="foo"> (foo.hlt:9:16)
 [debug/ast-final]         - type::Function <flavor="standard"> (foo.hlt:9:8) (non-const)
 [debug/ast-final]           - type::function::Result (foo.hlt:9:9)
 [debug/ast-final]             - type::String (foo.hlt:9:9) (non-const)
-[debug/ast-final]           - declaration::Parameter %5 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
+[debug/ast-final]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:20)
 [debug/ast-final]             - ID <name="foo"> (foo.hlt:9:25)
-[debug/ast-final]             - type::ResolvedID <resolved="%12"> (type: bool) (foo.hlt:9:20) (non-const)
+[debug/ast-final]             - type::ResolvedID <resolved="%14"> (type: bool) (foo.hlt:9:20) (non-const)
 [debug/ast-final]               - ID <name="Foo::Foo1"> (foo.hlt:9:20)
 [debug/ast-final]             - node::None (foo.hlt:9:20)
-[debug/ast-final]           - declaration::Parameter %6 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
+[debug/ast-final]           - declaration::Parameter %7 <is_struct_param="false" kind="in"> (foo.hlt:9:29)
 [debug/ast-final]             - ID <name="bar"> (foo.hlt:9:40)
-[debug/ast-final]             - type::ResolvedID <resolved="%8"> (type: string) (foo.hlt:9:29) (non-const)
+[debug/ast-final]             - type::ResolvedID <resolved="%10"> (type: string) (foo.hlt:9:29) (non-const)
 [debug/ast-final]               - ID <name="Bar::Bar1"> (foo.hlt:9:29)
 [debug/ast-final]             - node::None (foo.hlt:9:20)
 [debug/ast-final]         - node::None (foo.hlt:9:8)
@@ -394,6 +394,6 @@ HILTI_PRE_INIT(__hlt::Foo::__register_module)
 extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule({ "Foo", nullptr, nullptr, nullptr}); }
 
 /* __HILTI_LINKER_V1__
-{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.imported-id/foo.hlt","version":1}
+{"module":"Foo","namespace":"__hlt::Foo","path":"/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.imported-id/foo.hlt","version":1}
 */
 

--- a/tests/Baseline/hilti.ast.types/output
+++ b/tests/Baseline/hilti.ast.types/output
@@ -1,5 +1,5 @@
-[debug/compiler] parsing file "/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.types/types.hlt"
-[debug/compiler] registering AST for module Foo ("/Users/bbannier/src/spicy/tests/.tmp/hilti.ast.types/types.hlt")
+[debug/compiler] parsing file "/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.types/types.hlt"
+[debug/compiler] registering AST for module Foo ("/home/robin/work/spicy/topic/tests/.tmp/hilti.ast.types/types.hlt")
 [debug/compiler]   processing AST, round 1
 [debug/compiler]     performing missing imports for module Foo
 [debug/compiler]       updated cached AST for module Foo (final: no, requires_compilation: yes, dependencies: (none))
@@ -12,17 +12,17 @@
 [debug/compiler]   validating module Foo (post-transform)
 [debug/ast-final] # Foo: Final AST
 [debug/ast-final]   - Module %1 (types.hlt:5:1-10:2)
-[debug/ast-final]       | Foo -> Module %1
-[debug/ast-final]       | x1 -> declaration::GlobalVariable %2 <linkage="private">
-[debug/ast-final]       | x2 -> declaration::GlobalVariable %3 <linkage="private">
+[debug/ast-final]       | Foo -> declaration::Module %2 <id="Foo">
+[debug/ast-final]       | x1 -> declaration::GlobalVariable %3 <linkage="private">
+[debug/ast-final]       | x2 -> declaration::GlobalVariable %4 <linkage="private">
 [debug/ast-final]     - ID <name="Foo"> (types.hlt:5:8)
 [debug/ast-final]     - statement::Block (types.hlt:5:1-10:2)
-[debug/ast-final]     - declaration::GlobalVariable %2 <linkage="private"> (types.hlt:5:13-7:20)
+[debug/ast-final]     - declaration::GlobalVariable %3 <linkage="private"> (types.hlt:5:13-7:20)
 [debug/ast-final]       - ID <name="x1"> (types.hlt:7:8)
 [debug/ast-final]       - type::Bytes (types.hlt:5:13-7:20) (non-const)
 [debug/ast-final]       - expression::Ctor (types.hlt:7:13)
 [debug/ast-final]         - ctor::Bytes <value="abc"> (types.hlt:7:13)
-[debug/ast-final]     - declaration::GlobalVariable %3 <linkage="private"> (types.hlt:7:20-8:20)
+[debug/ast-final]     - declaration::GlobalVariable %4 <linkage="private"> (types.hlt:7:20-8:20)
 [debug/ast-final]       - ID <name="x2"> (types.hlt:8:8)
 [debug/ast-final]       - type::Tuple <wildcard="false"> (types.hlt:8:13) (non-const)
 [debug/ast-final]         - type::UnsignedInteger <width="64"> (types.hlt:8:13) (non-const)


### PR DESCRIPTION
Normally all scope entries should be pointing to declarations, but we
made an exception for "Module", which was inserted into the scope
directly. This commit introduces a separate "declaration::Module"
wrapper so that we can insert that into the scope, avoiding that
exception.

With that in place, we can then easily catch if an ID refers directly
to a module, which has no use case.

For the record: I did consider removing the current "Module" node
class altogether, and simply replacing it with "declaration::Module".
However, "Module" is special in that it's our only mutable AST node,
and it didn't feel right to mix that in with the other, non-mutable
declarations.

Closes #248.