### PR TITLE
Explicitly set locale in centos Docker container.

### DIFF
--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -8,6 +8,10 @@ WORKDIR /root
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
 ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
 
+RUN echo 'LC_CTYPE="C"' >> /etc/default/locale \
+ && echo 'LC_ALL="C"' >> /etc/default/locale \
+ && echo 'LANG="C"' >> /etc/default/locale
+
 RUN yum install -y epel-release yum-utils && yum-config-manager --set-enabled PowerTools
 RUN yum update -y
 


### PR DESCRIPTION
`hilti::rt::init` needs to be able to set the locale on the host system
and will abort with a fatal error if it cannot do so. This patch makes
sure this is possible in the centos-8 Docker container provided by us.

Note: This already worked in BTests since its config file enforces the
needed environment variables. This patch fixes it also for standalone
usage of Spicy (and now e.g., the `locale` command emits no more
errors).