### PR TITLE
Fix comment parsing in EVT files.

### DIFF
--- a/zeek/compiler/glue-compiler.cc
+++ b/zeek/compiler/glue-compiler.cc
@@ -235,6 +235,72 @@ GlueCompiler::GlueCompiler(Driver* driver) : _driver(driver) {}
 
 GlueCompiler::~GlueCompiler() {}
 
+hilti::Result<std::string> GlueCompiler::getNextEvtBlock(std::istream& in, int* lineno) const {
+    std::string chunk;
+
+    // Parser need to track whether we are inside a string or a comment.
+    enum State { Default, InComment, InString } state = Default;
+    char prev = '\0';
+
+    while ( true ) {
+        char cur;
+        if ( in.get(cur) ) {
+            chunk = util::trim(std::move(chunk));
+            if ( chunk.empty() )
+                // Legitimate end of data.
+                return std::string();
+            else
+                // End of input before semicolon.
+                return hilti::result::Error("unexpected end of file");
+        }
+
+        switch ( state ) {
+            case Default:
+                if ( cur == '"' && prev != '\\' )
+                    state = InString;
+
+                if ( cur == '#' && prev != '\\' ) {
+                    state = InComment;
+                    continue;
+                }
+
+                if ( cur == '\n' )
+                    ++*lineno;
+
+                if ( cur == ';' ) {
+                    // End of block found.
+                    chunk = util::trim(std::move(chunk));
+                    if ( chunk.size() )
+                        return chunk + ';';
+                    else
+                        return hilti::result::Error("empty block");
+                }
+
+                break;
+
+            case InString:
+                if ( cur == '"' && prev != '\\' )
+                    state = Default;
+
+                if ( cur == '\n' )
+                    ++*lineno;
+
+                break;
+
+            case InComment:
+                if ( cur != '\n' )
+                    // skip
+                    continue;
+
+                state = Default;
+                ++*lineno;
+        }
+
+        chunk += cur;
+        prev = cur;
+    }
+}
+
 bool GlueCompiler::loadEvtFile(std::filesystem::path& path) {
     std::ifstream in(path);
 
@@ -247,73 +313,48 @@ bool GlueCompiler::loadEvtFile(std::filesystem::path& path) {
     _locations.emplace_back(path);
 
     std::vector<glue::Event> new_events;
+    int lineno = 1;
 
     try {
-        int lineno = 0;
-        std::string chunk;
+        while ( true ) {
+            _locations.emplace_back(path, lineno);
 
-        while ( ! in.eof() ) {
-            _locations.emplace_back(path, ++lineno);
+            auto chunk = getNextEvtBlock(in, &lineno);
+            if ( ! chunk )
+                throw ParseError(chunk.error());
 
-            std::string line;
-            std::getline(in, line);
+            if ( chunk->empty() )
+                break; // end of input
 
-            // Skip comments and empty lines.
-            auto i = line.find_first_not_of(" \t");
-            if ( i == std::string::npos || line[i] == '#' ) {
-                _locations.pop_back();
-                continue;
-            }
-
-            if ( chunk.size() )
-                chunk += " ";
-
-            chunk += line.substr(i, std::string::npos);
-
-            // See if we have a semicolon-terminated chunk now.
-            i = line.find_last_not_of(" \t");
-            if ( i == std::string::npos )
-                i = line.size() - 1;
-
-            if ( line[i] != ';' ) {
-                // Nope, keep adding.
-                _locations.pop_back();
-                continue;
-            }
-
-            // Got it, parse the chunk.
-            chunk = util::trim(chunk);
-
-            if ( looking_at(chunk, 0, "protocol") ) {
-                auto a = parseProtocolAnalyzer(chunk);
+            if ( looking_at(*chunk, 0, "protocol") ) {
+                auto a = parseProtocolAnalyzer(*chunk);
                 _protocol_analyzers.push_back(a);
                 ZEEK_DEBUG(util::fmt("  Got protocol analyzer definition for %s", a.name));
             }
 
-
-            else if ( looking_at(chunk, 0, "file") ) {
-                auto a = parseFileAnalyzer(chunk);
+            else if ( looking_at(*chunk, 0, "file") ) {
+                auto a = parseFileAnalyzer(*chunk);
                 _file_analyzers.push_back(a);
                 ZEEK_DEBUG(util::fmt("  Got file analyzer definition for %s", a.name));
             }
 
-            else if ( looking_at(chunk, 0, "on") ) {
-                auto ev = parseEvent(chunk);
+            else if ( looking_at(*chunk, 0, "on") ) {
+                auto ev = parseEvent(*chunk);
                 ev.file = path;
                 new_events.push_back(ev);
                 ZEEK_DEBUG(util::fmt("  Got event definition for %s", ev.name));
             }
 
-            else if ( looking_at(chunk, 0, "import") ) {
+            else if ( looking_at(*chunk, 0, "import") ) {
                 size_t i = 0;
-                eat_token(chunk, &i, "import");
+                eat_token(*chunk, &i, "import");
 
-                hilti::ID module = extract_id(chunk, &i);
+                hilti::ID module = extract_id(*chunk, &i);
                 std::optional<hilti::ID> scope;
 
-                if ( looking_at(chunk, i, "from") ) {
-                    eat_token(chunk, &i, "from");
-                    scope = extract_path(chunk, &i);
+                if ( looking_at(*chunk, i, "from") ) {
+                    eat_token(*chunk, &i, "from");
+                    scope = extract_path(*chunk, &i);
                     ZEEK_DEBUG(util::fmt("  Got module %s to import from scope %s", module, *scope));
                 }
                 else
@@ -325,12 +366,8 @@ bool GlueCompiler::loadEvtFile(std::filesystem::path& path) {
             else
                 throw ParseError("expected 'import', '{file,protocol} analyzer', or 'on'");
 
-            chunk = "";
             _locations.pop_back();
         }
-
-        if ( chunk.size() )
-            throw ParseError("unterminated line at end of file");
 
     } catch ( const ParseError& e ) {
         if ( *e.what() )

--- a/zeek/compiler/glue-compiler.h
+++ b/zeek/compiler/glue-compiler.h
@@ -132,6 +132,17 @@ public:
     bool compile();
 
 private:
+    /**
+     * Extracts the next semicolon-terminated block from an input stream,
+     * accounting for special EVT constructs like strings and comments.
+     *
+     * @param in stream to read from
+     * @param lineno pointer to integer that will be increased with line breaks
+     * @return the read block of data, with comments removed, and empty if end of
+     * data has been reached; error will be set if parsing failed
+     */
+    hilti::Result<std::string> getNextEvtBlock(std::istream& in, int* lineno) const;
+
     // Parsers for parts from EVT files.
     glue::ProtocolAnalyzer parseProtocolAnalyzer(const std::string& chunk);
     glue::FileAnalyzer parseFileAnalyzer(const std::string& chunk);

--- a/zeek/plugin/lib/protocols/tftp.evt
+++ b/zeek/plugin/lib/protocols/tftp.evt
@@ -1,6 +1,6 @@
 protocol analyzer spicy::TFTP over UDP:
-    parse with TFTP::Message,
-    port 69/udp;
+    parse with TFTP::Message,   # entry point for parsing TFTP payload
+    port 69/udp;                # use analyzer for sessions on UDP port 69
 
 import TFTP;
 


### PR DESCRIPTION
The fix is quite involved because the parser is really just a hack
right now, and we need to add state machine to track whether we are
inside a comment. We need to switch to a flex/bison parser here
eventually.

We use new comments inside tftp.evt as our test, that used to be not
working.

Closes #312.