### PR TITLE
Remove C{,XX}_SYSTEM_INCLUDE_DIRS cmake flags.

### DIFF
--- a/configure
+++ b/configure
@@ -13,8 +13,6 @@ cmake_build_type="RelWithDebInfo"
 cmake_clang_root=""
 cmake_c_compiler=""
 cmake_cxx_compiler=""
-cmake_c_system_include_dirs=""
-cmake_cxx_system_include_dirs=""
 cmake_clang_resource_dir=""
 cmake_flex_root=""
 cmake_generator=""
@@ -71,8 +69,6 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-c-compiler=<path>           Set C compiler to use
     --with-cxx-compiler=<path>         Set C++ compiler to use
     --with-flex=<prefix>               Set prefix of Flex installation
-    --with-c-system-include-dirs=<path>   Set additional include directories for C library headers during JIT (separate with colons)
-    --with-cxx-system-include-dirs=<path> Set additional include directories for C++ library headers during JIT (separate with colons)
     --with-clang-resource-dir=<path>   Set resource directory to use with clang during JIT
     --with-llvm-root=<prefix>          Set prefix of LLVM installation
     --with-zeek=PATH                   Path to Zeek installation [default: ${cmake_zeek_root_dir}]
@@ -136,8 +132,6 @@ while [ $# -ne 0 ]; do
             fi
             ;;
 
-        --with-c-system-include-dirs=*)    cmake_c_system_include_dirs="${optarg}";;
-        --with-cxx-system-include-dirs=*)  cmake_cxx_system_include_dirs="${optarg}";;
         --with-clang-resource-dir=*)       cmake_clang_resource_dir="${optarg}";;
         --with-flex=*)                     cmake_flex_root="${optarg}";;
         --with-bison=*)                    cmake_bison_root="${optarg}";;
@@ -165,8 +159,6 @@ append_cache_entry CMAKE_BUILD_TYPE             STRING "${cmake_build_type}"
 append_cache_entry CMAKE_C_COMPILER             PATH   "${cmake_c_compiler}"
 append_cache_entry CMAKE_CXX_COMPILER           PATH   "${cmake_cxx_compiler}"
 append_cache_entry CLANG_RESOURCE_DIR           PATH   "${cmake_clang_resource_dir}"
-append_cache_entry C_SYSTEM_INCLUDE_DIRS        PATH   "${cmake_c_system_include_dirs}"
-append_cache_entry CXX_SYSTEM_INCLUDE_DIRS      PATH   "${cmake_cxx_system_include_dirs}"
 append_cache_entry CMAKE_INSTALL_PREFIX         PATH   "${cmake_install_prefix}"
 append_cache_entry FLEX_ROOT                    PATH   "${cmake_flex_root}"
 append_cache_entry HILTI_HAVE_JIT               BOOL   "${cmake_hilti_have_jit}"

--- a/hilti/include/config.h.in
+++ b/hilti/include/config.h.in
@@ -87,8 +87,6 @@ struct Configuration {
     bool jit_enabled; /** True if JIT support has been compiled in. */
     std::filesystem::path jit_clang_executable;   /**< Path to clang++ JITing */
     std::filesystem::path jit_clang_resource_dir; /**< Clang's resource directory for JITing */
-    std::filesystem::path jit_c_system_include_dirs;     /**< Additional include directories for C library headers */
-    std::filesystem::path jit_cxx_system_include_dirs;   /**< Additional include directories for C++ library headers */
 
     std::vector<std::string> runtime_cxx_flags_debug;  /**< C++ compiler flags when compiling custom code in debug mode
                                                           that uses the HILTI runtime library */

--- a/hilti/src/compiler/clang.cc
+++ b/hilti/src/compiler/clang.cc
@@ -270,16 +270,6 @@ bool ClangJIT::Implementation::compile(const std::string& file, std::optional<st
         args.emplace_back(dir.native());
     }
 
-    for ( auto dir : util::split(hilti::configuration().jit_c_system_include_dirs, ":") ) {
-        args.emplace_back("-isystem");
-        args.emplace_back(dir);
-    }
-
-    for ( auto dir : util::split(hilti::configuration().jit_cxx_system_include_dirs, ":") ) {
-        args.emplace_back("-isystem");
-        args.emplace_back(dir);
-    }
-
     args.push_back(file);
 
     // Reusing the driver across calls gives us trouble. In a perfect world,

--- a/hilti/src/config.cc.in
+++ b/hilti/src/config.cc.in
@@ -56,8 +56,6 @@ void Configuration::init(bool use_build_directory) {
 
     jit_clang_executable = "${CLANG_EXECUTABLE}";
     jit_clang_resource_dir = "${CLANG_RESOURCE_DIR}";
-    jit_c_system_include_dirs = "${C_SYSTEM_INCLUDE_DIRS}";
-    jit_cxx_system_include_dirs = "${CXX_SYSTEM_INCLUDE_DIRS}";
 
     std::vector<std::string> library_paths;
 


### PR DESCRIPTION
They weren't used consistently already. If needed, set CXX_FLAGS
instead during configure, e.g.:

    CXXFLAGS="-isystem /opt/rh/devtoolset-9/root/usr/include/c++/9" ./configure ...

Closes #423.