### PR TITLE
Extend test coverage of hilti::rt

### DIFF
--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -295,6 +295,7 @@ add_executable(hilti-rt-tests
                src/rt/tests/to_string.cc
                src/rt/tests/tuple.cc
                src/rt/tests/time.cc
+               src/rt/tests/union.cc
                src/rt/tests/util.cc
                src/rt/tests/vector.cc)
 target_compile_options(hilti-rt-tests PRIVATE "-Wall")

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -294,6 +294,7 @@ add_executable(hilti-rt-tests
                src/rt/tests/struct.cc
                src/rt/tests/to_string.cc
                src/rt/tests/tuple.cc
+               src/rt/tests/time.cc
                src/rt/tests/util.cc
                src/rt/tests/vector.cc)
 target_compile_options(hilti-rt-tests PRIVATE "-Wall")

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -291,6 +291,7 @@ add_executable(hilti-rt-tests
                src/rt/tests/set.cc
                src/rt/tests/stream.cc
                src/rt/tests/string.cc
+               src/rt/tests/struct.cc
                src/rt/tests/to_string.cc
                src/rt/tests/tuple.cc
                src/rt/tests/util.cc

--- a/hilti/include/rt/types/time.h
+++ b/hilti/include/rt/types/time.h
@@ -23,6 +23,7 @@ public:
     struct SecondTag {};
     struct NanosecondTag {};
 
+    /** Constructs null `Time` value. */
     Time() = default;
 
     /**
@@ -48,7 +49,6 @@ public:
               return integer::safe<uint64_t>(x);
           }()) {}
 
-    /** Constructs an unset time. */
     Time(const Time&) = default;
     Time(Time&&) noexcept = default;
     ~Time() = default;
@@ -59,7 +59,7 @@ public:
     /** Returns a UNIX timestmap. */
     double seconds() const { return _nsecs.Ref() / 1e9; }
 
-    /** Returns nanosecs since epoch. */
+    /** Returns nanoseconds since epoch. */
     uint64_t nanoseconds() const { return _nsecs; }
 
     bool operator==(const Time& other) const { return _nsecs == other._nsecs; }
@@ -71,7 +71,7 @@ public:
 
     Time operator+(const Interval& other) const {
         if ( other.nanoseconds() < 0 && (integer::safe<int64_t>(_nsecs) < (-other.nanoseconds())) )
-            throw RuntimeError(fmt("operation yielded negative time %n %n", _nsecs, other.nanoseconds()));
+            throw RuntimeError(fmt("operation yielded negative time %d %d", _nsecs, other.nanoseconds()));
 
         return Time(_nsecs + other.nanoseconds(), NanosecondTag{});
     }
@@ -88,10 +88,10 @@ public:
                         Interval::NanosecondTag());
     }
 
-    /** Returns true if the time is non-zero (i.e., not unset) */
+    /** Returns true if the time is non-zero */
     operator bool() const { return _nsecs.Ref() == 0.0; }
 
-    /** Returns a human-readable representation of the tiem. */
+    /** Returns a human-readable representation of the time. */
     operator std::string() const;
 
 private:

--- a/hilti/include/rt/types/time.h
+++ b/hilti/include/rt/types/time.h
@@ -15,8 +15,7 @@ namespace hilti::rt {
 
 /**
  * Represents HILTI's time type. Intervals are stored as nanoseconds
- * resolution as intervals since the UNIX epoch. A value of zero represents
- * an unset time.
+ * resolution as intervals since the UNIX epoch.
  */
 class Time {
 public:
@@ -87,9 +86,6 @@ public:
         return Interval(integer::safe<int64_t>(_nsecs) - integer::safe<int64_t>(other._nsecs),
                         Interval::NanosecondTag());
     }
-
-    /** Returns true if the time is non-zero */
-    operator bool() const { return _nsecs.Ref() == 0.0; }
 
     /** Returns a human-readable representation of the time. */
     operator std::string() const;

--- a/hilti/include/rt/types/union.h
+++ b/hilti/include/rt/types/union.h
@@ -84,7 +84,7 @@ public:
     }
 
     template<typename F>
