### PR TITLE
Avoid leaking passwords into command lines in `docker/Makefile`.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -38,9 +38,10 @@ run-centos-8:
 	./docker-helper run centos-8
 
 update_dockerhub: test-alpine-3.11 test-centos-8 test-ubuntu-19.10
-	@: $${DOCKER_USERNAME:?"DOCKER_USERNAME must be set"}
-	@: $${DOCKER_PASSWORD:?"DOCKER_PASSWORD must be set"}
-	docker login --username="$$DOCKER_USERNAME" --password="$$DOCKER_PASSWORD"; \
+	@: $${DOCKER_USERNAME:?"must be set to the username for login to Docker Hub"}
+	@: $${DOCKER_PASSWORD_FILE:?"must be set to a file containing a password for login to Docker Hub"}
+	@test -f "$$DOCKER_PASSWORD_FILE" || >&2 echo "File '$$DOCKER_PASSWORD_FILE' does not exist" && exit 1
+	cat "$$DOCKER_PASSWORD_FILE" | docker login --username="$$DOCKER_USERNAME" --password-stdin"; \
 	IMAGES="alpine-3.11 centos-8 ubuntu-19.10"; \
 	VERSION=$$(../scripts/autogen-version --short); \
 	for image in $${IMAGES}; do \


### PR DESCRIPTION
This patch changes `docker/Makefile` so that the Docker Hub password is
not passed on the command line anymore which could be inspected by
anyone with access to process table of the machine the job is running.
Instead we now read the password from a file and pass it via a pipe into
the login command.