### PR TITLE
Dockerfile for CentOS 7 [WIP].

### DIFF
--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -1,0 +1,60 @@
+FROM centos:7
+
+ARG SKIP_BUILD=
+
+WORKDIR /root
+
+ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+
+RUN yum install -y epel-release yum-utils
+RUN yum update -y
+
+# Install and activate devtoolsset-9.
+RUN yum install -y centos-release-scl && yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y devtoolset-9
+SHELL [ "/usr/bin/scl", "enable", "devtoolset-9"]
+
+# Install development tools.
+RUN yum install -y ccache git make ninja-build python3 python3-pip vim doxygen diffutils m4
+
+# Need a more recent CMake than available.
+RUN cd /usr/local && curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - && ln -s /usr/local/cmake-3.16.4-Linux-x86_64/bin/cmake /usr/local/bin
+
+# Need to compile Clang, there don't seem to be packages out there for v9.
+RUN mkdir -p /opt/clang9/src && \
+    cd /opt/clang9/src && \
+    git clone --branch llvmorg-9.0.1 --single-branch --recursive https://github.com/llvm/llvm-project.git && \
+    cd llvm-project && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -G Ninja ../llvm && \
+    ninja install && \
+    cd ../../.. && \
+    rm -rf /opt/clang9
+
+# This is a bit of a hack but clang++ won't find the devtools' libstc++ if run from /usr/local.
+RUN ln -s /usr/local/bin/clang++ /opt/rh/devtoolset-9/root/usr/bin
+
+# Install Spicy dependencies.
+RUN yum install -y python3-sphinx
+RUN pip3 install btest sphinx-rtd-theme
+
+# Need a more recent Bison than available.
+RUN cd /opt && curl -L http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz | tar xzvf - && cd /opt/bison-3.5 && ./configure && make install
+
+# Need a more recent flex than available.
+RUN cd /opt && curl -L https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz | tar xzvf - && cd /opt/flex-2.6.4  && ./configure && make install
+
+# Install Zeek dependencies.
+RUN yum install -y libpcap-devel openssl-devel python3-devel swig zlib-devel
+
+# Install Zeek.
+RUN mkdir -p /opt/zeek/src
+RUN cd /opt/zeek && git clone -b v3.0.3 --recursive https://github.com/zeek/zeek src
+RUN cd /opt/zeek/src && ./configure --generator=Ninja --prefix=/opt/zeek && cd build && ninja && ninja install && cd ../.. && rm -rf zeek
+
+WORKDIR /root
+
+# Install Spicy.
+ADD . /opt/spicy/src
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && CXXFLAGS="-isystem /opt/rh/devtoolset-9/root/usr/include/c++/9" ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=/opt/rh/devtoolset-9/root/usr/bin/clang++ && ninja -C build install && rm -rf build)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,6 +28,15 @@ test-alpine-3.11: build-alpine-3.11
 run-alpine-3.11:
 	./docker-helper run alpine-3.11
 
+build-centos-7:
+	./docker-helper build centos-7
+
+test-centos-7: build-centos-7
+	./docker-helper test centos-7
+
+run-centos-7:
+	./docker-helper run centos-7
+
 build-centos-8:
 	./docker-helper build centos-8
 


### PR DESCRIPTION
First stab at CentOS 7 Docker file. It builds and mostly works, except for a few tests that still fail (most of them due to some floating point output format change apparently). Full output of `make  test-centos-7` below.