-    Union& operator=(const F&& t) {
+    Union& operator=(F&& t) {
         value = std::move(t);
         return *this;
     }

--- a/hilti/src/rt/tests/struct.cc
+++ b/hilti/src/rt/tests/struct.cc
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#include <doctest/doctest.h>
+
+#include <optional>
+
+#include <hilti/rt/types/struct.h>
+
+using namespace hilti::rt;
+
+TEST_SUITE_BEGIN("struct");
+
+TEST_CASE("value_or_exception") {
+    CHECK_EQ(struct_::value_or_exception(std::optional<int>(42), "location:123"), 42);
+
+    CHECK_THROWS_WITH_AS(struct_::value_or_exception(std::optional<int>(std::nullopt), "location:123"),
+                         "struct attribute not set (location:123)", const AttributeNotSet&);
+}
+
+TEST_SUITE_END();

--- a/hilti/src/rt/tests/struct.cc
+++ b/hilti/src/rt/tests/struct.cc
@@ -4,6 +4,8 @@
 
 #include <optional>
 
+#include <hilti/rt/extension-points.h>
+#include <hilti/rt/types/integer.h>
 #include <hilti/rt/types/struct.h>
 
 using namespace hilti::rt;
@@ -16,5 +18,20 @@ TEST_CASE("value_or_exception") {
     CHECK_THROWS_WITH_AS(struct_::value_or_exception(std::optional<int>(std::nullopt), "location:123"),
                          "struct attribute not set (location:123)", const AttributeNotSet&);
 }
+
+struct Test : trait::isStruct {
+    Test(int x) : _x(x), _y(x + 1) {}
+
+    template<typename F>
+    void __visit(F f) const {
+        f("_x", _x);
+        f("_y", _y);
+    }
+
+    int _x;
+    int _y;
+};
+
+TEST_CASE("to_string") { CHECK_EQ(to_string(Test(42)), "[$_x=42, $_y=43]"); }
 
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/time.cc
+++ b/hilti/src/rt/tests/time.cc
@@ -27,11 +27,6 @@ TEST_CASE("current_time") {
 
 TEST_SUITE_BEGIN("Time");
 
-TEST_CASE("bool") {
-    CHECK(Time());
-    CHECK(Time(0, Time::SecondTag{}));
-}
-
 TEST_CASE("comparisions") {
     const auto t0 = Time(0, Time::NanosecondTag{});
     const auto t1 = Time(1, Time::NanosecondTag{});

--- a/hilti/src/rt/tests/time.cc
+++ b/hilti/src/rt/tests/time.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#include <doctest/doctest.h>
+
+#include <ctime>
+#include <limits>
+
+#include <hilti/rt/types/time.h>
+
+using namespace hilti::rt;
+
+TEST_SUITE_BEGIN("time");
+
+TEST_CASE("current_time") {
+    const auto start = std::time(nullptr);
+    const auto current_time = time::current_time();
+    const auto end = std::time(nullptr);
+
+    // We shift `start` and `end` by one second to account for possible precision
+    // mismatch and resulting rounding errors and use of different clocks.
+    CHECK_LE(start - 1, current_time.seconds());
+
+    // NOTE: This test could flake if the clock is adjusted after `start` has been taken.
+    CHECK_GE(end + 1, current_time.seconds());
+}
+
+TEST_SUITE_END();

--- a/hilti/src/rt/tests/time.cc
+++ b/hilti/src/rt/tests/time.cc
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <limits>
 
+#include <hilti/rt/types/interval.h>
 #include <hilti/rt/types/time.h>
 
 using namespace hilti::rt;
@@ -23,5 +24,94 @@ TEST_CASE("current_time") {
     // NOTE: This test could flake if the clock is adjusted after `start` has been taken.
     CHECK_GE(end + 1, current_time.seconds());
 }
+
+TEST_SUITE_BEGIN("Time");
+
+TEST_CASE("bool") {
+    CHECK(Time());
+    CHECK(Time(0, Time::SecondTag{}));
+}
+
+TEST_CASE("comparisions") {
+    const auto t0 = Time(0, Time::NanosecondTag{});
+    const auto t1 = Time(1, Time::NanosecondTag{});
+
+    CHECK_EQ(t0, t0);
+    CHECK_EQ(t1, t1);
+
+    CHECK_NE(t0, t1);
+    CHECK_NE(t1, t0);
+
+    CHECK_LT(t0, t1);
+    CHECK_LE(t0, t1);
+    CHECK_LE(t0, t0);
+
+    CHECK_GT(t1, t0);
+    CHECK_GE(t1, t0);
+    CHECK_GE(t1, t1);
+}
+
+TEST_CASE("operator+") {
+    CHECK_EQ(Time(1, Time::NanosecondTag{}) + Interval(0, Interval::SecondTag{}), Time(1, Time::NanosecondTag{}));
+    CHECK_EQ(Time(1, Time::NanosecondTag{}) + Interval(1, Interval::NanosecondTag{}), Time(2, Time::NanosecondTag{}));
+    CHECK_EQ(Time(1, Time::SecondTag{}) + Interval(1, Interval::SecondTag{}), Time(2, Time::SecondTag{}));
+
+    CHECK_THROWS_WITH_AS(Time(std::numeric_limits<uint64_t>::max(), Time::NanosecondTag{}) +
+                             Interval(std::numeric_limits<uint64_t>::max(), Interval::NanosecondTag{}),
+                         "integer overflow", const Overflow&);
+
+    CHECK_THROWS_WITH_AS(Time(0, Time::NanosecondTag{}) + Interval(-1, Interval::NanosecondTag{}),
+                         "operation yielded negative time 0 -1", const RuntimeError&);
+}
+
+TEST_CASE("operator-") {
+    SUBCASE("Interval") {
+        CHECK_EQ(Time(1, Time::NanosecondTag{}) - Interval(0, Interval::SecondTag{}), Time(1, Time::NanosecondTag{}));
+        CHECK_EQ(Time(1, Time::NanosecondTag{}) - Interval(1, Interval::NanosecondTag{}),
+                 Time(0, Time::NanosecondTag{}));
+        CHECK_EQ(Time(1, Time::SecondTag{}) - Interval(1, Interval::SecondTag{}), Time(0, Time::SecondTag{}));
+
+        CHECK_THROWS_WITH_AS(Time(1, Time::NanosecondTag{}) - Interval(1, Interval::SecondTag{}),
+                             "operation yielded negative time", const RuntimeError&);
+    }
+
+    SUBCASE("Time") {
+        CHECK_EQ(Time(1, Time::NanosecondTag{}) - Time(0, Time::SecondTag{}), Interval(1, Interval::NanosecondTag{}));
+        CHECK_EQ(Time(1, Time::NanosecondTag{}) - Time(1, Time::NanosecondTag{}),
+                 Interval(0, Interval::NanosecondTag{}));
+        CHECK_EQ(Time(1, Time::SecondTag{}) - Time(1, Time::SecondTag{}), Interval(0, Interval::SecondTag{}));
+        CHECK_EQ(Time(1, Time::NanosecondTag{}) - Time(10, Time::NanosecondTag{}),
+                 Interval(-9, Interval::NanosecondTag{}));
+    }
+}
+
+TEST_CASE("construct") {
+    SUBCASE("default") { CHECK_EQ(Time().nanoseconds(), 0); }
+
+    SUBCASE("from nanoseconds") {
+        CHECK_EQ(Time(42, Time::NanosecondTag{}).nanoseconds(), 42);
+        CHECK_THROWS_WITH_AS(Time(-1, Time::NanosecondTag{}).nanoseconds(), "integer overflow", const Overflow&);
+    }
+
+    SUBCASE("from seconds") {
+        CHECK_EQ(Time(42, Time::SecondTag{}).seconds(), 42);
+        CHECK_THROWS_WITH_AS(Time(-1, Time::SecondTag{}).seconds(), "Seconds -1 cannot be represented as Time",
+                             const RuntimeError&);
+        CHECK_THROWS_WITH_AS(Time(1e42, Time::SecondTag{}).seconds(), "Seconds 1e+42 cannot be represented as Time",
+                             const RuntimeError&);
+    }
+}
+
+TEST_CASE("nanoseconds") {
+    CHECK_EQ(Time(123, Time::SecondTag{}).nanoseconds(), 123'000'000'000);
+    CHECK_EQ(Time(500, Time::NanosecondTag{}).nanoseconds(), 500);
+}
+
+TEST_CASE("seconds") {
+    CHECK_EQ(Time(123, Time::SecondTag{}).seconds(), 123);
+    CHECK_EQ(Time(500'000'000, Time::NanosecondTag{}).seconds(), 0.5);
+}
+
+TEST_SUITE_END();
 
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/to_string.cc
+++ b/hilti/src/rt/tests/to_string.cc
@@ -244,6 +244,8 @@ TEST_CASE("Time") {
 
     CHECK_EQ(to_string(Time(integer::safe<uint64_t>(1), Time::NanosecondTag())), "1970-01-01T00:00:00.000000001Z");
     CHECK_EQ(to_string(Time(1, Time::SecondTag())), "1970-01-01T00:00:01.000000000Z");
+
+    CHECK_EQ(fmt("%s", Time(1, Time::SecondTag())), "1970-01-01T00:00:01.000000000Z");
 }
 
 TEST_CASE("tuple") {

--- a/hilti/src/rt/tests/to_string.cc
+++ b/hilti/src/rt/tests/to_string.cc
@@ -3,6 +3,7 @@
 #include <doctest/doctest.h>
 
 #include <cstdint>
+#include <string_view>
 #include <tuple>
 
 #include <hilti/rt/libhilti.h>
@@ -64,7 +65,15 @@ TEST_CASE("safe-int") {
     CHECK_EQ(to_string(safe<int64_t>(-42)), "-42");
 }
 
-TEST_CASE("string") { CHECK_EQ(to_string(std::string("abc")), "\"abc\""); }
+TEST_CASE("string") {
+    CHECK_EQ(to_string(std::string("abc")), "\"abc\"");
+    CHECK_EQ(to_string_for_print(std::string("abc")), "abc");
+}
+
+TEST_CASE("string_view") {
+    CHECK_EQ(to_string(std::string_view("abc")), "\"abc\"");
+    CHECK_EQ(to_string_for_print(std::string_view("abc")), "abc");
+}
 
 TEST_CASE("Address") {
     CHECK_EQ(to_string(Address()), "<bad address>");

--- a/hilti/src/rt/tests/union.cc
+++ b/hilti/src/rt/tests/union.cc
@@ -1,0 +1,119 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#include <doctest/doctest.h>
+
+#include <string>
+
+#include <hilti/rt/extension-points.h>
+#include <hilti/rt/types/integer.h>
+#include <hilti/rt/types/union.h>
+
+using namespace hilti::rt;
+
+TEST_SUITE_BEGIN("union");
+
+TEST_CASE("get") {
+    CHECK_EQ(union_::get<0>(Union<int>()), std::monostate());
+    CHECK_THROWS_WITH_AS(union_::get<1>(Union<int>()), "access to union member that does not hold value",
+                         const UnsetUnionMember&);
+
+    CHECK_THROWS_WITH_AS(union_::get<0>(Union<int>(42)), "access to union member that does not hold value",
+                         const UnsetUnionMember&);
+    CHECK_EQ(union_::get<1>(Union<int>(42)), 42);
+
+    CHECK_THROWS_WITH_AS(union_::get<0>(Union<int, std::string, double>("abc")),
+                         "access to union member that does not hold value", const UnsetUnionMember&);
+    CHECK_THROWS_WITH_AS(union_::get<1>(Union<int, std::string, double>("abc")),
+                         "access to union member that does not hold value", const UnsetUnionMember&);
+    CHECK_EQ(union_::get<2>(Union<int, std::string, double>("abc")), "abc");
+    CHECK_THROWS_WITH_AS(union_::get<3>(Union<int, std::string, double>("abc")),
+                         "access to union member that does not hold value", const UnsetUnionMember&);
+}
+
+TEST_CASE("get_proxy") {
+    auto u = Union<int, std::string, double>("abc");
+    REQUIRE_EQ(u.index(), 2);
+    REQUIRE_EQ(union_::get<2>(u), "abc");
+
+    // `get_proxy` is lazy.
+    union_::get_proxy<0>(u);
+    REQUIRE_EQ(u.index(), 2);
+
+    // We can reassign to the set field.
+    union_::get_proxy<2>(u) = "def";
+    CHECK_EQ(union_::get<2>(u), "def");
+
+    // We can change which field is set.
+    union_::get_proxy<1>(u) = 42;
+    CHECK_EQ(u.index(), 1u);
+    CHECK_EQ(union_::get<1>(u), 42);
+}
+
+TEST_SUITE_END();
+
+TEST_SUITE_BEGIN("Union");
+
+TEST_CASE("assign") {
+    SUBCASE("lvalue") {
+        Union<int, std::string> u("abc");
+        REQUIRE_EQ(u.index(), 2u);
+
+        // Not changing field.
+        const std::string s = "def";
+        u = s;
+        CHECK_EQ(u.index(), 2u);
+
+        // Changing field.
+        u = 42;
+        CHECK_EQ(u.index(), 1u);
+    }
+
+    SUBCASE("rvalue") {
+        Union<int, std::unique_ptr<double>> u(nullptr);
+        REQUIRE_EQ(u.index(), 2u);
+
+        // Not changing field.
+        u = std::unique_ptr<double>(new double(1e42));
+        CHECK_EQ(u.index(), 2u);
+
+        // Changing field.
+        u = 42;
+        CHECK_EQ(u.index(), 1u);
+    }
+}
+
+TEST_CASE("construct") {
+    CHECK_EQ(union_::get<0>(Union<int, std::string>()), std::monostate());
+    CHECK_EQ(union_::get<0>(Union<int, std::string>(std::monostate())), std::monostate());
+    CHECK_EQ(union_::get<1>(Union<int, std::string>(42)), 42);
+    CHECK_EQ(union_::get<2>(Union<int, std::string>("abc")), "abc");
+}
+
+TEST_CASE("index") {
+    CHECK_EQ(Union<int, std::string>().index(), 0u);
+    CHECK_EQ(Union<int, std::string>(42).index(), 1u);
+    CHECK_EQ(Union<int, std::string>("abc").index(), 2u);
+}
+
+struct TestUnion : Union<int, std::string> {
+    TestUnion() = default;
+
+    template<typename T>
+    TestUnion(T&& x) : Union(std::forward<T>(x)) {}
+
+    template<typename F>
+    void __visit(F f) const {
+        switch ( index() ) {
+            case 1: return f("int", &union_::get<1>(*this));
+            case 2: return f("string", &union_::get<2>(*this));
+        }
+    }
+};
+
+TEST_CASE("to_string") {
+    CHECK_EQ(to_string(TestUnion()), "<unset>");
+    CHECK_EQ(to_string(TestUnion(42)), "$int=42");
+    CHECK_EQ(to_string(TestUnion("abc")), "$string=\"abc\"");
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
This patch is part of #468 and covers `types/string.h`, `types/struct.h`, `types/time.h`, and `types/union.h`.

This series also contains a small number of bug fixes.