### PR TITLE
Properly escape data when stringifying streams

### DIFF
--- a/hilti/src/rt/tests/bytes.cc
+++ b/hilti/src/rt/tests/bytes.cc
@@ -7,6 +7,7 @@
 #include <hilti/rt/types/bytes.h>
 
 using namespace hilti::rt;
+using namespace hilti::rt::bytes;
 
 TEST_CASE("Bytes") {
     SUBCASE("iteration") {
@@ -16,5 +17,10 @@ TEST_CASE("Bytes") {
             (void)x;
             static_assert(std::is_same_v<decltype(x), Bytes::Iterator::reference>);
         }
+    }
+
+    SUBCASE("to_string") {
+        CHECK_EQ(to_string("ABC"_b), "b\"ABC\"");
+        CHECK_EQ(to_string("\0\2\3\0\6\7A\01"_b), "b\"\\x00\\x02\\x03\\x00\\x06\\x07A\\x01\"");
     }
 }

--- a/hilti/src/rt/tests/stream.cc
+++ b/hilti/src/rt/tests/stream.cc
@@ -389,3 +389,13 @@ TEST_CASE("Block iteration") {
     CHECK(block->is_last);
     CHECK(! v.nextBlock(block));
 }
+
+TEST_CASE("to_string") {
+    // Stream data should be rendered like the underlying `Bytes`.
+    const auto bytes = "ABC"_b;
+    const auto stream = Stream(bytes);
+    const auto view = stream.view();
+    REQUIRE_EQ(to_string(stream), to_string(bytes));
+    REQUIRE_EQ(to_string(view), to_string(bytes));
+    CHECK_EQ(to_string(stream.safeBegin()), fmt("<offset=0 data=%s>", to_string(bytes)));
+}

--- a/hilti/src/rt/types/stream.cc
+++ b/hilti/src/rt/types/stream.cc
@@ -1,7 +1,9 @@
 // Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
 
+#include "rt/types/stream.h"
+
+#include <hilti/rt/extension-points.h>
 #include <hilti/rt/types/bytes.h>
-#include <hilti/rt/types/stream.h>
 
 using namespace hilti::rt;
 using namespace hilti::rt::stream;
@@ -414,9 +416,9 @@ std::string hilti::rt::detail::adl::to_string(const stream::SafeConstIterator& x
         auto y = x + 10;
         auto v = stream::View(x, y);
         if ( y.isEnd() )
-            return fmt("%s", v);
+            return fmt("%s", hilti::rt::to_string(v));
 
-        return fmt("%s...", v);
+        return fmt("%s...", hilti::rt::to_string(v));
     };
 
     if ( x.isExpired() )
@@ -425,7 +427,7 @@ std::string hilti::rt::detail::adl::to_string(const stream::SafeConstIterator& x
     if ( x.isUnset() )
         return "<uninitialized>";
 
-    return fmt("<offset=%" PRIu64 " data=\"%s\">", x.offset(), str(x));
+    return fmt("<offset=%" PRIu64 " data=%s>", x.offset(), str(x));
 }
 
 void SafeConstIterator::debugPrint(std::ostream& out) const {


### PR DESCRIPTION
This closes #268.