### PR TITLE
Fix JIT-less build of Zeek plugin.

### DIFF
--- a/zeek/CMakeLists.txt
+++ b/zeek/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
 
-if ( ZEEK_HAVE_JIT )
-add_subdirectory(compiler)
-endif()
-
 add_subdirectory(plugin)
+add_subdirectory(compiler)
 
 add_executable(spicyz bin/spicyz.cc)
 target_compile_options(spicyz PRIVATE "-Wall")

--- a/zeek/compiler/CMakeLists.txt
+++ b/zeek/compiler/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SOURCES
 add_library(zeek-compiler OBJECT ${SOURCES})
 target_include_directories(zeek-compiler PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_compile_options(zeek-compiler PRIVATE "-fPIC")
-target_link_libraries(zeek-compiler PRIVATE $<$<BOOL:${ZEEK_HAVE_JIT}>:spicy>)
+target_link_libraries(zeek-compiler PRIVATE spicy)

--- a/zeek/compiler/debug.h
+++ b/zeek/compiler/debug.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <hilti/base/logger.h>
 #include <hilti/rt/logging.h>
 
 namespace spicy::zeek::debug {

--- a/zeek/plugin/CMakeLists.txt
+++ b/zeek/plugin/CMakeLists.txt
@@ -55,6 +55,10 @@ endif ()
 
 target_include_directories(${_plugin_lib} PRIVATE include)
 
+# Without JIT support, we won't have the "compiler/" include directory available
+# through the "zeek-compiler" target, so add it no matter what.
+target_include_directories(${_plugin_lib} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
 # For JIT support.
 target_link_libraries(${_plugin_lib} $<$<BOOL:${ZEEK_HAVE_JIT}>:zeek-compiler>)
 target_link_libraries(${_plugin_lib} $<$<BOOL:${ZEEK_HAVE_JIT}>:spicy>)

--- a/zeek/plugin/include/zeek-reporter.h
+++ b/zeek/plugin/include/zeek-reporter.h
@@ -10,9 +10,6 @@
 #include <stdlib.h>
 #include <string>
 
-#include <hilti/ast/location.h>
-#include <hilti/base/util.h>
-
 #include <compiler/debug.h>
 
 #include "plugin.h"
@@ -21,10 +18,6 @@ class Connection; // From Zeek.
 namespace file_analysis {
 class File;
 } // namespace file_analysis
-
-namespace spicy::zeek::debug {
-extern const hilti::logging::DebugStream ZeekPlugin;
-}
 
 namespace spicy::zeek::reporter {
 

--- a/zeek/plugin/src/plugin-jit.cc
+++ b/zeek/plugin/src/plugin-jit.cc
@@ -19,6 +19,10 @@
 #include <zeek-spicy/plugin-jit.h>
 #include <zeek-spicy/zeek-reporter.h>
 
+namespace spicy::zeek::debug {
+const hilti::logging::DebugStream ZeekPlugin("zeek");
+}
+
 #ifdef ZEEK_HAVE_JIT
 plugin::Zeek_Spicy::PluginJIT SpicyPlugin;
 plugin::Zeek_Spicy::Plugin* ::plugin::Zeek_Spicy::OurPlugin = &SpicyPlugin;
@@ -30,8 +34,6 @@ void ::spicy::zeek::debug::do_log(const std::string_view& msg) {
     HILTI_RT_DEBUG("zeek", msg);
     HILTI_DEBUG(::spicy::zeek::debug::ZeekPlugin, std::string(msg));
 }
-
-const ::hilti::logging::DebugStream spicy::zeek::debug::ZeekPlugin("zeek");
 
 void plugin::Zeek_Spicy::Driver::hookAddInput(const std::filesystem::path& path) {
     // Need to initialized before 1st input gets added, as the options need

--- a/zeek/plugin/src/plugin.cc
+++ b/zeek/plugin/src/plugin.cc
@@ -161,7 +161,7 @@ void plugin::Zeek_Spicy::Plugin::InitPreScript() {
     if ( auto dir = getenv("ZEEK_SPICY_PATH") )
         addLibraryPaths(dir);
 
-    addLibraryPaths(util::normalizePath(OurPlugin->PluginDirectory()).string() + "/spicy");
+    addLibraryPaths(hilti::rt::normalizePath(OurPlugin->PluginDirectory()).string() + "/spicy");
 
     ZEEK_DEBUG("Beginning pre-script initialization (runtime)");
 }
@@ -196,12 +196,12 @@ void plugin::Zeek_Spicy::Plugin::InitPostScript() {
         spicy::rt::init();
     } catch ( const hilti::rt::Exception& e ) {
         std::cerr << hilti::rt::fmt("uncaught runtime exception %s during initialization: %s",
-                                    util::demangle(typeid(e).name()), e.what())
+                                    hilti::rt::demangle(typeid(e).name()), e.what())
                   << std::endl;
         exit(1);
     } catch ( const std::runtime_error& e ) {
         std::cerr << hilti::rt::fmt("uncaught C++ exception %s during initialization: %s",
-                                    util::demangle(typeid(e).name()), e.what())
+                                    hilti::rt::demangle(typeid(e).name()), e.what())
                   << std::endl;
         exit(1);
     }


### PR DESCRIPTION
    - Fix include path
    - Build spicyz even if no JIT support is available (it can still generate C++ code).
    - Remove some unnecessary dependencies on HILTI/Spicy libs on plugin code