### PR TITLE
Set PATH when building documation so that we find the Spicy tools.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ clean:
 html: Makefile autogen-docs
 	@rm -f "$(BUILDDIR)/doc-root" && ln -s "../doc" "$(BUILDDIR)/doc-root"
 	@  # The RTD theme might be producing RemovedInSphinx30Warning
-	@PYTHONWARNINGS="ignore" $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
+	@PYTHONWARNINGS="ignore" PATH=$(BUILDDIR)/bin:$$PATH $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
 	@echo Built documentation in $(DESTDIR)/html/index.html
 
 autogen-docs:


### PR DESCRIPTION
Closes #282.

@bbannier Will this work with CI? (Don't remember what the earlier change there was)