### PR TITLE
Use plain function pointers for type info accessors.

### DIFF
--- a/doc/host-applications.rst
+++ b/doc/host-applications.rst
@@ -315,5 +315,5 @@ Our examples always passed the full input at once. You don't need to
 do that, Spicy's parsers can process input incrementally as it comes
 in, and return back to the caller to retrieve more. See the source of
 `spicy::Driver::processInput()
-<https://github.com/zeek/spicy/blob/master/spicy/src/rt/driver.cc#L121>`_
+<https://github.com/zeek/spicy/blob/master/spicy/src/rt/driver.cc>`_
 for an example of how to implement that.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -34,9 +34,9 @@ ubuntu-19.10
     :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_ubuntu_19_10/packages/build/spicy-linux.tar.gz>`,
     `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.ubuntu-19.10>`__
 
-alpine-3.11
-    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_alpine_3_11/packages/build/spicy-linux.tar.gz>`,
-    `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.alpine-3.11>`__
+alpine-3.12
+    :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_alpine_3_12/packages/build/spicy-linux.tar.gz>`,
+    `Dockerfile <https://github.com/zeek/spicy/blob/master/docker/Dockerfile.alpine-3.12>`__
 
 centos-8
     :download:`master <https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/docker_centos_8/packages/build/spicy-linux.tar.gz>`,
@@ -128,13 +128,13 @@ We provide Docker images with nightly Spicy builds for the following platforms:
 
 * `ubuntu-19.10 <https://hub.docker.com/repository/docker/zeekurity/spicy-ubuntu-19.10>`__
 * `centos-8 <https://hub.docker.com/repository/docker/zeekurity/spicy-centos-8>`__
-* `alpine-3.11 <https://hub.docker.com/repository/docker/zeekurity/spicy-alpine-3.11>`__
+* `alpine-3.12 <https://hub.docker.com/repository/docker/zeekurity/spicy-alpine-3.12>`__
 
 To run the image execute the command for the desired platform::
 
     docker run -it zeekurity/spicy-ubuntu-19.10:latest
     docker run -it zeekurity/spicy-centos-8:latest
-    docker run -it zeekurity/spicy-alpine-3.11:latest
+    docker run -it zeekurity/spicy-alpine-3.12:latest
 
 Spicy is installed in `/opt/spicy`.
 
@@ -152,7 +152,7 @@ see the container platforms available::
 
     Available platforms:
 
-        alpine-3.11
+        alpine-3.12
         centos-8
         ubuntu-19.10
 
@@ -278,9 +278,9 @@ On Ubuntu 19 (Eoan):
 
     - See the :repo:`Ubuntu 19 Docker file <docker/Dockerfile.ubuntu-19.10>`.
 
-On Alpine 3.11:
+On Alpine 3.12:
 
-    - See the :repo:`Alpine 3.11 Docker file <docker/Dockerfile.alpine-3.11>`.
+    - See the :repo:`Alpine 3.11 Docker file <docker/Dockerfile.alpine-3.12>`.
 
 On CentOS 8 / RedHat 8:
 

--- a/hilti/runtime/include/type-info.h
+++ b/hilti/runtime/include/type-info.h
@@ -158,7 +158,7 @@ public:
      * Type of a function that, given the outer value, returns a pointer to
      * the contained element.
      */
-    using Accessor = std::function<const void*(const Value& v)>;
+    using Accessor = const void* (*)(const Value& v);
 
     /**
      * Constructor.
@@ -291,9 +291,9 @@ public:
      * refers to.
      *
      */
-    using Accessor = std::tuple<std::function<std::optional<std::any>(const Value&)>,    // begin()
-                                std::function<std::optional<std::any>(const std::any&)>, // next()
-                                std::function<const void*(const std::any&)>>;            // deref()
+    using Accessor = std::tuple<std::optional<std::any> (*)(const Value&),    // begin()
+                                std::optional<std::any> (*)(const std::any&), // next()
+                                const void* (*)(const std::any&)>;            // deref()
 
     /**
      * Constructor.
@@ -543,9 +543,9 @@ public:
      * Similar semantics as with `IterableType`, but with different type for
      * dereferenced value.
      */
