### PR TITLE
Cirrus CI: Move Zeek package specs back into tasks.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,13 +1,11 @@
 environment:
     CCACHE_BASEDIR: $CIRRUS_WORKING_DIR
-    ZEEK_PACKAGES_CURRENT: zeek=3.2.0-* zeek-core-dev=3.2.0-*
-    ZEEK_PACKAGES_LTS:     zeek-lts=3.0.8-* zeek-lts-core-dev=3.0.8-*
 
 clang9_zeek_ubuntu_debug_task:
   container:
     dockerfile: ci/Dockerfile
     docker_arguments:
-      - zeek_packages: ${ZEEK_PACKAGES_CURRENT}
+      - zeek_packages: zeek=3.2.0-* zeek-core-dev=3.2.0-*
     cpu: 4
     memory: 8G
 
@@ -57,7 +55,7 @@ clang10_zeek_lts_ubuntu_release_task:
   container:
     dockerfile: ci/Dockerfile
     docker_arguments:
-      - zeek_packages: ${ZEEK_PACKAGES_LTS}
+      - zeek_packages: zeek-lts=3.0.8-* zeek-lts-core-dev=3.0.8-*
     cpu: 4
     memory: 8G
 
@@ -104,7 +102,7 @@ clang9_zeek_lts_ubuntu_release_static_task:
   container:
     dockerfile: ci/Dockerfile
     docker_arguments:
-      - zeek_packages: ${ZEEK_PACKAGES_LTS}
+      - zeek_packages: zeek-lts=3.0.8-* zeek-lts-core-dev=3.0.8-*
     cpu: 4
     memory: 8G
 
@@ -150,7 +148,7 @@ gcc9_ubuntu_release_no_jit_task:
   container:
     dockerfile: ci/Dockerfile
     docker_arguments:
-      - zeek_packages: ${ZEEK_PACKAGES_LTS}
+      - zeek_packages: zeek-lts=3.0.8-* zeek-lts-core-dev=3.0.8-*
     cpu: 4
     memory: 12G
 

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -3,8 +3,8 @@
 all:
 
 build:
-	export zeek_packages=$$(cat ../.cirrus.yml | grep ZEEK_PACKAGES_CURRENT: | cut -d ':' -f 2- | xargs); \
-		DOCKER_BUILDKIT=1 docker build --build-arg "zeek_packages=$${zeek_packages}" -t spicy-ci:latest
+	export zeek_packages=$$(cat ../.cirrus.yml | grep zeek_packages: | grep zeek= | cut -d ':' -f 2- | xargs); \
+		DOCKER_BUILDKIT=1 docker build --build-arg "zeek_packages=$${zeek_packages}" -t spicy-ci:latest .
 
 run:
 	docker run -v $$(cd .. && pwd):/opt/spicy -w /opt/spicy --cap-add SYS_PTRACE -i -t spicy-ci:latest /bin/bash


### PR DESCRIPTION
This is to work around https://github.com/cirruslabs/cirrus-ci-docs/issues/692