### PR TITLE
Add `strftime` to `hilti::rt`.

### DIFF
--- a/doc/autogen/spicy-functions.spicy
+++ b/doc/autogen/spicy-functions.spicy
@@ -46,3 +46,9 @@ Returns a bytes value rendered as a hex string.
 
 Returns the value of an environment variable, if set.
 
+.. _spicy_strftime:
+
+.. rubric:: ``function spicy::strftime(format: string, timestamp: time) : string``
+
+Formats a time according to user-specified format string.
+

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -274,6 +274,7 @@ add_executable(hilti-rt-tests
                src/rt/tests/set.cc
                src/rt/tests/stream.cc
                src/rt/tests/to_string.cc
+               src/rt/tests/util.cc
                src/rt/tests/vector.cc)
 target_compile_options(hilti-rt-tests PRIVATE "-Wall")
 target_link_libraries(hilti-rt-tests PRIVATE hilti-rt doctest)

--- a/hilti/include/rt/util.h
+++ b/hilti/include/rt/util.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cxxabi.h>
+
 #include <list>
 #include <memory>
 #include <set>
@@ -14,6 +15,7 @@
 #include <hilti/rt/autogen/config.h>
 #include <hilti/rt/exception.h>
 #include <hilti/rt/types/set_fwd.h>
+#include <hilti/rt/types/time.h>
 #include <hilti/rt/types/vector_fwd.h>
 
 #ifdef CXX_FILESYSTEM_IS_EXPERIMENTAL
@@ -486,5 +488,19 @@ enum class ByteOrder { Little, Big, Network, Host, Undef = -1 };
  * either `ByteOrder::Little` or `ByteOrder::Big`.
  */
 extern ByteOrder systemByteOrder();
+
+/** Formats a time according to user-specified format string.
+ *
+ * This function uses the currently active locale and timezone to format
+ * values. Formatted strings cannot exceed 128 bytes.
+ *
+ * @param format a POSIX-conformant format string, see
+ *        https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html
+ *        for the available format specifiers
+ * @param time timestamp to format
+ * @return formatted timestamp
+ * @throw `InvalidArgument` if the timestamp could not be formatted
+ */
+std::string strftime(const std::string& format, const Time& time);
 
 } // namespace hilti::rt

--- a/hilti/src/rt/tests/util.cc
+++ b/hilti/src/rt/tests/util.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+#include <ctime>
+#include <locale>
+
+#include <hilti/rt/types/time.h>
+#include <hilti/rt/util.h>
+
+using namespace hilti::rt;
+
+TEST_SUITE_BEGIN("util");
+
+TEST_CASE("strftime") {
+    auto t = hilti::rt::Time();
+
+    REQUIRE_EQ(::setenv("TZ", "UTC", 1), 0);
+    std::locale::global(std::locale::classic());
+
+    CHECK_EQ(strftime("%A %c", Time()), "Thursday Thu Jan  1 00:00:00 1970");
+
+    CHECK_THROWS_WITH_AS(strftime("", Time()), "could not format timestamp", const InvalidArgument&);
+    CHECK_THROWS_WITH_AS(strftime("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+                                  "XXXXXXXXXXXXXXXX %A %c",
+                                  Time()),
+                         "could not format timestamp", const InvalidArgument&);
+}

--- a/spicy/lib/spicy.spicy
+++ b/spicy/lib/spicy.spicy
@@ -80,4 +80,16 @@ public function current_time() : time &cxxname="::hilti::rt::time::current_time"
 public function bytes_to_hexstring(value: bytes) : string &cxxname="::spicy::rt::bytes_to_hexstring";
 
 ## Returns the value of an environment variable, if set.
-public function getenv(name: string) : optional<string> &cxxname="spicy::rt::getenv";
+public function getenv(name: string) : optional<string> &cxxname="::spicy::rt::getenv";
+
+##  Formats a time according to user-specified format string.
+##
+## This function uses the currently active locale and timezone to format
+## values. Formatted strings cannot exceed 128 bytes.
+##
+## The format string can contain format specifiers supported by POSIX strftime, see
+## https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html.
+##
+## This function can raise InvalidArgument if the timestamp could not be
+## converted to local time or formatted.
+public function strftime(format: string, timestamp: time) : string &cxxname="::hilti::rt::strftime";

--- a/tests/btest.cfg
+++ b/tests/btest.cfg
@@ -30,6 +30,7 @@ USING_BUILD_DIRECTORY=1
 # Set variables to well-defined state.
 LANG=C
 LC_ALL=C
+TZ=UTC
 CC=
 CXX=
 HILTICFLAGS=

--- a/tests/spicy/rt/strftime.spicy
+++ b/tests/spicy/rt/strftime.spicy
@@ -1,0 +1,11 @@
+# @TEST-EXEC: spicyc -j %INPUT
+
+module Test;
+
+import spicy;
+
+assert spicy::strftime("%A %c", time(0)) == "Thursday Thu Jan  1 00:00:00 1970";
+
+assert-exception spicy::strftime("", time(0));
+assert-exception spicy::strftime("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX %A %c",
+                                 time(0));


### PR DESCRIPTION
This function is exposed in Spicy as `strftime`.

Closes #237.