### PR TITLE
Fix build with static libraries.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,7 +98,7 @@ clang10_zeek31_ubuntu_release_task:
       type: text/xml
       format: junit
 
-clang9_zeek30_ubuntu_release_task:
+clang9_zeek30_ubuntu_release_static_task:
   container:
     dockerfile: ci/Dockerfile
     docker_arguments:
@@ -124,7 +124,7 @@ clang9_zeek30_ubuntu_release_task:
     - git fetch --tags
     - git submodule update --recursive --init
 
-  configure_script:      ./ci/run-ci -b build configure release --cxx-compiler clang++-9 --with-zeek /opt/zeek --clang-format `which clang-format-10` --clang-tidy `which clang-tidy-10`
+  configure_script:      ./ci/run-ci -b build configure release --cxx-compiler clang++-9 --with-zeek /opt/zeek --clang-format `which clang-format-10` --clang-tidy `which clang-tidy-10` --build-static-libs
   build_script:          ./ci/run-ci -b build build
   install_script:        ./ci/run-ci -b build install
   cleanup_script:        ./ci/run-ci -b build cleanup

--- a/ci/run-ci
+++ b/ci/run-ci
@@ -162,6 +162,11 @@ function run_configure {
                 shift 1;
                 ;;
 
+            --build-static-libs)
+                configure="${configure} --build-static-libs"
+                shift 1;
+                ;;
+
             *)  usage;;
         esac
     done

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -87,3 +87,29 @@ function(require_version name found have need require)
         endif()
     endif()
 endfunction ()
