### PR TITLE
Provide error message when attempting to have spicy-driver compile  when JIT is not available

### DIFF
--- a/hilti/toolchain/include/compiler/driver.h
+++ b/hilti/toolchain/include/compiler/driver.h
@@ -228,6 +228,12 @@ public:
      */
     Result<hilti::JIT*> jit();
 
+    /**
+     * Returns true if any input files have been added that require JIT for
+     * compilation before they can be executed.
+     */
+    bool needJIT() const { return _need_jit; }
+
 protected:
     /**
      * Prints a usage message to stderr. The message summarizes the options
@@ -443,6 +449,7 @@ private:
     std::vector<Unit> _hlts;
 
     bool _runtime_initialized = false; // true once initRuntime() has succeeded
+    bool _need_jit = false; // true once a file has been adeed that needs JIT
     std::set<std::string> _tmp_files;  // all tmp files created, so that we can clean them up.
 };
 

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -430,6 +430,7 @@ void Driver::_addUnit(Unit unit) {
 
     hookNewASTPreCompilation(unit.id(), unit.path(), unit.module());
     _pending_units.emplace_back(std::move(unit));
+    _need_jit = true;
 }
 
 Result<void*> Driver::_symbol(const std::string& symbol) {
@@ -486,6 +487,7 @@ Result<Nothing> Driver::addInput(const std::filesystem::path& path) {
     else if ( path.extension() == ".cc" || path.extension() == ".cxx" ) {
         HILTI_DEBUG(logging::debug::Driver, fmt("adding external C++ file %s", path));
         _external_cxxs.push_back(path);
+        _need_jit = true;
         return Nothing();
     }
 

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -226,6 +226,11 @@ int main(int argc, char** argv) {
 
     driver.parseOptions(argc, argv);
 
+#ifndef HILTI_HAVE_JIT
+    if ( driver.needJIT() )
+        fatalError("no JIT support available, cannot compile input file");
+#endif
+
     if ( auto x = driver.compile(); ! x )
         // The main error messages have been reported already at this point.
         // The returned error will have some more info about which pass

--- a/tests/Baseline/spicy.tools.spicy-driver-missing-jit/output
+++ b/tests/Baseline/spicy.tools.spicy-driver-missing-jit/output
@@ -1,0 +1,1 @@
+[error] spicy-driver: no JIT support available, cannot compile input file

--- a/tests/Scripts/have-jit
+++ b/tests/Scripts/have-jit
@@ -2,4 +2,4 @@
 #
 # Returns success if we have Zeek's Spicy plugin (and Zeek itself) available for testing
 
-test $(spicy-config --jit-support) == "yes"
+test $(spicy-config --jit-support) = "yes"

--- a/tests/spicy/tools/spicy-driver-missing-jit.spicy
+++ b/tests/spicy/tools/spicy-driver-missing-jit.spicy
@@ -1,0 +1,7 @@
+# @TEST-REQUIRES: ! have-jit
+# @TEST-EXEC-FAIL: spicy-driver %INPUT >output 2>&1
+# @TEST-EXEC: btest-diff output
+
+module Test;
+
+print "Hello, world!";


### PR DESCRIPTION

Closes #490.
Closes #507.