### PR TITLE
Remove unintended conversion of `rt::Result` to `bool`.

### DIFF
--- a/hilti/include/compiler/coercion.h
+++ b/hilti/include/compiler/coercion.h
@@ -55,7 +55,7 @@ enum class CoercionStyle {
 
     /**
      * If the source expression's AST node has an original type associated
-     * with it, use that's type for coersion.
+     * with it, use that's type for coercion.
      */
     PreferOriginalType = (1U << 6U),
 
@@ -105,7 +105,7 @@ enum class CoercionStyle {
 };
 
 /**
- * Returns a readable represenation of a coercion style setting for debugging
+ * Returns a readable representation of a coercion style setting for debugging
  * purposes.
  */
 extern std::string to_string(bitmask<CoercionStyle> style);
@@ -119,17 +119,17 @@ namespace hilti {
 /** Return type for the functions doing expression coercion. */
 struct CoercedExpression {
     /** Returns true if coercion was successful. */
-    operator bool() const { return coerced; }
+    operator bool() const { return coerced.hasValue(); }
 
     /**
-     * Coerced expression if succesful, an error if not. This will be set
+     * Coerced expression if successful, an error if not. This will be set
      * even if the coerced expression ends up being identical to the source
      * expression.
      */
     Result<Expression> coerced = {};
 
     /**
-     * Coerced expression if succesful and the coerced expression is not
+     * Coerced expression if successful and the coerced expression is not
      * identical to original one; unset otherwise.
      */
     std::optional<Expression> nexpr = {};

--- a/hilti/include/compiler/plugin.h
+++ b/hilti/include/compiler/plugin.h
@@ -31,19 +31,19 @@ class Stream;
  * Compiler plugin that can hook into the compilation process that's driven
  * by `Unit`.
  *
- * A plugin gets access the the AST at all major stages. In particular it can
+ * A plugin gets access to the AST at all major stages. In particular it can
  * add support implement support for new language using HILTI as its code
  * generation backend by providing a parse method building its AST, along
  * with a transformation method converting any non-standard nodes HILTI
  * equivalents.
  *
  * A plugin implements a set of hook methods that get called by the
- * compilation process at the appropiate times. All hooks should be
- * stateless, apart from changing the AST where appropiate.
+ * compilation process at the appropriate times. All hooks should be
+ * stateless, apart from changing the AST where appropriate.
  *
  * @note HILTI compilation itself is also implemented through a default
  * plugin that's always available. `Unit` cycles through all available
- * plugins during the compilation processm, including that default plugin.
+ * plugins during the compilation process, including that default plugin.
  */
 struct Plugin {
     /** Helper template to define the type of hook methods. */
@@ -108,7 +108,7 @@ struct Plugin {
      * @param arg2 type that needs coercion
      * @param arg3 target type for coercion
      * @param arg4 coercion style to use
-     * @return new type if plugin can handnle this coercion
+     * @return new type if plugin can handle this coercion
      */
     Hook<std::optional<Type>, Type, const Type&, bitmask<CoercionStyle>> coerce_type;
 
@@ -225,7 +225,7 @@ class PluginRegistry {
 public:
     PluginRegistry();
 
-    /** Returns a vector of all currentlh registered plugins. */
+    /** Returns a vector of all currently registered plugins. */
     const std::vector<Plugin>& plugins() const { return _plugins; }
 
     /**
@@ -241,7 +241,7 @@ public:
      * Checks if at least one plugin implements a given hook.
      *
      * \tparam PluginMember the hook
-     * \return true if there's an implemention for the hook
+     * \return true if there's an implementation for the hook
      */
     template<typename PluginMember>
     bool hasHookFor(PluginMember hook) {
@@ -259,9 +259,9 @@ public:
      * @param ext extension, including the leading `.`
      * \return true if there's a plugin for this extension
      */
-    bool supportsExtension(std::filesystem::path ext) const { return pluginForExtension(std::move(ext)); }
+    bool supportsExtension(std::filesystem::path ext) const { return pluginForExtension(std::move(ext)).hasValue(); }
 
-    /** Returns a vector of all exensions that registered set of plugins handles. */
+    /** Returns a vector of all extensions that registered set of plugins handles. */
     auto supportedExtensions() const {
         return util::transform(_plugins, [](auto& p) { return p.extension; });
     }
@@ -269,7 +269,7 @@ public:
     /**
      * Registers a plugin with the registry.
      *
-     * @note This method should nornally not be called directly, use
+     * @note This method should normally not be called directly, use
      * `plugin::Register()` instead.
      *
      * @param p plugin to register

--- a/hilti/include/rt/result.h
+++ b/hilti/include/rt/result.h
@@ -54,9 +54,12 @@ public:
 
 struct Nothing {};
 
+inline bool operator==(const Nothing&, const Nothing&) { return true; }
+inline bool operator!=(const Nothing&, const Nothing&) { return false; }
+
 /**
  * Represents either a successful result from function if it returned one, or
- * reflects an error if the function was unsuccesful.
+ * reflects an error if the function was unsuccessful.
  */
 template<typename T>
 class Result {
@@ -139,7 +142,7 @@ public:
         return error();
     }
 
-    /** Returns true if the result represents a succesful return value. */
+    /** Returns true if the result represents a successful return value. */
     bool hasValue() const { return std::holds_alternative<T>(_value); }
 
     /** Returns the result's value, assuming it indicates success. */
@@ -151,14 +154,26 @@ public:
     /** Returns the result's value, assuming it indicates success. */
     T* operator->() { return std::get_if<T>(&_value); }
 
-    /** Returns true if the result represents a succesful return value. */
-    operator bool() const { return hasValue(); }
+    /** Returns true if the result represents a successful return value. */
+    explicit operator bool() const { return hasValue(); }
 
-    /** Converts the result to an optional that's set if it represents a succesful return value. */
+    /** Converts the result to an optional that's set if it represents a successful return value. */
     operator std::optional<T>() const { return hasValue() ? std::make_optional(value()) : std::nullopt; }
 
     Result& operator=(const Result& other) = default;
     Result& operator=(Result&& other) = default; // NOLINT (hicpp-noexcept-move)
+
+    friend bool operator==(const Result& a, const Result& b) {
+        if ( a.hasValue() != b.hasValue() )
+            return false;
+
+        if ( a.hasValue() )
+            return a.value() == b.value();
+        else
+            return a.error() == b.error();
+    }
+
+    friend bool operator!=(const Result& a, const Result& b) { return ! (a == b); }
 
 private:
     std::variant<T, result::Error> _value;

--- a/hilti/src/compiler/clang.cc
+++ b/hilti/src/compiler/clang.cc
@@ -590,7 +590,7 @@ Result<Library> ClangJIT::Implementation::compileModule(llvm::Module&& module) {
     std::error_code error;
     llvm::raw_fd_ostream file(object_path->native(), error);
     if ( error )
-        return result::Error(util::fmt("could not open object file %s: %s", object_path, error.message()));
+        return result::Error(util::fmt("could not open object file %s: %s", *object_path, error.message()));
 
 #if LLVM_VERSION_MAJOR < 10
 #define CGFT_OBJECTFILE llvm::TargetMachine::CGFT_ObjectFile
@@ -601,7 +601,7 @@ Result<Library> ClangJIT::Implementation::compileModule(llvm::Module&& module) {
         return result::Error("adding passes failed");
 
     if ( ! manager.run(module) )
-        return result::Error(util::fmt("object file %s could not be created", object_path));
+        return result::Error(util::fmt("object file %s could not be created", *object_path));
 
     file.close();
 

--- a/hilti/src/compiler/driver.cc
+++ b/hilti/src/compiler/driver.cc
@@ -584,7 +584,7 @@ Result<Nothing> Driver::compileUnits() {
             if ( ! unit.isCompiledHILTI() )
                 continue;
 
-            HILTI_DEBUG(logging::debug::Driver, util::fmt("saving HILTI code for module %s to %s", unit.id(), output));
+            HILTI_DEBUG(logging::debug::Driver, util::fmt("saving HILTI code for module %s", unit.id()));
             if ( ! unit.print(*output) )
                 return error(fmt("error print HILTI code for module %s", unit.id()));
         }

--- a/hilti/src/rt/tests/result.cc
+++ b/hilti/src/rt/tests/result.cc
@@ -26,4 +26,15 @@ TEST_CASE_TEMPLATE("conversion to bool", T, Nothing, bool, std::string) {
     CHECK(r);
 }
 
+TEST_CASE("equal") {
+    CHECK_EQ(Result(42), Result(42));
+    CHECK_EQ(Result(0), Result(0));
+    CHECK_EQ(Result<int>(result::Error("foo")), Result<int>(result::Error("foo")));
+}
+
+TEST_CASE("not equal") {
+    CHECK_NE(Result(42), Result(0));
+    CHECK_NE(Result(42), Result<int>(result::Error("foo")));
+}
+
 TEST_SUITE_END();

--- a/spicy/tests/grammar.cc
+++ b/spicy/tests/grammar.cc
@@ -90,9 +90,9 @@ TEST_CASE("example1") {
     auto ABA = sequence("ABA", {A, B, A});
     auto S = lookAhead("S", ABA, cC);
 
-    CHECK(finalize(&g, S) ==
-          hilti::Result<hilti::Nothing>(hilti::result::Error(
-              "grammar example1, production A is ambiguous for look-ahead symbol(s) { b\"a\" (bytes) }")));
+    CHECK_EQ(finalize(&g, S),
+             hilti::Result<hilti::Nothing>(hilti::result::Error(
+                 "grammar example1, production A is ambiguous for look-ahead symbol(s) { b\"a\" (bytes) }\n")));
 }
 
 TEST_CASE("example2") {


### PR DESCRIPTION
`rt::Result` did provide implicit conversions to `bool`, but e.g., no
operators for `==` or `!=` so that Due to the language rules any (not)
equality check of `rt::Result` was performed by first converting both
operands to `bool` and then comparing them. Since `rt::Result`'s
bool conversion is just intended to check whether it has a value (a
typical use in conditionals), equality comparisions also just checked
whether both the operands had the same value state (both value, or both
error state). This is not what is intended.

This patch makes the conversion of `rt::Result` to `bool` `explicit`;
with that we can still use `rt::Result`s in conditionals, but disallow
unintended conversions. We also fix the code so that it now

- explicitly converts to bool where needed
- actually stringifies values in `rt::Result` instead of its value/error
  state
- tests for correct values