### PR TITLE
Unbreak build for when other Spicy headers are already installed.

### DIFF
--- a/3rdparty/justrx/CMakeLists.txt
+++ b/3rdparty/justrx/CMakeLists.txt
@@ -31,13 +31,13 @@ set(SOURCES
 
 add_library(jrx ${SOURCES})
 # target_link_libraries(jrx ${FLEX_LIBRARIES})
-target_include_directories(jrx PUBLIC include)
-target_include_directories(jrx PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(jrx BEFORE PUBLIC include)
+target_include_directories(jrx BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(jrx-objects OBJECT ${SOURCES})
 target_compile_options(jrx-objects PRIVATE "-fPIC")
 # target_link_libraries(jrx-objects ${FLEX_LIBRARIES})
-target_include_directories(jrx-objects PUBLIC include)
-target_include_directories(jrx-objects PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(jrx-objects BEFORE PUBLIC include)
+target_include_directories(jrx-objects BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(test)

--- a/3rdparty/justrx/test/CMakeLists.txt
+++ b/3rdparty/justrx/test/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
 add_executable(retest retest.c)
 target_link_libraries(retest jrx)

--- a/cmake/FindClangJIT.cmake
+++ b/cmake/FindClangJIT.cmake
@@ -170,7 +170,7 @@ if ( CLANG_JIT_FOUND )
     message(STATUS "Linking against clang libraries '${clang_libs}'")
 
     add_library(clang-jit INTERFACE)
-    target_include_directories(clang-jit INTERFACE ${LLVM_INCLUDE_DIRS})
+    target_include_directories(clang-jit BEFORE INTERFACE ${LLVM_INCLUDE_DIRS})
     target_compile_definitions(clang-jit INTERFACE ${LLVM_DEFINITIONS})
     target_link_options(clang-jit INTERFACE "LINKER:-rpath;${LLVM_LIBRARY_DIR}")
     target_link_libraries(clang-jit INTERFACE ${llvm_libs} ${clang_libs})

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -122,8 +122,8 @@ target_compile_options(hilti PRIVATE "-Wall")
 target_link_libraries(hilti PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>)
 target_link_libraries(hilti PRIVATE $<$<BOOL:${HILTI_HAVE_JIT}>:clang-jit>)
 target_link_libraries(hilti PRIVATE std::filesystem)
-target_include_directories(hilti PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-target_include_directories(hilti PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+target_include_directories(hilti BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(hilti BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 # Unclear why we need this: Without it, the generated Bison/Flex get a broken
 # include path on some systems. (Seen on Ubuntu 19.10).
@@ -164,9 +164,9 @@ foreach ( lib hilti-rt hilti-rt-debug )
     add_dependencies(${lib}-objects version)
     target_compile_options(${lib}-objects PRIVATE "-fPIC")
     target_link_libraries(${lib}-objects PRIVATE std::filesystem ${CMAKE_DL_LIBS})
-    target_include_directories(${lib}-objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-    target_include_directories(${lib}-objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-    target_include_directories(${lib}-objects PRIVATE include/3rdparty/libtask)
+    target_include_directories(${lib}-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_include_directories(${lib}-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+    target_include_directories(${lib}-objects BEFORE PRIVATE include/3rdparty/libtask)
 
     # The following should instead just be:
     #
@@ -177,7 +177,7 @@ foreach ( lib hilti-rt hilti-rt-debug )
     # referenced target is built before the dependent target is linked, we also
     # explicitly depend on jrx-objects to make sure all its objects are build.
     add_dependencies(${lib}-objects jrx-objects)
-    target_include_directories(${lib}-objects PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/justrx/include)
+    target_include_directories(${lib}-objects BEFORE PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/justrx/include)
     target_link_libraries(${lib}-objects      PRIVATE $<TARGET_OBJECTS:jrx-objects>)
 
     add_library(${lib} STATIC)

--- a/spicy/CMakeLists.txt
+++ b/spicy/CMakeLists.txt
@@ -79,8 +79,8 @@ target_compile_options(spicy PRIVATE "-Wall")
 target_link_libraries(spicy  PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>)
 target_link_libraries(spicy  PUBLIC hilti)
 target_link_libraries(spicy  PRIVATE std::filesystem)
-target_include_directories(spicy PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-target_include_directories(spicy PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+target_include_directories(spicy BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(spicy BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 # Unclear why we need this: Without it, the generated Bison/Flex get a broken
 # include path on some systems. (Seen on Ubuntu 19.10).
@@ -107,9 +107,9 @@ foreach ( lib spicy-rt spicy-rt-debug )
     target_compile_options(${lib}-objects PRIVATE "-fPIC")
     target_link_libraries(${lib}-objects PRIVATE std::filesystem)
     target_link_libraries(${lib}-objects PUBLIC ZLIB::ZLIB)
-    target_include_directories(${lib}-objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-    target_include_directories(${lib}-objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-    target_include_directories(${lib}-objects PRIVATE include/3rdparty/libtask)
+    target_include_directories(${lib}-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_include_directories(${lib}-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+    target_include_directories(${lib}-objects BEFORE PRIVATE include/3rdparty/libtask)
 
     add_library(${lib} STATIC)
     target_link_libraries(${lib} ${lib}-objects)

--- a/zeek/CMakeLists.txt
+++ b/zeek/CMakeLists.txt
@@ -6,6 +6,6 @@ add_subdirectory(compiler)
 add_executable(spicyz bin/spicyz.cc)
 target_compile_options(spicyz PRIVATE "-Wall")
 target_link_libraries(spicyz PRIVATE zeek-compiler spicy)
-target_include_directories(spicyz PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/plugin)
+target_include_directories(spicyz BEFORE PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/plugin)
 
 install(TARGETS spicyz RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/zeek/compiler/CMakeLists.txt
+++ b/zeek/compiler/CMakeLists.txt
@@ -6,6 +6,6 @@ set(SOURCES
     )
 
 add_library(zeek-compiler OBJECT ${SOURCES})
-target_include_directories(zeek-compiler PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_include_directories(zeek-compiler BEFORE PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 target_compile_options(zeek-compiler PRIVATE "-fPIC")
 target_link_libraries(zeek-compiler PRIVATE spicy)

--- a/zeek/plugin/CMakeLists.txt
+++ b/zeek/plugin/CMakeLists.txt
@@ -53,11 +53,11 @@ else ()
     set(ZEEK_DEBUG_BUILD_CXX "false")
 endif ()
 
-target_include_directories(${_plugin_lib} PRIVATE include)
+target_include_directories(${_plugin_lib} BEFORE PRIVATE include)
 
 # Without JIT support, we won't have the "compiler/" include directory available
 # through the "zeek-compiler" target, so add it no matter what.
-target_include_directories(${_plugin_lib} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(${_plugin_lib} BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 # For JIT support.
 target_link_libraries(${_plugin_lib} $<$<BOOL:${ZEEK_HAVE_JIT}>:zeek-compiler>)


### PR DESCRIPTION
If Spicy headers were already installed into a path somewhere in the
include lookup, we could have found the same header twice, preferring
the installed header over the one of the current checkout. This could
have lead to diagnostics about duplicate definitions since due to use of
`#pragma once` in our headers the compiler would not have detected that
a header was already included (and even if it would have detected this,
it would have included the incorrect header).

This patch adds include paths from the current checkout before any
system paths.

Closes #274.