### PR TITLE
Prevent loss of precision when codgening Time constructors.

### DIFF
--- a/hilti/src/compiler/codegen/ctors.cc
+++ b/hilti/src/compiler/codegen/ctors.cc
@@ -171,7 +171,7 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
     }
 
     result_t operator()(const ctor::Time& n) {
-        return fmt("hilti::rt::Time(%f, hilti::rt::Time::SecondTag())", n.value().seconds());
+        return fmt("hilti::rt::Time(%" PRId64 ", hilti::rt::Time::NanosecondTag())", n.value().nanoseconds());
     }
 
     result_t operator()(const ctor::Enum& n) {


### PR DESCRIPTION
`rt::Time` internally stores timestamps as `uint64_t` values. We however
where previously using the constructor from seconds in `double` when
generating C++ code, additionally formatting double values with only 6
significant digits via `%f`. This could lead to loss of precision, e.g.,
for very small time values.

With this patch we now construct `rt::Time` values from nanoseconds.
This prevents this particular loss of precision.

This closes #508.