### PR TITLE
Fix some build failures from building against Zeek 3.2 dev versions

### DIFF
--- a/zeek/plugin/include/runtime-support.h
+++ b/zeek/plugin/include/runtime-support.h
@@ -21,6 +21,7 @@
 #include <Type.h>
 #include <Val.h>
 #include <Var.h>
+#include <IPAddr.h>
 #undef DEBUG
 
 #include "cookie.h"

--- a/zeek/plugin/src/file-analyzer.cc
+++ b/zeek/plugin/src/file-analyzer.cc
@@ -29,7 +29,7 @@ inline void FileAnalyzer::DebugMsg(const std::string_view& msg, int len, const u
 #if ZEEK_DEBUG_BUILD
     if ( data ) { // NOLINT(bugprone-branch-clone) pylint believes the two branches are the same
         zeek::rt::debug(_cookie, hilti::rt::fmt("%s: |%s%s| (eod=%s)", msg,
-                                                fmt_bytes(reinterpret_cast<const char*>(data), min(40, len)),
+                                                fmt_bytes(reinterpret_cast<const char*>(data), std::min(40, len)),
                                                 len > 40 ? "..." : "", (eod ? "true" : "false")));
     }
 

--- a/zeek/plugin/src/plugin-jit.cc
+++ b/zeek/plugin/src/plugin-jit.cc
@@ -20,6 +20,9 @@
 #include <zeek-spicy/plugin-jit.h>
 #include <zeek-spicy/zeek-reporter.h>
 
+#include <Var.h>
+#include <Val.h>
+
 namespace spicy::zeek::debug {
 const hilti::logging::DebugStream ZeekPlugin("zeek");
 }

--- a/zeek/plugin/src/plugin.cc
+++ b/zeek/plugin/src/plugin.cc
@@ -113,7 +113,7 @@ void plugin::Zeek_Spicy::Plugin::registerEnumType(
     ::zeekygen_mgr->Script("<Spicy>");
     ::set_location(::Location("<Spicy>", 0, 0, 0, 0));
 
-    ::ID* zeek_id = install_ID(id.c_str(), ns.c_str(), true, true);
+    auto zeek_id = install_ID(id.c_str(), ns.c_str(), true, true);
     zeek_id->SetType(etype);
     zeek_id->MakeType();
 }

--- a/zeek/plugin/src/protocol-analyzer.cc
+++ b/zeek/plugin/src/protocol-analyzer.cc
@@ -43,7 +43,7 @@ inline void ProtocolAnalyzer::DebugMsg(const ProtocolAnalyzer::Endpoint& endp, c
 #if ZEEK_DEBUG_BUILD
     if ( data ) { // NOLINT(bugprone-branch-clone) pylint believes the two branches are the same
         zeek::rt::debug(endp.cookie, hilti::rt::fmt("%s: |%s%s| (eod=%s)", msg,
-                                                    fmt_bytes(reinterpret_cast<const char*>(data), min(40, len)),
+                                                    fmt_bytes(reinterpret_cast<const char*>(data), std::min(40, len)),
                                                     len > 40 ? "..." : "", (eod ? "true" : "false")));
     }
 

--- a/zeek/plugin/src/runtime-support.cc
+++ b/zeek/plugin/src/runtime-support.cc
@@ -13,6 +13,8 @@
 #include <Val.h>
 #include <file_analysis/File.h>
 #include <file_analysis/Manager.h>
+#include <Conn.h>
+#include <Event.h>
 
 #if ZEEK_VERSION_NUMBER >= 30100
 #include <module_util.h>
@@ -206,7 +208,7 @@ void rt::reject_protocol(const std::string& reason) {
         throw ValueUnavailable("no current connection available");
 }
 
-static string _file_id(const rt::cookie::ProtocolAnalyzer& c) {
+static std::string _file_id(const rt::cookie::ProtocolAnalyzer& c) {
     auto id = hilti::rt::fmt("%" PRIu64 ".%" PRIu64 ".%d", c.analyzer_id, c.file_id, static_cast<int>(c.is_orig));
     return ::file_mgr->HashHandle(id);
 }


### PR DESCRIPTION
This PR makes some simple changes that fix problems with building against Zeek's master branch. https://github.com/zeek/zeek/pull/1066 is a corresponding PR on the Zeek side that fixes a number of related issues that are causing Spicy builds to fail.

The only issue that this does not fix is the usage of versions of `ConnectionEstablished` and `ConnectionFinished` that take `int` arguments in zeek/plugin/include/protocol-analyzer.h. These methods were changed in Zeek to take `bool` arguments, but deprecated versions of them were not added (because virtual methods aren't flagged as deprecated when overridden anwyays). A NEWS entry for Zeek indicates that this is a breaking change, and Spicy should be updated to use those when appropriate.