+
+# Link a target against libhilti. This picks the right version of
+# libhilti (shared or object) based on the build configuration.
+function(target_link_hilti lib)
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries(${lib} "${ARGN}" hilti)
+    else ()
+        target_link_libraries(${lib} "${ARGN}" hilti-objects)
+        target_link_libraries(${lib} "${ARGN}" $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>) # doesn't transfer from hilti-objects
+        set_property(TARGET ${lib} PROPERTY ENABLE_EXPORTS true)
+    endif ()
+endfunction ()
+
+# Link a target against libspicy. This picks the right version of
+# libspicy (shared or object) based on the build configuration.
+function(target_link_spicy lib)
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries(${lib} "${ARGN}" spicy)
+    else ()
+        target_link_libraries(${lib} "${ARGN}" spicy-objects)
+        target_link_libraries(${lib} "${ARGN}" $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>) # doesn't transfer from spicy-objects
+        set_property(TARGET ${lib} PROPERTY ENABLE_EXPORTS true)
+    endif ()
+
+    target_link_hilti(${lib} "${ARGN}")
+endfunction ()

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -117,20 +117,25 @@ set(SOURCES_COMPILER
 # (lib64/libhilti.so: undefined reference to `llvm::cfg::Update<llvm::BasicBlock*>::dump() const')
 set_source_files_properties(src/compiler/clang.cc PROPERTIES COMPILE_DEFINITIONS "NDEBUG")
 
-add_library(hilti ${SOURCES_COMPILER})
-add_dependencies(hilti version)
-target_compile_options(hilti PRIVATE "-Wall")
-target_compile_options(hilti PRIVATE $<$<CONFIG:Debug>:-O0>)
-target_link_libraries(hilti PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>)
-target_link_libraries(hilti PRIVATE $<$<BOOL:${HILTI_HAVE_JIT}>:clang-jit>)
-target_link_libraries(hilti PRIVATE std::filesystem ${CMAKE_DL_LIBS})
-target_link_options(hilti   PRIVATE $<$<CONFIG:Debug>:-O0>)
-target_include_directories(hilti BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-target_include_directories(hilti BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+add_library(hilti-objects OBJECT ${SOURCES_COMPILER})
+set_property(TARGET hilti-objects PROPERTY POSITION_INDEPENDENT_CODE ON)
+add_dependencies(hilti-objects version)
+target_compile_options(hilti-objects PRIVATE "-Wall")
+target_compile_options(hilti-objects PRIVATE $<$<CONFIG:Debug>:-O0>)
+target_link_libraries(hilti-objects PUBLIC $<$<BOOL:${HILTI_HAVE_JIT}>:clang-jit>)
+target_link_libraries(hilti-objects PUBLIC $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>)
+target_link_libraries(hilti-objects PUBLIC std::filesystem ${CMAKE_DL_LIBS})
+target_link_options(hilti-objects PRIVATE $<$<CONFIG:Debug>:-O0>)
+target_include_directories(hilti-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(hilti-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 # Unclear why we need this: Without it, the generated Bison/Flex get a broken
 # include path on some systems. (Seen on Ubuntu 19.10).
-set_target_properties(hilti PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
+set_target_properties(hilti-objects PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
+
+add_library(hilti)
+target_link_libraries(hilti PUBLIC hilti-objects)
+target_link_libraries(hilti PUBLIC $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>) # doesn't transfer from hilti-objects
 
 ##### Runtime library.
 
@@ -256,15 +261,15 @@ configure_file(src/config.cc.in ${AUTOGEN_CC}/config.cc)
 
 add_executable(hiltic bin/hiltic.cc)
 target_compile_options(hiltic PRIVATE "-Wall")
-target_link_libraries(hiltic PRIVATE hilti)
+target_link_hilti(hiltic PRIVATE)
 
 add_executable(hilti-config bin/hilti-config.cc)
 target_compile_options(hilti-config PRIVATE "-Wall")
-target_link_libraries(hilti-config PRIVATE hilti)
+target_link_hilti(hilti-config PRIVATE)
 
 add_executable(jit-test bin/jit-test.cc)
 target_compile_options(jit-test PRIVATE "-Wall")
-target_link_libraries(jit-test PRIVATE hilti)
+target_link_hilti(jit-test PRIVATE)
 
 # Tests
 add_executable(hilti-rt-tests
@@ -296,7 +301,8 @@ add_executable(hilti-tests
                tests/main.cc
                tests/visitor.cc
                tests/util.cc)
-target_link_libraries(hilti-tests PRIVATE hilti doctest)
+target_link_hilti(hilti-tests PRIVATE)
+target_link_libraries(hilti-tests PRIVATE doctest)
 target_compile_options(hilti-tests PRIVATE "-Wall")
 add_test(NAME hilti-tests COMMAND ${CMAKE_BINARY_DIR}/bin/hilti-tests)
 

--- a/hilti/include/compiler/detail/clang.h
+++ b/hilti/include/compiler/detail/clang.h
@@ -86,27 +86,6 @@ public:
      */
     void setDumpCode();
 
-    /**
-     * Prepares the runtime environment for execution. In particular runs
-     * any static constructors.
-     *
-     * This must be called only after ``jit()`` has succeeded.
-     *
-     * @return true if initialization was succesfull
-     */
-    bool initRuntime();
-
-    /**
-     * Cleans up the runtime environment after execution. In particular runs
-     * any static destructors.
-     *
-     * This must be called only after ``initRuntime()`` has succeeded.
-     * Afterwards no more functionality of this class may be used.
-     *
-     * @return true if clean up was succesfull
-     */
-    bool finishRuntime();
-
     /** Returns a string describing the version of Clang compiler in use. */
     static std::string compilerVersion();
 

--- a/hilti/include/compiler/jit.h
+++ b/hilti/include/compiler/jit.h
@@ -195,23 +195,6 @@ public:
     Result<std::reference_wrapper<const Library>> retrieveLibrary() const;
 
     /**
-     * Initalizes the HILTI runtime system. This is necessary before any of
-     * the compiled code can be used, and must be done only after `jit()` has
-     * succeeded. Initializing the runtime will directly execute any
-     * initialization logic part of the compiled code, such as intialization
-     * HILTI globals and running module-global HILT statements.
-     *
-     * @return true if the runtime has bee succesfully initialized
-     */
-    bool initRuntime();
-
-    /**
-     * Shuts down the runtime system. Calling this is optional, it will run
-     * at JIT destruction time at the latest.
-     */
-    bool finishRuntime();
-
-    /**
      * Returns true if any source files have been added that need to be
      * compiled. If this returns false, its safe to skip calling `compile()`
      * (though still doing so won't hurt).

--- a/hilti/include/compiler/plugin.h
+++ b/hilti/include/compiler/plugin.h
@@ -65,6 +65,12 @@ struct Plugin {
     std::vector<std::filesystem::path> cxx_includes;
 
     /**
+     * Callbacks for plugins will be executed in numerical order, with lower
+     * order numbers executing first.
+     */
+    int order = 0;
+
+    /**
      * Hook called to retrieve paths to search when importing modules that
      * this plugin handles.
      *
@@ -227,7 +233,10 @@ class PluginRegistry {
 public:
     PluginRegistry();
 
-    /** Returns a vector of all currently registered plugins. */
+    /**
+     * Returns a vector of all currently registered plugins, sorted by their
+     * order numbers.
+     */
     const std::vector<Plugin>& plugins() const { return _plugins; }
 
     /**
@@ -276,7 +285,7 @@ public:
      *
      * @param p plugin to register
      */
-    void register_(const Plugin& p) { _plugins.push_back(p); }
+    void register_(const Plugin& p);
 
 private:
     std::vector<Plugin> _plugins;

--- a/hilti/src/compiler/clang.cc
+++ b/hilti/src/compiler/clang.cc
@@ -139,12 +139,6 @@ struct ClangJIT::Implementation { // NOLINT
     /** See `ClangJit::setDumpCode()`. */
     void setDumpCode() { dump_code = true; }
 
-    /** See `ClangJit::initRuntime()`. */
-    bool initRuntime();
-
-    /** See `ClangJit::finishRuntime()`. */
-    bool finishRuntime();
-
     /** Returns the compiler options in use. */
     auto options() const { return context->options(); }
 
@@ -521,16 +515,6 @@ std::optional<std::reference_wrapper<const Library>> ClangJIT::Implementation::r
     return *shared_library;
 }
 
-bool ClangJIT::Implementation::initRuntime() {
-    util::timing::Collector _("hilti/jit/clang/init-runtime");
-    return true;
-}
-
-bool ClangJIT::Implementation::finishRuntime() {
-    util::timing::Collector _("hilti/jit/clang/finish-runtime");
-    return true;
-}
-
 void ClangJIT::Implementation::saveBitcode(const llvm::Module& module, std::string path) {
     // Logging to driver because that's where all the other "saving to ..." messages go.
     HILTI_DEBUG(logging::debug::Driver,
@@ -749,10 +733,6 @@ bool ClangJIT::compile(const CxxCode& code) { return _impl->compile(util::fmt("%
 bool ClangJIT::compile(const std::filesystem::path& p) { return _impl->compile(p, {}); }
 
 Result<Nothing> ClangJIT::jit() { return _impl->jit(); }
-
-bool ClangJIT::initRuntime() { return _impl->initRuntime(); }
-
-bool ClangJIT::finishRuntime() { return _impl->finishRuntime(); }
 
 std::optional<std::reference_wrapper<const Library>> ClangJIT::retrieveLibrary() const {
     return _impl->retrieveLibrary();

--- a/hilti/src/compiler/driver.cc
+++ b/hilti/src/compiler/driver.cc
@@ -851,10 +851,6 @@ Result<Nothing> Driver::initRuntime() {
 
     try {
         HILTI_DEBUG(logging::debug::Driver, "initializing runtime");
-
-        if ( _requires_jit() )
-            _jit->initRuntime();
-
         rt::init();
         hookInitRuntime();
     } catch ( const hilti::rt::Exception& e ) {
@@ -906,10 +902,8 @@ Result<Nothing> Driver::finishRuntime() {
         _runtime_initialized = false;
     }
 
-    if ( _jit ) {
-        _jit->finishRuntime();
+    if ( _jit )
         _jit.reset();
-    }
 
     return Nothing();
 }

--- a/hilti/src/compiler/jit.cc
+++ b/hilti/src/compiler/jit.cc
@@ -71,10 +71,7 @@ JIT::JIT(std::shared_ptr<Context> context) : _context(std::move(context)) {
     _jit = std::make_unique<detail::ClangJIT>(_context);
 }
 
-JIT::~JIT() {
-    if ( _jit )
-        finishRuntime();
-}
+JIT::~JIT() {}
 
 bool JIT::compile() {
     util::timing::Collector _("hilti/jit/compile");
@@ -129,22 +126,6 @@ Result<std::reference_wrapper<const Library>> JIT::retrieveLibrary() const {
         return result::Error("no library available");
 
     return *_jit->retrieveLibrary();
-}
-
-bool JIT::initRuntime() {
-    if ( ! _jit )
-        return false;
-
-    return _jit->initRuntime();
-}
-
-bool JIT::finishRuntime() {
-    if ( ! _jit )
-        return false;
-
-    _jit->finishRuntime();
-    _jit.reset();
-    return true;
 }
 
 std::string JIT::compilerVersion() { return detail::ClangJIT::compilerVersion(); }

--- a/hilti/src/compiler/plugin.cc
+++ b/hilti/src/compiler/plugin.cc
@@ -22,12 +22,18 @@ PluginRegistry& plugin::registry() {
     return singleton;
 }
 
+void PluginRegistry::register_(const Plugin& p) {
+    _plugins.push_back(p);
+    std::sort(_plugins.begin(), _plugins.end(), [](const auto x, const auto& y) { return x.order < y.order; });
+}
+
 // Always-on default plugin with HILTI functionality.
 static Plugin hilti_plugin() {
     return Plugin{
         .component = "HILTI",
         .extension = ".hlt",
         .cxx_includes = {"hilti/rt/libhilti.h"},
+        .order = 1,
 
         .library_paths =
             [](const std::shared_ptr<hilti::Context>& ctx) { return hilti::configuration().hilti_library_paths; },

--- a/spicy/CMakeLists.txt
+++ b/spicy/CMakeLists.txt
@@ -76,19 +76,25 @@ set(SOURCES_COMPILER
     ${FLEX_scanner_spicy_OUTPUTS}
     )
 
-add_library(spicy ${SOURCES_COMPILER})
-target_compile_options(spicy PRIVATE "-Wall")
-target_compile_options(spicy PRIVATE $<$<CONFIG:Debug>:-O0>)
-target_link_libraries(spicy  PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>)
-target_link_libraries(spicy  PUBLIC hilti)
-target_link_libraries(spicy  PRIVATE std::filesystem)
-target_link_options(spicy    PRIVATE $<$<CONFIG:Debug>:-O0>)
-target_include_directories(spicy BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
-target_include_directories(spicy BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+add_library(spicy-objects OBJECT ${SOURCES_COMPILER})
+set_property(TARGET spicy-objects PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_options(spicy-objects PRIVATE "-Wall")
+target_compile_options(spicy-objects PRIVATE $<$<CONFIG:Debug>:-O0>)
+target_link_libraries(spicy-objects PUBLIC $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>)
+target_link_hilti(spicy-objects PUBLIC)
+target_link_libraries(spicy-objects  PRIVATE std::filesystem  ${CMAKE_DL_LIBS})
+target_link_options(spicy-objects    PRIVATE $<$<CONFIG:Debug>:-O0>)
+target_include_directories(spicy-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(spicy-objects BEFORE PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
 
 # Unclear why we need this: Without it, the generated Bison/Flex get a broken
 # include path on some systems. (Seen on Ubuntu 19.10).
-set_target_properties(spicy PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
+set_target_properties(spicy-objects PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
+
+add_library(spicy)
+target_link_libraries(spicy PUBLIC spicy-objects)
+target_link_hilti(spicy PUBLIC) # doesn't seem to transfer from spicy-objects
+target_link_libraries(hilti PUBLIC $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>) # doesn't transfer from hilti-objects
 
 ##### Runtime library.
 
@@ -173,19 +179,19 @@ configure_file(src/config.cc.in ${AUTOGEN_CC}/config.cc)
 
 add_executable(spicyc bin/spicyc.cc)
 target_compile_options(spicyc PRIVATE "-Wall")
-target_link_libraries(spicyc PRIVATE spicy)
+target_link_spicy(spicyc PRIVATE)
 
 add_executable(spicy-config bin/spicy-config.cc)
 target_compile_options(spicy-config PRIVATE "-Wall")
-target_link_libraries(spicy-config PRIVATE spicy)
+target_link_spicy(spicy-config PRIVATE)
 
 add_executable(spicy-driver bin/spicy-driver.cc)
 target_compile_options(spicy-driver PRIVATE "-Wall")
-target_link_libraries(spicy-driver PRIVATE spicy)
+target_link_spicy(spicy-driver PRIVATE)
 
 add_executable(spicy-doc bin/spicy-doc.cc)
 target_compile_options(spicy-doc PRIVATE "-Wall")
-target_link_libraries(spicy-doc PRIVATE spicy)
+target_link_spicy(spicy-doc PRIVATE)
 
 add_subdirectory(bin/spicy-dump)
 
@@ -198,7 +204,8 @@ add_custom_command(TARGET spicy-build
 add_executable(spicy-tests
                tests/main.cc
                tests/grammar.cc)
-target_link_libraries(spicy-tests PRIVATE spicy doctest)
+target_link_spicy(spicy-tests PRIVATE)
+target_link_libraries(spicy-tests PRIVATE doctest)
 target_compile_options(spicy-tests PRIVATE "-Wall")
 add_test(NAME spicy-tests COMMAND ${CMAKE_BINARY_DIR}/bin/spicy-tests)
 

--- a/spicy/bin/spicy-doc.cc
+++ b/spicy/bin/spicy-doc.cc
@@ -6,10 +6,6 @@
 
 #include <spicy/spicy.h>
 
-// Force linking of the Spicy library. (Note to self: Don't used an inlined
-// function here).
-auto _ = ::spicy::configuration();
-
 using nlohmann::json;
 
 template<typename T>

--- a/spicy/bin/spicy-dump/CMakeLists.txt
+++ b/spicy/bin/spicy-dump/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(spicy-dump main.cc printer-text.cc printer-json.cc)
 target_compile_options(spicy-dump PRIVATE "-Wall")
-target_link_libraries(spicy-dump PRIVATE spicy)
+target_link_spicy(spicy-dump PRIVATE)
 
 install(TARGETS spicy-dump RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/spicy/src/compiler/plugin.cc
+++ b/spicy/src/compiler/plugin.cc
@@ -16,6 +16,7 @@ static hilti::Plugin spicy_plugin() {
         .component = "Spicy",
         .extension = ".spicy",
         .cxx_includes = {"spicy/rt/libspicy.h"},
+        .order = 2,
 
         .library_paths =
             [](const std::shared_ptr<hilti::Context>& /* ctx */) { return spicy::configuration().spicy_library_paths; },

--- a/zeek/CMakeLists.txt
+++ b/zeek/CMakeLists.txt
@@ -5,7 +5,8 @@ add_subdirectory(compiler)
 
 add_executable(spicyz bin/spicyz.cc)
 target_compile_options(spicyz PRIVATE "-Wall")
-target_link_libraries(spicyz PRIVATE zeek-compiler spicy)
+target_link_libraries(spicyz PRIVATE zeek-compiler)
+target_link_spicy(spicyz PRIVATE)
 target_include_directories(spicyz BEFORE PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/plugin)
 
 install(TARGETS spicyz RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/zeek/plugin/CMakeLists.txt
+++ b/zeek/plugin/CMakeLists.txt
@@ -61,11 +61,8 @@ target_include_directories(${_plugin_lib} BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 # For JIT support.
 target_link_libraries(${_plugin_lib} $<$<BOOL:${ZEEK_HAVE_JIT}>:zeek-compiler>)
-target_link_libraries(${_plugin_lib} $<$<BOOL:${ZEEK_HAVE_JIT}>:spicy>)
-
-target_link_libraries(${_plugin_lib} $<IF:$<CONFIG:Debug>,hilti-rt-debug-objects,hilti-rt-objects>)
-target_link_libraries(${_plugin_lib} $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>)
-target_link_libraries(${_plugin_lib} std::filesystem ${CMAKE_DL_LIBS})
+target_link_hilti(${_plugin_lib})
+target_link_spicy(${_plugin_lib})
 
 # Create an alias for the plugin target.
 add_custom_target(zeek-plugin DEPENDS ${_plugin_lib})


### PR DESCRIPTION
The binaries weren't pulling in the Spicy plugin because the linker
didn't see any of its symbols referenced and would just strip it all
out, including the global constructor. Even when I forced my way
around that, the same problem would show up in other ways: other
constructors now missing, and runtime functions not being included
because a binary would seemingly not make use of them.

I now fixed that in a similar way as we already do for the runtime
libraries: using object libraries instead of static libraries. That
seems the way to go with CMake. So if the build is configured for
static libraries, we now link our binaries against separately defined
object versions of libhilti and libspicy. That makes sure everything
gets included. We still build the actual static libraries as well for
use by external applications.

Test suite passes for me with both shared and static libraries on
macOS (with one exception that I need to track down still). CI will
show how it's looking on Linux. This commits changes the CI build for
clang9_zeek30_ubuntu_release to use static libraries.

Note: Different from what I thought at first, I don't think we
actually need to do anything about spicy-config output because that's
not refering to libhilti/spicy at all, just to the runtime libraries
(which are already static).

Closes #400.