### PR TITLE
Fix missing filter end-of-input signal.

### DIFF
--- a/spicy/src/compiler/codegen/parser-builder.cc
+++ b/spicy/src/compiler/codegen/parser-builder.cc
@@ -1245,6 +1245,9 @@ void ParserBuilder::finalizeUnit(bool success, const Location& l) {
     if ( unit.supportsFilters() )
         builder()->addCall("spicy_rt::filter_disconnect", {state().self});
 
+    if ( unit.isFilter() )
+        builder()->addCall("spicy_rt::filter_forward_eod", {state().self});
+
     for ( const auto& s : unit.items<type::unit::item::Sink>() )
         builder()->addMemberCall(builder::member(state().self, s.id()), "close", {}, l);
 }

--- a/tests/Baseline/spicy.rt.base64-filter-eod/output
+++ b/tests/Baseline/spicy.rt.base64-filter-eod/output
@@ -1,0 +1,2 @@
+Hello, Spicy!\x0a
+[$x=b"Hello, Spicy!\x0a"]

--- a/tests/spicy/rt/base64-filter-eod.spicy
+++ b/tests/spicy/rt/base64-filter-eod.spicy
@@ -1,0 +1,12 @@
+# @TEST-EXEC: echo "SGVsbG8sIFNwaWN5IQo=" | spicy-driver %INPUT >output
+# @TEST-EXEC: btest-diff output
+
+module Test;
+
+import filter;
+
+public type Foo = unit {
+    on %init { self.connect_filter(new filter::Base64Decode); }
+    x: bytes &eod { print self.x; }
+    on %done { print self; }
+};


### PR DESCRIPTION
End-of-input would not always be carried through to units that had
their inputs filtered.