### PR TITLE
Increase test coverage for reference types in hilti-rt library

### DIFF
--- a/hilti/include/rt/deferred-expression.h
+++ b/hilti/include/rt/deferred-expression.h
@@ -6,6 +6,9 @@
 #include <string>
 #include <utility>
 
+#include <hilti/rt/extension-points.h>
+#include <hilti/rt/types/result.h>
+
 namespace hilti::rt {
 
 /**

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -414,7 +414,7 @@ public:
     }
 
     /** Returns true if the reference is not null. */
-    operator bool() const { return ! isNull(); }
+    explicit operator bool() const { return ! isNull(); }
 
     /**
      * Reinitializes the reference with a newly allocated value, releasing

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -307,13 +307,10 @@ private:
         if ( auto ptr = _get() )
             return ptr;
 
-        throw NullReference("attempt to access null value reference");
+        throw NullReference("attempt to access null reference");
     }
 
     T* _safeGet() {
-        if ( _ptr.valueless_by_exception() )
-            throw NullReference("no valid value");
-
         if ( _ptr.index() == std::variant_npos )
             throw NullReference("no valid value");
 

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -356,9 +356,6 @@ public:
     /** Move constructor. */
     StrongReference(StrongReference&& other) noexcept : Base(std::move(other)) {}
 
-    /** Destructor. */
-    ~StrongReference() {}
-
     /**
      * Returns true if the reference does not refer any value.
      */

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -629,13 +629,20 @@ public:
     template<typename T>
     StrongReferenceGeneric(StrongReference<T> x) : _ptr(std::move(x)) {}
 
-    /** Returns a pointer to the bound instance, or null if unbound. */
+    /** Obtains a pointer to the stored value.
+     * @returns a pointer to the bound instance, or null if unbound.
+     * @throws IllegalReference if the target type does not match the stored reference type.
+     * */
     template<typename T>
     T* as() const {
         if ( ! _ptr.has_value() )
             return nullptr;
 
-        return std::any_cast<StrongReference<T>>(_ptr).get();
+        try {
+            return std::any_cast<StrongReference<T>>(_ptr).get();
+        } catch ( const std::bad_any_cast& ) {
+            throw IllegalReference("invalid target type");
+        }
     }
 
     /** Releases the bound reference. */

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -707,8 +707,7 @@ inline std::string detail::to_string_for_print<StrongReference<std::string>>(con
 }
 
 template<>
-inline std::string detail::to_string_for_print<WeakReference<std::string_view>>(
-    const WeakReference<std::string_view>& x) {
+inline std::string detail::to_string_for_print<WeakReference<std::string>>(const WeakReference<std::string>& x) {
     if ( x.isExpired() )
         return "<expired ref>";
 

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -48,7 +48,7 @@ using Controllable = std::enable_shared_from_this<T>;
  * into a shared_ptr right there. On the downside, that would mean a
  * `shared_from_this()` call even if the resulting instance is never used --
  * which with the current code generator could happen frequently (at least
- * once we optimizde to use `this` instead of the `self` wrapper when
+ * once we optimized to use `this` instead of the `self` wrapper when
  * possible). So leaving it alone for now.
  */
 template<typename T>
@@ -74,7 +74,7 @@ public:
      * the new reference will keep a pointer to the same value.
      *
      * This constructor is mostly for internal purposes to create a new value
-     * reference that's associatged with an existing `StrongReference`.
+     * reference that's associated with an existing `StrongReference`.
      *
      * @param t shared pointer to link to
      */
@@ -213,7 +213,7 @@ public:
     bool operator!=(const T& other) const { return *_safeGet() != other; }
 
     /**
-     * Assigns to the contained value. Assgining does not invalidate other
+     * Assigns to the contained value. Assigning does not invalidate other
      * references associated with the same value; they'll see the change.
      *
      * @throws NullReference if the instance does not currently refer to a valid value
@@ -224,7 +224,7 @@ public:
     }
 
     /**
-     * Assigns to the contained value. Assgining does not invalidate other
+     * Assigns to the contained value. Assigning does not invalidate other
      * references associated with the same value; they'll see the change.
      *
      * @throws NullReference if the instance does not currently refer to a valid value
@@ -237,15 +237,15 @@ public:
     }
 
     /**
-     * Assigns to the contained value. Assgining does not invalidate other
+     * Assigns to the contained value. Assigning does not invalidate other
      * references associated with the same value; they'll see the change.
      *
      * @throws NullReference if the instance does not currently refer to a valid value
      */
     ValueReference& operator=(ValueReference&& other) noexcept {
         if ( &other != this ) {
-            // We can't move the actual value as other referencez may be
-            // refering to it.
+            // We can't move the actual value as other references may be
+            // referring to it.
             *_safeGet() = *other._safeGet();
             other._ptr = nullptr;
         }
@@ -254,7 +254,7 @@ public:
     }
 
     /**
-     * Shortcut to create a new instance refering to an existing value of
+     * Shortcut to create a new instance referring to an existing value of
      * type `T`. `T` must be derived from `Controllable<T>`.
      *
      * This is for internal use by the code generator to wrap `this` inside
@@ -320,7 +320,7 @@ private:
 
 /**
  * A strong reference to a shared value. This is essentially a `shared_ptr`
- * that can bind to the values of `ValueReference` or `WeakReferecne.`
+ * that can bind to the values of `ValueReference` or `WeakReference.`
  *
  * Note that different from `ValueReference`, a strong reference can
  * explicitly be null.
@@ -341,7 +341,7 @@ public:
     explicit StrongReference(T t) : Base(std::make_shared<T>(std::move(t))) {}
 
     /**
-     * Instantiates a reference pointing to the value refered to be an
+     * Instantiates a reference pointing to the value referred to be an
      * existing `ValueReference`. This does not copy the value, it will be
      * shared (and managed jointly) afterwards.
      */
@@ -362,8 +362,8 @@ public:
     bool isNull() const { return this->get() == nullptr; }
 
     /**
-     * Returns a value reference that is linked to the refered value. If the
-     * strong reference is null, the returns referecne will be so, too.
+     * Returns a value reference that is linked to the referred value. If the
+     * strong reference is null, the returned reference will be so, too.
      */
     ValueReference<T> derefAsValue() const { return ValueReference<T>(*this); }
 
@@ -428,7 +428,7 @@ public:
     }
 
     /**
-     * Reinitiqalized the reference to now point to to the value refered to
+     * Reinitialized the reference to now point to to the value referred to
      * be an existing `ValueReference`. This does not copy that value, it
      * will be shared (and managed jointly) afterwards.
      */
@@ -474,14 +474,14 @@ public:
     WeakReference() : Base() {}
 
     /**
-     * Instantiates a reference pointing to the value refered to be an
+     * Instantiates a reference pointing to the value referred to be an
      * existing `ValueReference`. This does not copy the value, it will be
      * shared afterwards.
      */
     explicit WeakReference(const ValueReference<T>& t) : Base(t.asSharedPtr()) {}
 
     /**
-     * Instantiates a reference pointing to the value refered to be an
+     * Instantiates a reference pointing to the value referred to be an
      * existing `StrongReference`. This does not copy the value, it will be
      * shared afterwards.
      */
@@ -512,13 +512,13 @@ public:
     }
 
     /**
-     * Returns a pointer to the value being refered to. This will be null if
+     * Returns a pointer to the value being referred to. This will be null if
      * the weak point is null or expired.
      */
     const T* get() const { return this->lock().get(); }
 
     /**
-     * Returns a value reference that is linked to the refered value. If the
+     * Returns a value reference that is linked to the referred value. If the
      * weak reference is null or expired, the returned reference will be null.
      */
     ValueReference<T> derefAsValue() const { return ValueReference<T>(this->lock()); }
@@ -574,7 +574,7 @@ public:
     operator bool() const { return ! isNull(); }
 
     /**
-     * Reinitiqalized the reference to now point to to the value refered to
+     * Reinitialize the reference to now point to to the value referred to
      * be an existing `ValueReference`. This does not copy that value, it
      * will be shared afterwards.
      */
@@ -584,7 +584,7 @@ public:
     }
 
     /**
-     * Reinitiqalized the reference to now point to to the value refered to
+     * Reinitialize the reference to now point to to the value referred to
      * be an existing `StrongReference`. This does not copy that value, it
      * will be shared afterwards.
      */

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -471,7 +471,7 @@ public:
     using Base = std::weak_ptr<T>;
 
     /** Default constructor creating a null reference. */
