### PR TITLE
Zeek plugin: Respect %port and %mime-type properties in units.

### DIFF
--- a/doc/zeek.rst
+++ b/doc/zeek.rst
@@ -161,10 +161,12 @@ properties are supported:
         for port constants <type_port>` (e.g., ``80/tcp``). The ports'
         transport protocol must match that of the analyzer.
 
-        .. todo::
+        .. note::
 
-            The plugin should pick up any ``%port`` :ref:`unit_meta_data`,
-            but it doesn't yet (:issue:`95`).
+            The plugin will also honor any ``%port`` :ref:`meta data
+            property <unit_meta_data>` that the responder-side
+            ``SPICY_UNIT`` may define (as long as the attribute's
+            direction is not ``originator``).
 
     ``replaces ANALYZER_NAME``
         Disables an existing analyzer that Zeek already provides
@@ -217,6 +219,12 @@ File analyzers support the following properties:
         activate your analyzer when it sees a corresponding file on
         the network. The type is a specified in standard
         ``type/subtype`` notion, without quotes (e.g., ``image/gif``).
+
+        .. note::
+
+            The plugin will also honor any ``%mime-type`` :ref:`meta
+            data property <unit_meta_data>` that the ``SPICY_UNIT``
+            may define.
 
         .. note::
 

--- a/tests/Baseline/zeek.evt.file-analyzer-property/output
+++ b/tests/Baseline/zeek.evt.file-analyzer-property/output
@@ -1,0 +1,1 @@
+text data, FcRmxz1fPbKQEgGGUi, hello world

--- a/tests/zeek/evt/file-analyzer-property.zeek
+++ b/tests/zeek/evt/file-analyzer-property.zeek
@@ -1,0 +1,28 @@
+# @TEST-REQUIRES: have-zeek-plugin-jit
+#
+# @TEST-EXEC: ${ZEEK} -r ${TRACES}/http-post.trace text.spicy ./text.evt %INPUT >output
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=${SCRIPTS}/canonify-zeek-log btest-diff output
+#
+## @TEST-GROUP: spicy-core
+
+event text::data(f: fa_file, data: string)
+	{
+	print "text data", f$id, data;
+	}
+
+# @TEST-START-FILE text.spicy
+module Text;
+
+public type Data = unit {
+    %mime-type = "text/plain";
+    data: bytes &eod;
+};
+# @TEST-END-FILE
+
+# @TEST-START-FILE text.evt
+
+file analyzer spicy::Text:
+    parse with Text::Data;
+
+on Text::Data -> event text::data($file, self.data);
+# @TEST-END-FILE

--- a/tests/zeek/evt/import-from.zeek
+++ b/tests/zeek/evt/import-from.zeek
@@ -15,6 +15,8 @@ event ssh::test(x: string, y: string)
 module SSH;
 
 public type Banner = unit {
+    %port = 22/tcp;
+
     magic   : /SSH-/;
     version : /[^-]*/;
     dash    : /-/;
@@ -47,8 +49,7 @@ public function y()  : string {
 
 # @TEST-START-FILE ssh.evt
 protocol analyzer spicy::SSH over TCP:
-    parse with SSH::Banner,
-    port 22/tcp;
+    parse with SSH::Banner;
 
 import X;
 import Y from a.b.c;

--- a/zeek/plugin/src/plugin.cc
+++ b/zeek/plugin/src/plugin.cc
@@ -266,6 +266,16 @@ void plugin::Zeek_Spicy::Plugin::InitPostScript() {
             ZEEK_DEBUG(hilti::rt::fmt("  Scheduling analyzer for port %s", port));
             ::zeek::analyzer_mgr->RegisterAnalyzerForPort(tag, transport_protocol(port), port.port());
         }
+
+        if ( p.parser_resp ) {
+            for ( auto port : p.parser_resp->ports ) {
+                if ( port.direction != spicy::rt::Direction::Both && port.direction != spicy::rt::Direction::Responder )
+                    continue;
+
+                ZEEK_DEBUG(hilti::rt::fmt("  Scheduling analyzer for port %s", port.port));
+                ::zeek::analyzer_mgr->RegisterAnalyzerForPort(tag, transport_protocol(port.port), port.port.port());
+            }
+        }
     }
 
     for ( auto& p : _file_analyzers_by_subtype ) {
@@ -291,7 +301,7 @@ void plugin::Zeek_Spicy::Plugin::InitPostScript() {
         if ( ! tag )
             reporter::internalError(hilti::rt::fmt("cannot get analyzer tag for '%s'", p.name_analyzer));
 
-        for ( auto mt : p.mime_types ) {
+        auto register_analyzer_for_mime_type = [&](auto tag, const std::string& mt) {
             ZEEK_DEBUG(hilti::rt::fmt("  Scheduling analyzer for MIME type %s", mt));
 
             // MIME types are registered in scriptland, so we'll raise an
@@ -303,6 +313,14 @@ void plugin::Zeek_Spicy::Plugin::InitPostScript() {
             ::zeek::EventHandlerPtr handler =
                 ::spicy::zeek::compat::event_register_Register("spicy_analyzer_for_mime_type");
             ::spicy::zeek::compat::event_mgr_Enqueue(handler, vals);
+        };
+
+        for ( auto mt : p.mime_types )
+            register_analyzer_for_mime_type(tag, mt);
+
+        if ( p.parser ) {
+            for ( auto mt : p.parser->mime_types )
+                register_analyzer_for_mime_type(tag, mt);
         }
     }
 


### PR DESCRIPTION
Unit-side %port and %mime-type may properties may be used instead of
specifying them inside the EVT file.

Closes #95.