### PR TITLE
Zeek plugin: Catch if more parameters are given than Zeek expects.

### DIFF
--- a/zeek/compiler/glue-compiler.cc
+++ b/zeek/compiler/glue-compiler.cc
@@ -915,7 +915,8 @@ bool GlueCompiler::CreateSpicyHook(glue::Event* ev) {
                 return false;
             }
 
-            auto ztype = builder::call("zeek_rt::event_arg_type", {builder::id(handler_id), builder::integer(i)}, meta);
+            auto ztype = builder::call("zeek_rt::event_arg_type",
+                                       {builder::id(handler_id), builder::integer(i), location(e)}, meta);
             val = builder::call("zeek_rt::to_val", {std::move(*expr), ztype, location(e)}, meta);
         }
 

--- a/zeek/plugin/include/runtime-support.h
+++ b/zeek/plugin/include/runtime-support.h
@@ -102,7 +102,7 @@ void raise_event(EventHandlerPtr handler, const hilti::rt::Vector<Val*>& args, s
  * Returns the Zeek type of an event's i'th argument. The result's ref count
  * is not increased.
  */
-BroType* event_arg_type(EventHandlerPtr handler, uint64_t idx);
+BroType* event_arg_type(EventHandlerPtr handler, uint64_t idx, std::string_view location);
 
 /**
  * Retrieves the connection ID for the currently processed Zeek connection.

--- a/zeek/plugin/spicy/zeek_rt.hlt
+++ b/zeek/plugin/spicy/zeek_rt.hlt
@@ -15,7 +15,7 @@ declare public bool have_handler(EventHandlerPtr handler) &cxxname="::spicy::zee
 declare public EventHandlerPtr internal_handler(string event) &cxxname="::spicy::zeek::rt::internal_handler";
 
 declare public void raise_event(EventHandlerPtr handler, vector<Val> args, string location) &cxxname="::spicy::zeek::rt::raise_event";
-declare public BroType event_arg_type(EventHandlerPtr handler, uint<64> idx) &cxxname="::spicy::zeek::rt::event_arg_type";
+declare public BroType event_arg_type(EventHandlerPtr handler, uint<64> idx, string location) &cxxname="::spicy::zeek::rt::event_arg_type";
 declare public Val to_val(any x, BroType target, string location) &cxxname="::spicy::zeek::rt::to_val";
 
 declare public Val current_conn(string location) &cxxname="::spicy::zeek::rt::current_conn";

--- a/zeek/plugin/src/runtime-support.cc
+++ b/zeek/plugin/src/runtime-support.cc
@@ -86,9 +86,15 @@ void rt::raise_event(EventHandlerPtr handler, const hilti::rt::Vector<Val*>& arg
     ::mgr.QueueEventFast(handler, vl);
 }
 
-BroType* rt::event_arg_type(EventHandlerPtr handler, uint64_t idx) {
+BroType* rt::event_arg_type(EventHandlerPtr handler, uint64_t idx, std::string_view location) {
     assert(handler);
-    return (*handler->FType()->ArgTypes()->Types())[idx];
+
+    auto zeek_args = handler->FType()->ArgTypes()->Types();
+    if ( idx >= static_cast<uint64_t>(zeek_args->length()) )
+        throw TypeMismatch(fmt("more parameters given than the %d that the Zeek event expects", zeek_args->length()),
+                           location);
+
+    return (*zeek_args)[idx];
 }
 
 Val* rt::current_conn(std::string_view location) {


### PR DESCRIPTION
The check we already had for this came to late.

Skipping a test, as it would require a full compiler cycle + Zeek
execution to trigger the error message.

Closes #365.