-    WeakReference() : Base() {}
+    WeakReference() = default;
 
     /**
      * Instantiates a reference pointing to the value referred to be an
@@ -491,13 +491,13 @@ public:
      * Copy constructor. This copies the reference, not the value, which will
      * be shared afterwards.
      */
-    WeakReference(const WeakReference& other) : Base(other) {}
+    WeakReference(const WeakReference& other) = default;
 
     /** Move constructor. */
-    WeakReference(WeakReference&& other) noexcept : Base(std::move(other)) {}
+    WeakReference(WeakReference&& other) noexcept = default;
 
     /** Destructor. */
-    ~WeakReference() {}
+    ~WeakReference() = default;
 
     /** Returns true if the reference is either null or expired. */
     bool isNull() const { return this->lock() == nullptr; }

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -284,7 +284,7 @@ private:
         if ( auto ptr = std::get_if<std::shared_ptr<T>>(&_ptr) )
             return (*ptr).get();
 
-        throw IllegalReference("unexpted variant type in val_ref");
+        cannot_be_reached();
     }
 
     T* _get() {
@@ -294,7 +294,7 @@ private:
         if ( auto ptr = std::get_if<std::shared_ptr<T>>(&_ptr) )
             return (*ptr).get();
 
-        throw IllegalReference("unexpted variant type in val_ref");
+        cannot_be_reached();
     }
 
     const T* _safeGet() const {

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -298,11 +298,7 @@ private:
     }
 
     const T* _safeGet() const {
-        if ( _ptr.valueless_by_exception() )
-            throw NullReference("no valid value");
-
-        if ( _ptr.index() == std::variant_npos )
-            throw NullReference("no valid value");
+        assert(_ptr.index() != std::variant_npos);
 
         if ( auto ptr = _get() )
             return ptr;
@@ -311,8 +307,7 @@ private:
     }
 
     T* _safeGet() {
-        if ( _ptr.index() == std::variant_npos )
-            throw NullReference("no valid value");
+        assert(_ptr.index() != std::variant_npos);
 
         if ( auto ptr = _get() )
             return ptr;

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -571,7 +571,7 @@ public:
     }
 
     /** Returns true if the reference is not null or expired. */
-    operator bool() const { return ! isNull(); }
+    explicit operator bool() const { return ! isNull(); }
 
     /**
      * Reinitialize the reference to now point to to the value referred to

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -14,10 +14,6 @@
 
 namespace hilti::rt {
 
-namespace trait {
-struct isStruct;
-} // namespace trait
-
 /** Exception indicating access to an unset (null) reference. **/
 HILTI_EXCEPTION(NullReference, RuntimeError)
 

--- a/hilti/include/rt/types/reference.h
+++ b/hilti/include/rt/types/reference.h
@@ -623,7 +623,7 @@ private:
 class StrongReferenceGeneric {
 public:
     /** Leaves the reference unbound. */
-    StrongReferenceGeneric() {}
+    StrongReferenceGeneric() = default;
 
     /** Binds to the same instance as an existing strong reference.  */
     template<typename T>
@@ -635,7 +635,7 @@ public:
         if ( ! _ptr.has_value() )
             return nullptr;
 
-        return std::any_cast<StrongReference<T>>(&_ptr)->get();
+        return std::any_cast<StrongReference<T>>(_ptr).get();
     }
 
     /** Releases the bound reference. */

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -85,6 +85,22 @@ TEST_CASE_TEMPLATE("construct", U, int, T) {
     }
 }
 
