### PR TITLE
Add http_all_headers() event to HTTP EVT file.

### DIFF
--- a/tests/Baseline/zeek.lib.protocols.http/output
+++ b/tests/Baseline/zeek.lib.protocols.http/output
@@ -1,0 +1,14 @@
+all headers, [orig_h=141.142.228.5, orig_p=53595/tcp, resp_h=54.243.55.129, resp_p=80/tcp], {
+[2] = [name=ACCEPT, value=*/*],
+[4] = [name=CONTENT-TYPE, value=application/x-www-form-urlencoded],
+[1] = [name=HOST, value=httpbin.org],
+[0] = [name=USER-AGENT, value=curl/7.29.0],
+[3] = [name=CONTENT-LENGTH, value=11]
+}
+all headers, [orig_h=141.142.228.5, orig_p=53595/tcp, resp_h=54.243.55.129, resp_p=80/tcp], {
+[2] = [name=CONTENT-TYPE, value=application/json],
+[4] = [name=CONNECTION, value=close],
+[1] = [name=DATE, value=Tue, 19 Mar 2013 16:05:11 GMT],
+[0] = [name=SERVER, value=gunicorn/0.16.1],
+[3] = [name=CONTENT-LENGTH, value=366]
+}

--- a/tests/zeek/lib/protocols/http.zeek
+++ b/tests/zeek/lib/protocols/http.zeek
@@ -2,7 +2,13 @@
 #
 # @TEST-EXEC: spicyz -o http.hlto ${DIST}/spicy/lib/protocols/http.spicy ${DIST}/zeek/plugin/lib/protocols/http.evt
 # @TEST-EXEC: ${SCRIPTS}/run-zeek -NN http.hlto | grep -q spicy_HTTP
-# @TEST-EXEC: ${SCRIPTS}/run-zeek -r ${TRACES}/http-post.trace frameworks/files/hash-all-files http.hlto
+# @TEST-EXEC: ${SCRIPTS}/run-zeek -r ${TRACES}/http-post.trace frameworks/files/hash-all-files http.hlto %INPUT >output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=${SCRIPTS}/canonify-zeek-log btest-diff conn.log
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=${SCRIPTS}/canonify-zeek-log btest-diff http.log
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=${SCRIPTS}/canonify-zeek-log btest-diff files.log
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=${SCRIPTS}/canonify-zeek-log btest-diff output
+
+event http_all_headers(c: connection, is_orig: bool, hlist: mime_header_list)
+    {
+    print "all headers", c$id, hlist;
+    }

--- a/zeek/plugin/lib/protocols/http.evt
+++ b/zeek/plugin/lib/protocols/http.evt
@@ -16,6 +16,7 @@ on HTTP::Message               -> event http_message_done($conn, $is_orig, Zeek_
 on HTTP::Message::%error       -> event http_message_done($conn, $is_orig, Zeek_HTTP::create_http_message_stats(self));
 
 on HTTP::Message::end_of_hdr   -> event http_content_type($conn, $is_orig, self.content_type[0], self.content_type[1]);
+on HTTP::Message::end_of_hdr   -> event http_all_headers($conn, $is_orig, Zeek_HTTP::convert_all_headers(self.headers));
 
 on HTTP::Content::data         -> event http_entity_data($conn, $is_orig, |self.data|, self.data);
 on HTTP::Header                -> event http_header($conn, $is_orig, self.name, self.content);

--- a/zeek/plugin/lib/protocols/zeek_http.spicy
+++ b/zeek/plugin/lib/protocols/zeek_http.spicy
@@ -12,6 +12,16 @@ public function create_http_message_stats(msg: HTTP::Message) : tuple<time, bool
     return (cast<time>(0), False, b"", (msg.has_body ? msg.body_len : 0), 0 , 0);
 }
 
+# Create an map of all headers as http_all_headers() expects it.
+public function convert_all_headers(headers: vector<HTTP::Header>) : map<uint64, tuple<bytes, bytes>> {
+    local hdrs: map<uint64, tuple<bytes, bytes>>;
+
+    for ( i in headers )
+        hdrs[|hdrs|] = (i.name, i.content);
+
+    return hdrs;
+}
+
 on HTTP::RequestLine::%done {
     zeek::confirm_protocol();
     # zeek::rule_match(zeek::PatternType::HTTP_REQUEST, self.uri, True, True, True);


### PR DESCRIPTION
The event isn't used anywhere by default in Zeek, but it's a nice
example of transforming Spicy information on the fly to match a
Zeek-side event signature.

#335