### PR TITLE
Make UTF8 default for bytes::decode().

### DIFF
--- a/doc/autogen/types/bytes.rst
+++ b/doc/autogen/types/bytes.rst
@@ -5,7 +5,7 @@
     Returns an iterator representing the offset *i* inside the bytes
     value.
 
-.. spicy:method:: bytes::decode bytes decode False string (charset: enum~{~~})
+.. spicy:method:: bytes::decode bytes decode False string (charset: enum~{~~} = hilti::Charset::UTF8)
 
     Interprets the ``bytes`` as representing an binary string encoded with
     the given character set, and converts it into a UTF8 string.

--- a/hilti/include/ast/operators/bytes.h
+++ b/hilti/include/ast/operators/bytes.h
@@ -348,7 +348,9 @@ BEGIN_METHOD(bytes, Decode)
         return Signature{.self = type::constant(type::Bytes()),
                          .result = type::String(),
                          .id = "decode",
-                         .args = {{.id = "charset", .type = type::Enum(type::Wildcard())}},
+                         .args = {{.id = "charset",
+                                   .type = type::Enum(type::Wildcard()),
+                                   .default_ = builder::id("hilti::Charset::UTF8")}},
                          .doc =
                              R"(
 Interprets the ``bytes`` as representing an binary string encoded with the given

--- a/tests/hilti/types/bytes/decode.hlt
+++ b/tests/hilti/types/bytes/decode.hlt
@@ -8,5 +8,5 @@ import hilti;
 hilti::print(b"testing".decode(hilti::Charset::ASCII));
 hilti::print(b"testüng\n".decode(hilti::Charset::ASCII));
 hilti::print(b"testüng".decode(hilti::Charset::UTF8));
-
+assert b"testüng".decode(hilti::Charset::UTF8) == b"testüng".decode(); # Check default
 }


### PR DESCRIPTION
Close #254.