-    using Accessor = std::tuple<std::function<std::optional<std::any>(const Value&)>,                 // begin()
-                                std::function<std::optional<std::any>(const std::any&)>,              // next()
-                                std::function<std::pair<const void*, const void*>(const std::any&)>>; // deref()
+    using Accessor = std::tuple<std::optional<std::any> (*)(const Value&),                 // begin()
+                                std::optional<std::any> (*)(const std::any&),              // next()
+                                std::pair<const void*, const void*> (*)(const std::any&)>; // deref()
 
     /**
      * Constructor.
@@ -586,7 +586,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> std::optional<std::any> { // next()
+            [](const std::any& i_) -> std::optional<std::any> { // next()
                 auto i = std::any_cast<iterator_pair<K, V>>(i_);
                 auto n = std::make_pair(++i.first, i.second);
                 if ( n.first != n.second )
@@ -594,7 +594,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> std::pair<const void*, const void*> { // deref()
+            [](const std::any& i_) -> std::pair<const void*, const void*> { // deref()
                 auto i = std::any_cast<iterator_pair<K, V>>(i_);
                 return std::make_pair(&(*i.first).first, &(*i.first).second);
             });
@@ -605,7 +605,7 @@ private:
 
     const TypeInfo* _ktype;
     const TypeInfo* _vtype;
-    const Accessor _accessor;
+    Accessor _accessor;
 };
 
 namespace map {
@@ -648,7 +648,7 @@ public:
      * Type of a function that, given the outer value, returns a pointer to
      * the contained element.
      */
-    using Accessor = std::function<std::pair<const void*, const void*>(const Value& v)>;
+    using Accessor = std::pair<const void*, const void*> (*)(const Value& v);
 
     /**
      * Constructor.
@@ -755,7 +755,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> std::optional<std::any> {
+            [](const std::any& i_) -> std::optional<std::any> {
                 auto i = std::any_cast<iterator_pair<T>>(i_);
                 auto n = std::make_pair(++i.first, i.second);
                 if ( n.first != n.second )
@@ -763,7 +763,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> const void* {
+            [](const std::any& i_) -> const void* {
                 auto i = std::any_cast<iterator_pair<T>>(i_);
                 return &*i.first;
             });
@@ -823,7 +823,7 @@ struct Field {
      * Type of a function that, given a field value, returns a pointer to the
      * contained value.
      */
-    using Accessor = std::function<const void*(const Value& v)>;
+    using Accessor = const void* (*)(const Value& v);
 
     /**
      * Constructor.
@@ -1008,7 +1008,7 @@ public:
      * Type of a function that, given a union value, returns the index of the
      * currently set field, with `npos` indicating no field being set.
      */
-    using Accessor = std::function<std::size_t(const Value& v)>;
+    using Accessor = std::size_t (*)(const Value& v);
     const size_t npos = std::variant_npos;
 
     /**
@@ -1080,7 +1080,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> std::optional<std::any> { // next()
+            [](const std::any& i_) -> std::optional<std::any> { // next()
                 auto i = std::any_cast<iterator_pair<T, Allocator>>(i_);
                 auto n = std::make_pair(++i.first, i.second);
                 if ( n.first != n.second )
@@ -1088,7 +1088,7 @@ public:
                 else
                     return std::nullopt;
             },
-            [](std::any i_) -> const void* { // deref()
+            [](const std::any& i_) -> const void* { // deref()
                 auto i = std::any_cast<iterator_pair<T, Allocator>>(i_);
                 return &*i.first;
             });

--- a/tests/hilti/codegen/type-info.hlt
+++ b/tests/hilti/codegen/type-info.hlt
@@ -149,7 +149,7 @@ public function tuple<strong_ref<TestOptionals>, TypeInfo> makeTestOptionals() {
 
 }
 
-@TEST-START-FILE type-info.cc
+# @TEST-START-FILE type-info.cc
 
 // Standalone test application that exercises the HILTI-side type-info API.
 
@@ -549,4 +549,4 @@ int main(int argc, char** argv) {
     hilti::rt::done();
 }
 
-@TEST-END-FILE
+# @TEST-END-FILE


### PR DESCRIPTION
It turns out that std::function not only adds runtime overhead, but also
that it is significantly slower to compiler than a function pointer.

This commit partially addresses #546.