### PR TITLE
Fix shell commands in `docker/Makefile`.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -40,8 +40,8 @@ run-centos-8:
 update_dockerhub: test-alpine-3.11 test-centos-8 test-ubuntu-19.10
 	@: $${DOCKER_USERNAME:?"must be set to the username for login to Docker Hub"}
 	@: $${DOCKER_PASSWORD_FILE:?"must be set to a file containing a password for login to Docker Hub"}
-	@test -f "$$DOCKER_PASSWORD_FILE" || >&2 echo "File '$$DOCKER_PASSWORD_FILE' does not exist" && exit 1
-	cat "$$DOCKER_PASSWORD_FILE" | docker login --username="$$DOCKER_USERNAME" --password-stdin"; \
+	@test -f "$$DOCKER_PASSWORD_FILE" || sh -c ">&2 echo 'File $$DOCKER_PASSWORD_FILE does not exist' && exit 1"
+	cat "$$DOCKER_PASSWORD_FILE" | docker login --username="$$DOCKER_USERNAME" --password-stdin; \
 	IMAGES="alpine-3.11 centos-8 ubuntu-19.10"; \
 	VERSION=$$(../scripts/autogen-version --short); \
 	for image in $${IMAGES}; do \


### PR DESCRIPTION
This patch fixes two errors in `docker/Makefile`:

- correctly terminated a quoted string
- fix control flow for error exit on missing Docker password file