```
ctest.all [installation] ... not available, skipped
hilti.hiltic.cc.leak [installation] ... not available, skipped
hilti.hiltic.jit.leak [installation] ... not available, skipped
hilti.rt.debug [installation] ... not available, skipped
hilti.rt.exception-location [installation] ... not available, skipped
hilti.types.integer.coercion [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.integer.coercion/coercion.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Foo::inexact == 9007199254740992' (/opt/spicy/src/tests/.tmp/hilti.types.integer.coercion/coercion.hlt:60:1)

hilti.types.map.ctor [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.map.ctor/ctor.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5118:58: error: no type named 'iterator_category' in 'std::iterator_traits<std::basic_string<char> >'
            typedef typename iterator_traits<_InIterator>::iterator_category _Tag;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5140:11: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct_aux<std::basic_string<char> >' requested here
            return _S_construct_aux(__beg, __end, __a, _Integral());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.tcc:679:19: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct<std::basic_string<char> >' requested here
      : _M_dataplus(_S_construct(__beg, __end, __a), __a)
                    ^
  Test.cc:19:55: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::basic_string<char> >' requested here
      if ( ! (hilti::rt::Map<std::string, std::string>{{{std::string("foo"), std::string("1")}, {std::string("2"), std::string("foo")}}} == hilti::rt::Map<std::string, std::string>{{{(*x), std::string("1")}, {std::string("2"), (*x)}}}) ) {
                                                        ^
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: use of undeclared identifier '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: must qualify identifier to find this declaration in dependent base class
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: must qualify identifier to find this declaration in dependent base class
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  4 errors generated.
  [error] jit: failed to execute compilation action.
  [error] jit: failed to compile C++ code unit Test to bitcode
  [error] hiltic: JIT compilation failed

hilti.types.real.coercion-fail [installation] ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  [error] /opt/spicy/src/tests/.tmp/hilti.types.real.coercion-fail/coercion-fail.hlt:6:14-8:27: cannot coerce expression '1.01' of type 'real' to type 'bool'
  [error] /opt/spicy/src/tests/.tmp/hilti.types.real.coercion-fail/coercion-fail.hlt:8:27-9:26: cannot coerce expression '0' of type 'real' to type 'bool'
  [error] /opt/spicy/src/tests/.tmp/hilti.types.real.coercion-fail/coercion-fail.hlt:9:26-11:36: cannot coerce expression '18446744073709551615' of type 'uint<64>' to type 'real'
  [error] /opt/spicy/src/tests/.tmp/hilti.types.real.coercion-fail/coercion-fail.hlt:11:36-13:34: cannot coerce expression '9007199254740993' of type 'uint<64>' to type 'real'
  [error] hiltic: aborting after errors
  == Diff ===============================
  --- /tmp/test-diff.6034.output.baseline.tmp	2020-07-22 08:12:51.894281695 +0000
  +++ /tmp/test-diff.6034.output.tmp	2020-07-22 08:12:51.930281683 +0000
  @@ -1,5 +1,5 @@
  -[error] <...>/coercion-fail.hlt:6:14-8:27: cannot coerce expression '0x1.028f5c28f5c29p+0' of type 'real' to type 'bool'
  -[error] <...>/coercion-fail.hlt:8:27-9:26: cannot coerce expression '0x0p+0' of type 'real' to type 'bool'
  +[error] <...>/coercion-fail.hlt:6:14-8:27: cannot coerce expression '1.01' of type 'real' to type 'bool'
  +[error] <...>/coercion-fail.hlt:8:27-9:26: cannot coerce expression '0' of type 'real' to type 'bool'
   [error] <...>/coercion-fail.hlt:9:26-11:36: cannot coerce expression '18446744073709551615' of type 'uint<64>' to type 'real'
   [error] <...>/coercion-fail.hlt:11:36-13:34: cannot coerce expression '9007199254740993' of type 'uint<64>' to type 'real'
   [error] hiltic: aborting after errors
  =======================================

  % cat .stderr

hilti.types.real.nops [installation] ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  module Foo {

  global real d;
  global real r = 0.1;

  assert 0.1 == 0.1;

  }
  // Begin of Foo (from "/opt/spicy/src/tests/.tmp/hilti.types.real.nops/nops.hlt")
  // Compiled by HILTI version

  #include <hilti/rt/compiler-setup.h>

  #include <hilti/rt/libhilti.h>

  namespace __hlt::Foo {
      struct __globals_t : hilti::rt::trait::isStruct, hilti::rt::Controllable<__globals_t> {
          double d{};
          double r{};
          template<typename F> void __visit(F _) const { _("d", d); _("r", r); }
      };

      inline unsigned int __globals_index;
      static inline auto __globals() { return hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
      extern void __init_globals(hilti::rt::Context* ctx);
      extern void __init_module();
      extern void __register_module();
  }

  HILTI_PRE_INIT(__hlt::Foo::__register_module)

  extern void __hlt::Foo::__init_globals(hilti::rt::Context* ctx) {
      hilti::rt::detail::initModuleGlobals<__globals_t>(__globals_index);
      __globals()->r = 0.1;
  }

  extern void __hlt::Foo::__init_module() {
        __location__("/opt/spicy/src/tests/.tmp/hilti.types.real.nops/nops.hlt:11:1");
      if ( ! (0.1 == 0.1) ) {
          throw hilti::rt::AssertionFailure("failed expression '0.1 == 0.1'", "/opt/spicy/src/tests/.tmp/hilti.types.real.nops/nops.hlt:11:1");
      }
  }

  extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule({ "Foo", &__init_module, &__init_globals, &__globals_index}); }

  /* __HILTI_LINKER_V1__
  {"module":"Foo","namespace":"__hlt::Foo","path":"/opt/spicy/src/tests/.tmp/hilti.types.real.nops/nops.hlt","version":1}
  */

  == Diff ===============================
  --- /tmp/test-diff.6295.output.baseline.tmp	2020-07-22 08:12:52.934281369 +0000
  +++ /tmp/test-diff.6295.output.tmp	2020-07-22 08:12:52.950281364 +0000
  @@ -1,9 +1,9 @@
   module Foo {

   global real d;
  -global real r = 0x1.999999999999ap-4;
  +global real r = 0.1;

  -assert 0x1.999999999999ap-4 == 0x1.999999999999ap-4;
  +assert 0.1 == 0.1;

   }
   // Begin of Foo (from "<...>/nops.hlt")
  @@ -31,13 +31,13 @@

   extern void __hlt::Foo::__init_globals(hilti::rt::Context* ctx) {
       hilti::rt::detail::initModuleGlobals<__globals_t>(__globals_index);
  -    __globals()->r = 0x1.999999999999ap-4;
  +    __globals()->r = 0.1;
   }

   extern void __hlt::Foo::__init_module() {
         __location__("<...>/nops.hlt:11:1");
  -    if ( ! (0x1.999999999999ap-4 == 0x1.999999999999ap-4) ) {
  -        throw hilti::rt::AssertionFailure("failed expression '0x1.999999999999ap-4 == 0x1.999999999999ap-4'", "<...>/nops.hlt:11:1");
  +    if ( ! (0.1 == 0.1) ) {
  +        throw hilti::rt::AssertionFailure("failed expression '0.1 == 0.1'", "<...>/nops.hlt:11:1");
       }
   }

  =======================================

  % cat .stderr

hilti.types.optional.coercion [installation] ... failed
  % 'hiltic -j /opt/spicy/src/tests/.tmp/hilti.types.optional.coercion/coercion.hlt >output' failed unexpectedly (exit code 139)
  % cat .stderr
  /bin/sh: line 1:  5730 Segmentation fault      (core dumped) hiltic -j /opt/spicy/src/tests/.tmp/hilti.types.optional.coercion/coercion.hlt > output

hilti.types.real.coercion [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.real.coercion/coercion.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Foo::piish == 3.14159' (/opt/spicy/src/tests/.tmp/hilti.types.real.coercion/coercion.hlt:62:1)

hilti.types.real.inf_NaN [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.real.inf_NaN/inf_NaN.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  Foo.cc:31:26: warning: division by zero is undefined
      __globals()->inf = 1 / 0;
                           ^ ~
  Foo.cc:32:33: warning: division by zero is undefined
      __globals()->minus_inf = -1 / 0;
                                  ^ ~
  Foo.cc:33:26: warning: division by zero is undefined
      __globals()->nan = 0 / 0;
                           ^ ~
  3 warnings generated.
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Foo::inf == 3.14159 / 0' (/opt/spicy/src/tests/.tmp/hilti.types.real.inf_NaN/inf_NaN.hlt:15:1)

hilti.types.set.ctor [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.set.ctor/ctor.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5118:58: error: no type named 'iterator_category' in 'std::iterator_traits<std::basic_string<char> >'
            typedef typename iterator_traits<_InIterator>::iterator_category _Tag;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5140:11: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct_aux<std::basic_string<char> >' requested here
            return _S_construct_aux(__beg, __end, __a, _Integral());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.tcc:679:19: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct<std::basic_string<char> >' requested here
      : _M_dataplus(_S_construct(__beg, __end, __a), __a)
                    ^
  Test.cc:19:41: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::basic_string<char> >' requested here
      if ( ! (hilti::rt::Set<std::string>{{std::string("foo"), std::string("bar")}} == hilti::rt::Set<std::string>{{(*x), std::string("bar")}}) ) {
                                          ^
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: use of undeclared identifier '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: must qualify identifier to find this declaration in dependent base class
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: must qualify identifier to find this declaration in dependent base class
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  4 errors generated.
  [error] jit: failed to execute compilation action.
  [error] jit: failed to compile C++ code unit Test to bitcode
  [error] hiltic: JIT compilation failed

hilti.types.set.ops [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.set.ops/ops.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5118:58: error: no type named 'iterator_category' in 'std::iterator_traits<std::basic_string<char> >'
            typedef typename iterator_traits<_InIterator>::iterator_category _Tag;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5140:11: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct_aux<std::basic_string<char> >' requested here
            return _S_construct_aux(__beg, __end, __a, _Integral());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.tcc:679:19: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct<std::basic_string<char> >' requested here
      : _M_dataplus(_S_construct(__beg, __end, __a), __a)
                    ^
  Test.cc:30:51: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::basic_string<char> >' requested here
      __globals()->s0 = hilti::rt::Set<std::string>{{std::string("A"), std::string("B")}};
                                                    ^
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: use of undeclared identifier '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: must qualify identifier to find this declaration in dependent base class
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: must qualify identifier to find this declaration in dependent base class
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  4 errors generated.
  [error] jit: failed to execute compilation action.
  [error] jit: failed to compile C++ code unit Test to bitcode
  [error] hiltic: JIT compilation failed

hilti.types.time.ops [installation] ... failed
  % '${HILTIC} -j /opt/spicy/src/tests/.tmp/hilti.types.time.ops/ops.hlt >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Test::t1.seconds() == 1.29542e+09' (/opt/spicy/src/tests/.tmp/hilti.types.time.ops/ops.hlt:13:1)

spicy.rt.release-vs-debug [installation] ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  == spicy-build
  HILTI runtime library version  () [release build]
  Spicy runtime library version  () [release build]
  == spicy-build -d
  HILTI runtime library version  () [debug build]
  Spicy runtime library version  () [debug build]
  == Diff ===============================
  --- /tmp/test-diff.12278.output.baseline.tmp	2020-07-22 08:13:49.438275343 +0000
  +++ /tmp/test-diff.12278.output.tmp	2020-07-22 08:13:49.454275346 +0000
  @@ -1,6 +1,6 @@
   == spicy-build
  -HILTI runtime library version X.X.X [release build]
  -Spicy runtime library version X.X.X [release build]
  +HILTI runtime library version  () [release build]
  +Spicy runtime library version  () [release build]
   == spicy-build -d
  -HILTI runtime library version X.X.X [debug build]
  -Spicy runtime library version X.X.X [debug build]
  +HILTI runtime library version  () [debug build]
  +Spicy runtime library version  () [debug build]
  =======================================

  % cat .stderr

spicy.types.bitfield.parse-debug-output [installation] ... not available, skipped
spicy.types.integer.coercion [installation] ... failed
  % '${SPICYC} -j /opt/spicy/src/tests/.tmp/spicy.types.integer.coercion/coercion.spicy >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Foo::inexact == 9007199254740992' (/opt/spicy/src/tests/.tmp/spicy.types.integer.coercion/coercion.spicy:50:1)

spicy.types.real.coercion-fail [installation] ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:4:12-6:28: cannot coerce expression '1.01' of type 'real' to type 'bool'
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:6:28-7:27: cannot coerce expression '0' of type 'real' to type 'bool'
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:7:27-9:42: cannot coerce expression '18446744073709551615' of type 'uint<64>' to type 'real'
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:9:42-11:42: cannot coerce expression '18446744073709550592' of type 'uint<64>' to type 'real'
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:11:42-13:42: cannot coerce expression '-9223372036854775296' of type 'int<64>' to type 'real'
  [error] /opt/spicy/src/tests/.tmp/spicy.types.real.coercion-fail/coercion-fail.spicy:13:42-15:35: cannot coerce expression '9007199254740993' of type 'uint<64>' to type 'real'
  [error] spicyc: aborting after errors
  == Diff ===============================
  --- /tmp/test-diff.17493.output.baseline.tmp	2020-07-22 08:14:58.658271536 +0000
  +++ /tmp/test-diff.17493.output.tmp	2020-07-22 08:14:58.674271533 +0000
  @@ -1,5 +1,5 @@
  -[error] <...>/coercion-fail.spicy:4:12-6:28: cannot coerce expression '0x1.028f5c28f5c29p+0' of type 'real' to type 'bool'
  -[error] <...>/coercion-fail.spicy:6:28-7:27: cannot coerce expression '0x0p+0' of type 'real' to type 'bool'
  +[error] <...>/coercion-fail.spicy:4:12-6:28: cannot coerce expression '1.01' of type 'real' to type 'bool'
  +[error] <...>/coercion-fail.spicy:6:28-7:27: cannot coerce expression '0' of type 'real' to type 'bool'
   [error] <...>/coercion-fail.spicy:7:27-9:42: cannot coerce expression '18446744073709551615' of type 'uint<64>' to type 'real'
   [error] <...>/coercion-fail.spicy:9:42-11:42: cannot coerce expression '18446744073709550592' of type 'uint<64>' to type 'real'
   [error] <...>/coercion-fail.spicy:11:42-13:42: cannot coerce expression '-9223372036854775296' of type 'int<64>' to type 'real'
  =======================================

  % cat .stderr

spicy.types.set.ops [installation] ... failed
  % '${SPICYC} -j /opt/spicy/src/tests/.tmp/spicy.types.set.ops/ops.spicy >output' failed unexpectedly (exit code 1)
  % cat .stderr
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5118:58: error: no type named 'iterator_category' in 'std::iterator_traits<std::basic_string<char> >'
            typedef typename iterator_traits<_InIterator>::iterator_category _Tag;
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5140:11: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct_aux<std::basic_string<char> >' requested here
            return _S_construct_aux(__beg, __end, __a, _Integral());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.tcc:679:19: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct<std::basic_string<char> >' requested here
      : _M_dataplus(_S_construct(__beg, __end, __a), __a)
                    ^
  Test.cc:27:51: note: in instantiation of function template specialization 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::basic_string<char> >' requested here
      __globals()->s0 = hilti::rt::Set<std::string>{{std::string("A"), std::string("B")}};
                                                    ^
  In file included from Test.cc:6:
  In file included from /opt/spicy/include/hilti/rt/libhilti.h:5:
  In file included from /opt/spicy/include/hilti/rt/autogen/config.h:5:
  In file included from /opt/rh/devtoolset-9/root/usr/include/c++/9/string:55:
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: use of undeclared identifier '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: must qualify identifier to find this declaration in dependent base class
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: must qualify identifier to find this declaration in dependent base class
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: must qualify identifier to find this declaration in dependent base class
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5119:18: error: no matching function for call to '_S_construct'
            return _S_construct(__beg, __end, __a, _Tag());
                   ^~~~~~~~~~~~
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5146:10: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::input_iterator_tag' for 4th argument
           _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a,
           ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5153:9: note: candidate function template not viable: no known conversion from '_Tag' (aka 'int') to 'std::forward_iterator_tag' for 4th argument
          _S_construct(_FwdIterator __beg, _FwdIterator __end, const _Alloc& __a,
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5137:9: note: candidate function template not viable: requires 3 arguments, but 4 were provided
          _S_construct(_InIterator __beg, _InIterator __end, const _Alloc& __a)
          ^
  /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/basic_string.h:5157:7: note: candidate function not viable: requires 3 arguments, but 4 were provided
        _S_construct(size_type __req, _CharT __c, const _Alloc& __a);
        ^
  4 errors generated.
  [error] jit: failed to execute compilation action.
  [error] jit: failed to compile C++ code unit Test to bitcode
  [error] spicyc: JIT compilation failed

spicy.types.real.coercion [installation] ... failed
  % '${SPICYC} -j /opt/spicy/src/tests/.tmp/spicy.types.real.coercion/coercion.spicy >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression '9007199254740992 != 9.0072e+15' (/opt/spicy/src/tests/.tmp/spicy.types.real.coercion/coercion.spicy:10:1)

spicy.types.time.ops [installation] ... failed
  % '${SPICYC} -j /opt/spicy/src/tests/.tmp/spicy.types.time.ops/ops.spicy >output' failed unexpectedly (exit code 1)
  % cat .stderr
  uncaught exception hilti::rt::AssertionFailure: failed expression 'Test::t1.seconds() == 1.29542e+09' (/opt/spicy/src/tests/.tmp/spicy.types.time.ops/ops.spicy:15:1)

spicy.types.unit.count-fail-3 [installation] ... failed
  % 'btest-diff output' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  [error] /opt/spicy/src/tests/.tmp/spicy.types.unit.count-fail-3/count-fail.spicy:5:6: cannot coerce expression '0.5' of type 'real' to type 'uint<64>'
  [error] spicyc: aborting after errors
  == Diff ===============================
  --- /tmp/test-diff.19661.output.baseline.tmp	2020-07-22 08:15:36.774265865 +0000
  +++ /tmp/test-diff.19661.output.tmp	2020-07-22 08:15:36.790265862 +0000
  @@ -1,2 +1,2 @@
  -[error] <...>/count-fail.spicy:5:6: cannot coerce expression '0x1p-1' of type 'real' to type 'uint<64>'
  +[error] <...>/count-fail.spicy:5:6: cannot coerce expression '0.5' of type 'real' to type 'uint<64>'
   [error] spicyc: aborting after errors
  =======================================

  % cat .stderr
```