### PR TITLE
Fix construction of vectors with element types that provide default v…

### DIFF
--- a/hilti/src/compiler/codegen/coercions.cc
+++ b/hilti/src/compiler/codegen/coercions.cc
@@ -47,8 +47,15 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
         if ( auto t = dst.tryAs<type::Set>() )
             return fmt("hilti::rt::Set(%s)", expr);
 
-        if ( auto t = dst.tryAs<type::Vector>() )
-            return fmt("hilti::rt::Vector(%s)", expr);
+        if ( auto t = dst.tryAs<type::Vector>() ) {
+            auto x = cg->compile(t->elementType(), codegen::TypeUsage::Storage);
+
+            std::string allocator;
+            if ( auto def = cg->typeDefaultValue(t->elementType()) )
+                allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+
+            return fmt("hilti::rt::Vector<%s%s>(%s)", x, allocator, expr);
+        }
 
         logger().internalError(fmt("codegen: unexpected type coercion from lisst to %s", dst.typename_()));
     }

--- a/hilti/src/compiler/codegen/ctors.cc
+++ b/hilti/src/compiler/codegen/ctors.cc
@@ -182,7 +182,13 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
             // Can only be the empty list.
             return "hilti::rt::vector::Empty()";
 
-        return fmt("hilti::rt::Vector<%s>({%s})", cg->compile(n.elementType(), codegen::TypeUsage::Storage),
+        auto x = cg->compile(n.elementType(), codegen::TypeUsage::Storage);
+
+        std::string allocator;
+        if ( auto def = cg->typeDefaultValue(n.elementType()) )
+            allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+
+        return fmt("hilti::rt::Vector<%s%s>({%s})", x, allocator,
                    util::join(util::transform(n.value(), [this](auto e) { return fmt("%s", cg->compile(e)); }), ", "));
     }
 

--- a/tests/Baseline/hilti.types.enum.basic/output
+++ b/tests/Baseline/hilti.types.enum.basic/output
@@ -3,3 +3,6 @@ Y::Undef
 X::A1
 Y::B2
 [$x1=X::Undef, $x2=(not set), $y1=(not set)]
+[]
+[]
+[X::A1, X::A2]

--- a/tests/hilti/types/enum/basic.hlt
+++ b/tests/hilti/types/enum/basic.hlt
@@ -38,4 +38,22 @@ assert X::A1;
 assert !X::Undef;
 assert x && X::A1 ;
 
+# Passing back from function
+function vector<X> x1() {
+    return [];
+}
+
+function vector<X> x2() {
+    return vector<X>();
+}
+
+function vector<X> x3() {
+    return [X::A1, X::A2];
+}
+
+
+hilti::print(x1());
+hilti::print(x2());
+hilti::print(x3());
+
 }


### PR DESCRIPTION
…alues.

We need to pass an custom allocator for these types, which we didn't
do consistently.

Closes #361.