+TEST_CASE("get") {
+    T x(42);
+
+    SUBCASE("valid value") {
+        CHECK_NE(ValueReference<T>().get(), nullptr);
+
+        REQUIRE(ValueReference<T>(x).get());
+        CHECK_EQ(*ValueReference<T>(x).get(), x);
+        CHECK_NE(ValueReference<T>(x).get(), nullptr);
+
+        CHECK_EQ(ValueReference<T>::self(&x).get(), &x);
+    }
+
+    SUBCASE("invalid value") { CHECK_EQ(ValueReference<T>::self(nullptr).get(), nullptr); }
+}
+
 TEST_CASE("self") {
     T x1(0);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -16,8 +16,8 @@ struct T : public hilti::rt::trait::isStruct, hilti::rt::Controllable<T> {
     void foo(int y) {
         // Ensure we can reconstruct a value ref from "this".
         auto self = ValueReference<T>::self(this);
-        REQUIRE_EQ(x, y);
-        REQUIRE_EQ(self->x, y);
+        CHECK_EQ(x, y);
+        CHECK_EQ(self->x, y);
     }
 };
 
@@ -35,36 +35,36 @@ TEST_CASE("value-reference-int") {
     using T = int;
 
     ValueReference<T> x1;
-    REQUIRE_EQ(*x1, 0);
+    CHECK_EQ(*x1, 0);
 
     ValueReference<T> x2(42);
-    REQUIRE_EQ(*x2, 42);
+    CHECK_EQ(*x2, 42);
 
     ValueReference<T> x3(x2);
-    REQUIRE_EQ(*x3, 42);
+    CHECK_EQ(*x3, 42);
 
     x3 = 21;
-    REQUIRE_EQ(*x3, 21);
-    REQUIRE_EQ(*x2, 42);
+    CHECK_EQ(*x3, 21);
+    CHECK_EQ(*x2, 42);
 
     ValueReference<T> x4(std::move(x3));
-    REQUIRE_EQ(*x4, 21);
-    REQUIRE(x3.isNull());
+    CHECK(x3.isNull());
+    CHECK_EQ(*x4, 21);
 
     ValueReference<T> x5;
     x5 = std::move(x4);
-    REQUIRE_EQ(*x5, 21);
-    REQUIRE(x4.isNull());
+    CHECK(x4.isNull());
+    CHECK_EQ(*x5, 21);
 }
 
 TEST_CASE("value-reference-struct") {
     ValueReference<T> x1;
-    REQUIRE_EQ(x1->x, 0);
+    CHECK_EQ(x1->x, 0);
 
     T t;
     t.x = 42;
     ValueReference<T> x2(t);
-    REQUIRE_EQ(x2->x, 42);
+    CHECK_EQ(x2->x, 42);
 
     x2->x = 21;
     x2->foo(21);
@@ -79,11 +79,11 @@ TEST_CASE("value-reference-struct-self") {
     auto self = ValueReference<T>::self(&x1);
 
     self->x = 42;
-    REQUIRE_EQ(self->x, 42);
-    REQUIRE_EQ(x1.x, 42);
+    CHECK_EQ(self->x, 42);
+    CHECK_EQ(x1.x, 42);
 
-    REQUIRE_THROWS(StrongReference<T>{self});
-    REQUIRE_THROWS(WeakReference<T>{self});
+    CHECK_THROWS(StrongReference<T>{self});
+    CHECK_THROWS(WeakReference<T>{self});
 }
 
 
@@ -91,19 +91,19 @@ TEST_CASE("strong-reference") {
     using T = int;
 
     StrongReference<T> x0;
-    REQUIRE_FALSE(x0);
+    CHECK_FALSE(x0);
 
     StrongReference<T> x1(42);
     REQUIRE(x1);
-    REQUIRE_EQ(*x1, 42);
+    CHECK_EQ(*x1, 42);
 
     StrongReference<T> x2(x1);
     REQUIRE(x2);
-    REQUIRE_EQ(*x2, 42);
+    CHECK_EQ(*x2, 42);
 
     *x1 = 21;
-    REQUIRE_EQ(*x1, 21);
-    REQUIRE_EQ(*x2, 21);
+    CHECK_EQ(*x1, 21);
+    CHECK_EQ(*x2, 21);
 
     ValueReference<T> v1{1};
     ValueReference<T> v2{2};
@@ -112,10 +112,10 @@ TEST_CASE("strong-reference") {
     x2 = x1;
     v1 = v2;
 
-    REQUIRE_EQ(*x1, 2);
-    REQUIRE_EQ(*v1, 2);
-    REQUIRE_EQ(*x2, 2);
-    REQUIRE_EQ(*v2, 2);
+    CHECK_EQ(*x1, 2);
+    CHECK_EQ(*v1, 2);
+    CHECK_EQ(*x2, 2);
+    CHECK_EQ(*v2, 2);
 }
 
 struct Foo;

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <hilti/rt/types/integer.h>
 #include <hilti/rt/types/reference.h>
 #include <hilti/rt/types/struct.h>
 
@@ -26,14 +27,6 @@ struct T : public hilti::rt::trait::isStruct, hilti::rt::Controllable<T> {
 
     friend bool operator==(const T& a, const T& b) { return a._x == b._x; }
 };
-
-namespace hilti::rt::detail::adl {
-
-inline std::string to_string(int x, tag /*unused*/) { return hilti::rt::fmt("%d", x); }
-
-inline std::string to_string(const T& x, tag /*unused*/) { return hilti::rt::fmt("x=%d", x._x); }
-
-} // namespace hilti::rt::detail::adl
 
 TEST_SUITE_BEGIN("ValueReference");
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -413,6 +413,33 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("isExpired") {
+    SUBCASE("non-null") {
+        const auto wref = WeakReference<int>();
+
+        {
+            const auto ref = StrongReference<int>(42);
+            CHECK_FALSE(WeakReference<int>(ref).isExpired());
+        }
+
+        CHECK_FALSE(wref.isExpired());
+    }
+
+    SUBCASE("null") {
+        // FIXME(bbannier): Shouldn't these CHECKs be true?
+
+        SUBCASE("default value") { CHECK_FALSE(WeakReference<int>().isExpired()); }
+
+        SUBCASE("from null StrongReference") {
+            const auto wref = WeakReference<int>();
+
+            const auto ref = StrongReference<int>();
+            REQUIRE(ref.isNull());
+            CHECK_FALSE(WeakReference<int>(ref).isExpired());
+        }
+    }
+}
+
 TEST_CASE("isNull") {
     SUBCASE("null") {
         const auto ref1 = StrongReference<int>();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -108,6 +108,27 @@ TEST_CASE_TEMPLATE("construct", U, int, T) {
     }
 }
 
+TEST_CASE("deref") {
+    T x(42);
+    SUBCASE("mutable") {
+        CHECK_EQ(*ValueReference<T>(x), x);
+        CHECK_THROWS_WITH_AS(*ValueReference<T>::self(nullptr), "attempt to access null reference",
+                             const NullReference&);
+    }
+
+    SUBCASE("const") {
+        {
+            const auto ref = ValueReference<T>(x);
+            CHECK_EQ(*ref, x);
+        }
+
+        {
+            const auto ref = ValueReference<T>::self(nullptr);
+            CHECK_THROWS_WITH_AS(*ref, "attempt to access null reference", const NullReference&);
+        }
+    }
+}
+
 TEST_CASE("get") {
     T x(42);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -237,6 +237,26 @@ TEST_SUITE_END();
 
 TEST_SUITE_BEGIN("StrongReference");
 
+TEST_CASE("arrow") {
+    SUBCASE("mutable") {
+        auto ref = ValueReference<int>(42);
+        CHECK_EQ(StrongReference<int>(ref).operator->(), ref.get());
+
+        CHECK_THROWS_WITH_AS(StrongReference<int>().operator->(), "attempt to access null reference",
+                             const NullReference&);
+    }
+
+    SUBCASE("const") {
+        const auto ref1 = ValueReference<int>(42);
+        const auto ref2 = StrongReference<int>(ref1);
+        const auto ref3 = StrongReference<int>();
+
+        CHECK_EQ(ref2.operator->(), ref1.get());
+
+        CHECK_THROWS_WITH_AS(ref3.operator->(), "attempt to access null reference", const NullReference&);
+    }
+}
+
 TEST_CASE("construct") {
     SUBCASE("default") { CHECK(StrongReference<int>().isNull()); }
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -413,6 +413,37 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("get") {
+    SUBCASE("null") {
+        const auto sref = StrongReference<int>();
+        const auto ref = WeakReference<int>(sref);
+        REQUIRE(ref.isNull());
+
+        CHECK_EQ(ref.get(), nullptr);
+    }
+
+    SUBCASE("expired") {
+        auto ref = WeakReference<int>();
+        {
+            const auto sref = StrongReference<int>(42);
+            ref = sref;
+        }
+        REQUIRE(ref.isExpired());
+
+        CHECK_EQ(ref.get(), nullptr);
+    }
+
+    SUBCASE("valid data") {
+        const auto sref = StrongReference<int>(42);
+        const auto wref = WeakReference<int>(sref);
+
+        REQUIRE_FALSE(wref.isExpired());
+        REQUIRE_FALSE(wref.isNull());
+
+        CHECK_EQ(wref.get(), sref.get());
+    }
+}
+
 TEST_CASE("isExpired") {
     SUBCASE("non-null") {
         const auto wref = WeakReference<int>();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -269,6 +269,15 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("derefAsValue") {
+    SUBCASE("unset") { CHECK_EQ(StrongReference<int>().derefAsValue().asSharedPtr(), nullptr); }
+
+    SUBCASE("set") {
+        const auto ref = ValueReference<int>();
+        CHECK_EQ(StrongReference<int>(ref).derefAsValue().get(), ref.get());
+    }
+}
+
 TEST_CASE("isNull") {
     CHECK(StrongReference<int>().isNull());
     CHECK_FALSE(StrongReference<int>(42).isNull());

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -36,6 +36,13 @@ inline std::string to_string(const T& x, tag /*unused*/) { return hilti::rt::fmt
 
 TEST_SUITE_BEGIN("ValueReference");
 
+TEST_CASE("arrow") {
+    CHECK_EQ(ValueReference<T>(42)->_x, 42);
+
+    CHECK_THROWS_WITH_AS((void)ValueReference<T>::self(nullptr)->_x, "attempt to access null reference",
+                         const NullReference&);
+}
+
 TEST_CASE("asSharedPtr") {
     SUBCASE("owning") {
         T x(42);

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -380,6 +380,33 @@ TEST_SUITE_END();
 
 TEST_SUITE_BEGIN("WeakReference");
 
+TEST_CASE_TEMPLATE("arrow", WeakReference_t, WeakReference<int>, const WeakReference<int>) {
+    SUBCASE("expired") {
+        WeakReference_t wref = WeakReference<int>(StrongReference<int>(42));
+        REQUIRE(wref.isExpired());
+        CHECK_THROWS_WITH_AS(wref.operator->(), "attempt to access expired reference", const ExpiredReference&);
+    }
+
+    SUBCASE("null") {
+        WeakReference_t wref1 = WeakReference<int>();
+        REQUIRE(wref1.isNull());
+        CHECK_THROWS_WITH_AS(wref1.operator->(), "attempt to access null reference", const NullReference&);
+
+        const auto sref = StrongReference<int>();
+        WeakReference_t wref2 = WeakReference<int>(sref);
+        REQUIRE(wref2.isNull());
+        CHECK_THROWS_WITH_AS(wref2.operator->(), "attempt to access null reference", const NullReference&);
+    }
+
+    SUBCASE("valid value") {
+        const auto sref = StrongReference<int>(42);
+        WeakReference_t wref = WeakReference<int>(sref);
+        REQUIRE_FALSE(wref.isNull());
+        REQUIRE_FALSE(wref.isExpired());
+        CHECK_EQ(wref.operator->(), sref.get());
+    }
+}
+
 TEST_CASE("construct") {
     const auto ref = ValueReference<int>(42);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -2,7 +2,6 @@
 
 #include <doctest/doctest.h>
 
-#include <any>
 #include <exception>
 #include <memory>
 #include <sstream>
@@ -663,8 +662,8 @@ TEST_CASE("as") {
     CHECK_EQ(StrongReferenceGeneric().as<int>(), nullptr);
     CHECK_EQ(StrongReferenceGeneric(StrongReference<int>()).as<int>(), nullptr);
     CHECK_EQ(*StrongReferenceGeneric(StrongReference<int>(42)).as<int>(), 42);
-    CHECK_THROWS_WITH_AS(StrongReferenceGeneric(StrongReference<int>(42)).as<double>(), "bad any cast",
-                         const std::bad_any_cast&);
+    CHECK_THROWS_WITH_AS(StrongReferenceGeneric(StrongReference<int>(42)).as<double>(), "invalid target type",
+                         const IllegalReference&);
 }
 
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -133,6 +133,21 @@ TEST_CASE("isNull") {
     CHECK(ValueReference<T>::self(nullptr).isNull());
 }
 
+TEST_CASE("reset") {
+    T x(42);
+
+    ValueReference<T> ref;
+
+    SUBCASE("owning") { ref = ValueReference<T>(x); }
+    SUBCASE("non-owning") { ref = ValueReference<T>::self(&x); }
+
+    REQUIRE(! ref.isNull());
+
+    ref.reset();
+
+    CHECK(ref.isNull());
+}
+
 TEST_CASE("self") {
     T x1(0);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -257,6 +257,11 @@ TEST_CASE("arrow") {
     }
 }
 
+TEST_CASE("bool") {
+    CHECK(StrongReference<int>(42));
+    CHECK_FALSE(StrongReference<int>());
+}
+
 TEST_CASE("construct") {
     SUBCASE("default") { CHECK(StrongReference<int>().isNull()); }
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -377,3 +377,40 @@ TEST_CASE("reset") {
 }
 
 TEST_SUITE_END();
+
+TEST_SUITE_BEGIN("WeakReference");
+
+TEST_CASE("construct") {
+    const auto ref = ValueReference<int>(42);
+
+    SUBCASE("copy") {
+        const auto wref1 = WeakReference<int>(ref);
+        const auto wref2(wref1);
+
+        CHECK_EQ(*wref2, *wref1);
+    }
+
+    SUBCASE("default") {
+        const auto wref = WeakReference<int>();
+        CHECK(wref.isNull());
+        CHECK_FALSE(wref.isExpired());
+    }
+
+    SUBCASE("from ValueReference") { CHECK_EQ(WeakReference(ref).derefAsValue(), ref); }
+
+    SUBCASE("from StrongReference") {
+        const auto sref = StrongReference<int>(42);
+        CHECK_EQ(*WeakReference(sref), *sref);
+    }
+
+    SUBCASE("move") {
+        auto wref1 = WeakReference<int>(ref);
+        REQUIRE_EQ(wref1.derefAsValue(), ref);
+
+        const auto wref2(std::move(wref1));
+
+        CHECK_EQ(wref2.derefAsValue(), ref);
+    }
+}
+
+TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -269,4 +269,12 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("isNull") {
+    CHECK(StrongReference<int>().isNull());
+    CHECK_FALSE(StrongReference<int>(42).isNull());
+
+    CHECK(StrongReference<int>(ValueReference<int>(std::shared_ptr<int>())).isNull());
+    CHECK_FALSE(StrongReference<int>(ValueReference<int>(std::make_shared<int>(42))).isNull());
+}
+
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -32,9 +32,9 @@ inline std::string to_string(const T& x, tag /*unused*/) { return hilti::rt::fmt
 
 } // namespace hilti::rt::detail::adl
 
-TEST_SUITE_BEGIN("reference");
+TEST_SUITE_BEGIN("ValueReference");
 
-TEST_CASE_TEMPLATE("value-reference", U, int, T) {
+TEST_CASE_TEMPLATE("construct", U, int, T) {
     ValueReference<U> x1;
     CHECK_EQ(*x1, 0);
 
@@ -58,7 +58,7 @@ TEST_CASE_TEMPLATE("value-reference", U, int, T) {
     CHECK_EQ(*x5, 21);
 }
 
-TEST_CASE("value-reference-struct-self") {
+TEST_CASE("self") {
     T x1(0);
 
     auto self = ValueReference<T>::self(&x1);
@@ -69,38 +69,6 @@ TEST_CASE("value-reference-struct-self") {
 
     CHECK_THROWS_WITH_AS(StrongReference<T>{self}, "reference to non-heap instance", const IllegalReference&);
     CHECK_THROWS_WITH_AS(WeakReference<T>{self}, "reference to non-heap instance", const IllegalReference&);
-}
-
-
-TEST_CASE("strong-reference") {
-    using T = int;
-
-    StrongReference<T> x0;
-    CHECK_FALSE(x0);
-
-    StrongReference<T> x1(42);
-    REQUIRE(x1);
-    CHECK_EQ(*x1, 42);
-
-    StrongReference<T> x2(x1);
-    REQUIRE(x2);
-    CHECK_EQ(*x2, 42);
-
-    *x1 = 21;
-    CHECK_EQ(*x1, 21);
-    CHECK_EQ(*x2, 21);
-
-    ValueReference<T> v1{1};
-    ValueReference<T> v2{2};
-
-    x1 = v1;
-    x2 = x1;
-    v1 = v2;
-
-    CHECK_EQ(*x1, 2);
-    CHECK_EQ(*v1, 2);
-    CHECK_EQ(*x2, 2);
-    CHECK_EQ(*v2, 2);
 }
 
 struct Foo;
@@ -120,6 +88,39 @@ TEST_CASE("cyclic") {
 
     __foo->t = __test;
     test->f = (*__foo);
+}
+
+TEST_SUITE_END();
+
+TEST_SUITE_BEGIN("StrongReference");
+
+TEST_CASE_TEMPLATE("construct", U, int, T) {
+    StrongReference<U> x0;
+    CHECK_FALSE(x0);
+
+    StrongReference<U> x1(42);
+    REQUIRE(x1);
+    CHECK_EQ(*x1, 42);
+
+    StrongReference<U> x2(x1);
+    REQUIRE(x2);
+    CHECK_EQ(*x2, 42);
+
+    *x1 = 21;
+    CHECK_EQ(*x1, 21);
+    CHECK_EQ(*x2, 21);
+
+    ValueReference<U> v1{1};
+    ValueReference<U> v2{2};
+
+    x1 = v1;
+    x2 = x1;
+    v1 = v2;
+
+    CHECK_EQ(*x1, 2);
+    CHECK_EQ(*v1, 2);
+    CHECK_EQ(*x2, 2);
+    CHECK_EQ(*v2, 2);
 }
 
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -269,6 +269,21 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("deref") {
+    SUBCASE("mutable") {
+        CHECK_EQ(*StrongReference<int>(42), 42);
+        CHECK_THROWS_WITH_AS(*StrongReference<int>(), "attempt to access null reference", const NullReference&);
+    }
+
+    SUBCASE("const") {
+        auto ref1 = StrongReference<int>(42);
+        auto ref2 = StrongReference<int>();
+
+        CHECK_EQ(*ref1, 42);
+        CHECK_THROWS_WITH_AS(*ref2, "attempt to access null reference", const NullReference&);
+    }
+}
+
 TEST_CASE("derefAsValue") {
     SUBCASE("unset") { CHECK_EQ(StrongReference<int>().derefAsValue().asSharedPtr(), nullptr); }
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -101,6 +101,15 @@ TEST_CASE("get") {
     SUBCASE("invalid value") { CHECK_EQ(ValueReference<T>::self(nullptr).get(), nullptr); }
 }
 
+TEST_CASE("isNull") {
+    T x(42);
+
+    CHECK_FALSE(ValueReference<T>().isNull());
+    CHECK_FALSE(ValueReference<T>(x).isNull());
+    CHECK_FALSE(ValueReference<T>::self(&x).isNull());
+    CHECK(ValueReference<T>::self(nullptr).isNull());
+}
+
 TEST_CASE("self") {
     T x1(0);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -380,6 +380,54 @@ TEST_SUITE_END();
 
 TEST_SUITE_BEGIN("WeakReference");
 
+TEST_CASE("assign") {
+    SUBCASE("from ValueReference") {
+        auto wref = WeakReference<int>();
+        REQUIRE(wref.isNull());
+
+        const auto vref = ValueReference<int>(42);
+        wref = vref;
+        CHECK_EQ(*wref, *vref);
+    }
+
+    SUBCASE("from StrongReference") {
+        auto wref = WeakReference<int>();
+        REQUIRE(wref.isNull());
+
+        const auto sref = StrongReference<int>(42);
+        REQUIRE_EQ(*sref, 42);
+        wref = sref;
+        CHECK_EQ(*wref, *sref);
+    }
+
+    SUBCASE("from lvalue WeakReference") {
+        const auto sref = StrongReference<int>(47);
+        const auto wref1 = WeakReference<int>(sref);
+        auto wref2 = WeakReference<int>();
+        REQUIRE_EQ(*wref1, *sref);
+        REQUIRE(wref2.isNull());
+
+        wref2 = wref1;
+        CHECK_EQ(*wref2, *wref1);
+
+        *wref2 = 11;
+        CHECK_EQ(*wref1, 11);
+        CHECK_EQ(*sref, 11);
+    }
+
+    SUBCASE("from rvalue WeakReference") {
+        const auto sref = StrongReference<int>(47);
+        auto wref = WeakReference<int>();
+        REQUIRE(wref.isNull());
+
+        wref = WeakReference<int>(sref);
+        CHECK_EQ(*wref, *sref);
+
+        *wref = 11;
+        CHECK_EQ(*sref, 11);
+    }
+}
+
 TEST_CASE_TEMPLATE("arrow", WeakReference_t, WeakReference<int>, const WeakReference<int>) {
     SUBCASE("expired") {
         WeakReference_t wref = WeakReference<int>(StrongReference<int>(42));

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -43,6 +43,30 @@ TEST_CASE("arrow") {
                          const NullReference&);
 }
 
+TEST_CASE("assign") {
+    SUBCASE("from T") {
+        ValueReference<int> ref;
+        int x = 42;
+
+        REQUIRE_NE(ref, x);
+
+        ref = x;
+
+        CHECK_EQ(ref, x);
+    }
+
+    SUBCASE("from ValueReference") {
+        ValueReference<int> ref1;
+        ValueReference<int> ref2(42);
+
+        REQUIRE_NE(ref1, ref2);
+
+        ref1 = ref2;
+
+        CHECK_EQ(ref1, ref2);
+    }
+}
+
 TEST_CASE("asSharedPtr") {
     SUBCASE("owning") {
         T x(42);

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -407,6 +407,23 @@ TEST_CASE_TEMPLATE("arrow", WeakReference_t, WeakReference<int>, const WeakRefer
     }
 }
 
+TEST_CASE("bool") {
+    const auto sref1 = StrongReference<int>(42);
+    const auto sref2 = StrongReference<int>();
+
+    CHECK_FALSE(WeakReference<int>());
+
+    const auto wref1 = WeakReference<int>(sref1);
+    REQUIRE_FALSE(wref1.isNull());
+    REQUIRE_FALSE(wref1.isExpired());
+    CHECK(wref1);
+
+    const auto wref2 = WeakReference<int>(sref2);
+    REQUIRE(wref2.isNull());
+    REQUIRE_FALSE(wref2.isExpired());
+    CHECK_FALSE(wref2);
+}
+
 TEST_CASE("construct") {
     const auto ref = ValueReference<int>(42);
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -257,6 +257,50 @@ TEST_CASE("arrow") {
     }
 }
 
+TEST_CASE("assign") {
+    SUBCASE("from lvalue StrongReference") {
+        const auto ref1 = ValueReference<int>(42);
+        auto ref2 = StrongReference<int>();
+        auto ref3 = StrongReference<int>(ref1);
+        REQUIRE(ref2.isNull());
+        REQUIRE_EQ(ref3.get(), ref1.get());
+
+        ref2 = ref3;
+        CHECK_EQ(ref2, ref3);
+        CHECK_EQ(ref2.get(), ref1.get());
+    }
+
+    SUBCASE("from rvalue StrongReference") {
+        const auto ref1 = ValueReference<int>(42);
+        auto ref2 = StrongReference<int>();
+        auto ref3 = StrongReference<int>(ref1);
+        REQUIRE(ref2.isNull());
+        REQUIRE_EQ(ref3.get(), ref1.get());
+
+        ref2 = std::move(ref3);
+        CHECK_EQ(ref2.get(), ref1.get());
+    }
+
+    SUBCASE("from ValueReference") {
+        const auto ref1 = ValueReference<int>(42);
+        auto ref2 = StrongReference<int>();
+        REQUIRE(ref2.isNull());
+
+        ref2 = ref1;
+        CHECK_EQ(ref2.derefAsValue(), ref1);
+        CHECK_EQ(ref2.get(), ref1.get());
+    }
+
+    SUBCASE("from T") {
+        const int x = 42;
+        auto ref = StrongReference<int>();
+        REQUIRE(ref.isNull());
+
+        ref = x;
+        CHECK_EQ(*ref, x);
+    }
+}
+
 TEST_CASE("bool") {
     CHECK(StrongReference<int>(42));
     CHECK_FALSE(StrongReference<int>());

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -413,6 +413,30 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE_TEMPLATE("deref", WeakReference_t, WeakReference<int>, const WeakReference<int>) {
+    SUBCASE("valid") {
+        const auto sref = StrongReference<int>(42);
+
+        WeakReference_t wref = WeakReference<int>(sref);
+        REQUIRE_FALSE(wref.isExpired());
+        REQUIRE_FALSE(wref.isNull());
+
+        CHECK_EQ(*wref, *sref);
+    }
+
+    SUBCASE("null") {
+        WeakReference_t wref = WeakReference<int>();
+        REQUIRE(wref.isNull());
+        CHECK_THROWS_WITH_AS(*wref, "attempt to access null reference", const NullReference&);
+    }
+
+    SUBCASE("expired") {
+        WeakReference_t wref = WeakReference<int>(StrongReference<int>(42));
+        REQUIRE(wref.isExpired());
+        CHECK_THROWS_WITH_AS(*wref, "attempt to access expired reference", const ExpiredReference&);
+    }
+}
+
 TEST_CASE("derefAsValue") {
     SUBCASE("expired") {
         auto sref = StrongReference<int>(42);

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -286,4 +286,17 @@ TEST_CASE("isNull") {
     CHECK_FALSE(StrongReference<int>(ValueReference<int>(std::make_shared<int>(42))).isNull());
 }
 
+TEST_CASE("reset") {
+    const auto ref1 = ValueReference<int>(42);
+    REQUIRE_FALSE(ref1.isNull());
+
+    auto ref2 = StrongReference<int>(ref1);
+    REQUIRE_FALSE(ref2.isNull());
+    REQUIRE_EQ(ref1.get(), ref2.get());
+
+    ref2.reset();
+    CHECK_FALSE(ref1.isNull());
+    CHECK(ref2.isNull());
+}
+
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -413,4 +413,27 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("isNull") {
+    SUBCASE("null") {
+        const auto ref1 = StrongReference<int>();
+        REQUIRE(ref1.isNull());
+
+        const auto ref2 = StrongReference<int>(42);
+        REQUIRE_FALSE(ref2.isNull());
+
+        CHECK(WeakReference<int>(ref1).isNull());
+        CHECK_FALSE(WeakReference<int>(ref2).isNull());
+    }
+
+    SUBCASE("expired") {
+        auto ref = ValueReference<int>();
+        auto wref = WeakReference<int>(ref);
+
+        CHECK_FALSE(wref.isNull());
+
+        ref.reset();
+        CHECK(wref.isNull());
+    }
+}
+
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -82,8 +82,8 @@ TEST_CASE("value-reference-struct-self") {
     CHECK_EQ(self->x, 42);
     CHECK_EQ(x1.x, 42);
 
-    CHECK_THROWS(StrongReference<T>{self});
-    CHECK_THROWS(WeakReference<T>{self});
+    CHECK_THROWS_WITH_AS(StrongReference<T>{self}, "reference to non-heap instance", const IllegalReference&);
+    CHECK_THROWS_WITH_AS(WeakReference<T>{self}, "reference to non-heap instance", const IllegalReference&);
 }
 
 

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -519,4 +519,23 @@ TEST_CASE("isNull") {
     }
 }
 
+TEST_CASE("reset") {
+    SUBCASE("reset not null") {
+        const auto sref = StrongReference<int>(42);
+        auto wref = WeakReference<int>(sref);
+        REQUIRE_FALSE(wref.isNull());
+
+        wref.reset();
+        CHECK(wref.isNull());
+    }
+
+    SUBCASE("reset null") {
+        auto wref = WeakReference<int>();
+        REQUIRE(wref.isNull());
+
+        wref.reset();
+        CHECK(wref.isNull());
+    }
+}
+
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -2,6 +2,7 @@
 
 #include <doctest/doctest.h>
 
+#include <any>
 #include <exception>
 #include <memory>
 #include <sstream>
@@ -652,6 +653,18 @@ TEST_CASE("reset") {
         wref.reset();
         CHECK(wref.isNull());
     }
+}
+
+TEST_SUITE_END();
+
+TEST_SUITE_BEGIN("StrongReferenceGeneric");
+
+TEST_CASE("as") {
+    CHECK_EQ(StrongReferenceGeneric().as<int>(), nullptr);
+    CHECK_EQ(StrongReferenceGeneric(StrongReference<int>()).as<int>(), nullptr);
+    CHECK_EQ(*StrongReferenceGeneric(StrongReference<int>(42)).as<int>(), 42);
+    CHECK_THROWS_WITH_AS(StrongReferenceGeneric(StrongReference<int>(42)).as<double>(), "bad any cast",
+                         const std::bad_any_cast&);
 }
 
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -413,6 +413,31 @@ TEST_CASE("construct") {
     }
 }
 
+TEST_CASE("derefAsValue") {
+    SUBCASE("expired") {
+        auto sref = StrongReference<int>(42);
+
+        const auto wref = WeakReference<int>(sref);
+        REQUIRE_FALSE(wref.isExpired());
+        REQUIRE_FALSE(wref.isNull());
+
+        CHECK_EQ(wref.derefAsValue(), sref.derefAsValue());
+
+        sref.reset();
+        REQUIRE(wref.isExpired());
+
+        CHECK(wref.derefAsValue().isNull());
+    }
+
+    SUBCASE("null") {
+        const auto sref = StrongReference<int>();
+        const auto wref = WeakReference<int>(sref);
+        REQUIRE(wref.isNull());
+
+        CHECK(wref.derefAsValue().isNull());
+    }
+}
+
 TEST_CASE("get") {
     SUBCASE("null") {
         const auto sref = StrongReference<int>();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -666,4 +666,12 @@ TEST_CASE("as") {
                          const IllegalReference&);
 }
 
+TEST_CASE("reset") {
+    auto ref = StrongReferenceGeneric(StrongReference<int>(42));
+    REQUIRE_EQ(*ref.as<int>(), 42);
+
+    ref.reset();
+    CHECK_EQ(ref.as<int>(), nullptr);
+}
+
 TEST_SUITE_END();

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -16,8 +16,8 @@ struct T : public hilti::rt::trait::isStruct, hilti::rt::Controllable<T> {
     void foo(int y) {
         // Ensure we can reconstruct a value ref from "this".
         auto self = ValueReference<T>::self(this);
-        REQUIRE(x == y);
-        REQUIRE(self->x == y);
+        REQUIRE_EQ(x, y);
+        REQUIRE_EQ(self->x, y);
     }
 };
 
@@ -35,36 +35,36 @@ TEST_CASE("value-reference-int") {
     using T = int;
 
     ValueReference<T> x1;
-    REQUIRE(*x1 == 0);
+    REQUIRE_EQ(*x1, 0);
 
     ValueReference<T> x2(42);
-    REQUIRE(*x2 == 42);
+    REQUIRE_EQ(*x2, 42);
 
     ValueReference<T> x3(x2);
-    REQUIRE(*x3 == 42);
+    REQUIRE_EQ(*x3, 42);
 
     x3 = 21;
-    REQUIRE(*x3 == 21);
-    REQUIRE(*x2 == 42);
+    REQUIRE_EQ(*x3, 21);
+    REQUIRE_EQ(*x2, 42);
 
     ValueReference<T> x4(std::move(x3));
-    REQUIRE(*x4 == 21);
+    REQUIRE_EQ(*x4, 21);
     REQUIRE(x3.isNull());
 
     ValueReference<T> x5;
     x5 = std::move(x4);
-    REQUIRE(*x5 == 21);
+    REQUIRE_EQ(*x5, 21);
     REQUIRE(x4.isNull());
 }
 
 TEST_CASE("value-reference-struct") {
     ValueReference<T> x1;
-    REQUIRE(x1->x == 0);
+    REQUIRE_EQ(x1->x, 0);
 
     T t;
     t.x = 42;
     ValueReference<T> x2(t);
-    REQUIRE(x2->x == 42);
+    REQUIRE_EQ(x2->x, 42);
 
     x2->x = 21;
     x2->foo(21);
@@ -79,8 +79,8 @@ TEST_CASE("value-reference-struct-self") {
     auto self = ValueReference<T>::self(&x1);
 
     self->x = 42;
-    REQUIRE(self->x == 42);
-    REQUIRE(x1.x == 42);
+    REQUIRE_EQ(self->x, 42);
+    REQUIRE_EQ(x1.x, 42);
 
     REQUIRE_THROWS(StrongReference<T>{self});
     REQUIRE_THROWS(WeakReference<T>{self});
@@ -91,19 +91,19 @@ TEST_CASE("strong-reference") {
     using T = int;
 
     StrongReference<T> x0;
-    REQUIRE(! x0);
+    REQUIRE_FALSE(x0);
 
     StrongReference<T> x1(42);
     REQUIRE(x1);
-    REQUIRE(*x1 == 42);
+    REQUIRE_EQ(*x1, 42);
 
     StrongReference<T> x2(x1);
     REQUIRE(x2);
-    REQUIRE(*x2 == 42);
+    REQUIRE_EQ(*x2, 42);
 
     *x1 = 21;
-    REQUIRE(*x1 == 21);
-    REQUIRE(*x2 == 21);
+    REQUIRE_EQ(*x1, 21);
+    REQUIRE_EQ(*x2, 21);
 
     ValueReference<T> v1{1};
     ValueReference<T> v2{2};
@@ -112,10 +112,10 @@ TEST_CASE("strong-reference") {
     x2 = x1;
     v1 = v2;
 
-    REQUIRE(*x1 == 2);
-    REQUIRE(*v1 == 2);
-    REQUIRE(*x2 == 2);
-    REQUIRE(*v2 == 2);
+    REQUIRE_EQ(*x1, 2);
+    REQUIRE_EQ(*v1, 2);
+    REQUIRE_EQ(*x2, 2);
+    REQUIRE_EQ(*v2, 2);
 }
 
 struct Foo;

--- a/hilti/src/rt/tests/reference.cc
+++ b/hilti/src/rt/tests/reference.cc
@@ -36,6 +36,29 @@ inline std::string to_string(const T& x, tag /*unused*/) { return hilti::rt::fmt
 
 TEST_SUITE_BEGIN("ValueReference");
 
+TEST_CASE("asSharedPtr") {
+    SUBCASE("owning") {
+        T x(42);
+
+        REQUIRE(ValueReference<T>(x).asSharedPtr());
+        CHECK_EQ(*ValueReference<T>(x).asSharedPtr(), x);
+    }
+
+    SUBCASE("non-owning") {
+        auto ptr = std::make_shared<T>(42);
+
+        REQUIRE(ValueReference<T>::self(ptr.get()).asSharedPtr());
+        CHECK_EQ(*ValueReference<T>::self(ptr.get()).asSharedPtr(), *ptr);
+
+        CHECK_THROWS_WITH_AS(ValueReference<T>::self(nullptr).asSharedPtr(), "unexpected state of value reference",
+                             const IllegalReference&);
+
+        T x(42);
+        CHECK_THROWS_WITH_AS(ValueReference<T>::self(&x).asSharedPtr(), "reference to non-heap instance",
+                             const IllegalReference&);
+    }
+}
+
 TEST_CASE_TEMPLATE("construct", U, int, T) {
     SUBCASE("default") {
         const ValueReference<U> ref;


### PR DESCRIPTION
This patchset is part of #468, in particular the work on `hilti/rt/types/reference.h`.