### PR TITLE
Fix bug in regular expression parsing.

### DIFF
--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -118,7 +118,7 @@ std::pair<int32_t, uint64_t> regexp::MatchState::_advance(const stream::View& da
         if ( is_final && _pimpl->_acc <= 0 )
             _pimpl->_acc = jrx_current_accept(&_pimpl->_ms);
 
-        return std::make_pair(is_final ? _pimpl->_acc : -1, 0);
+        return std::make_pair(is_final ? _pimpl->_acc : -1, data.offset());
     }
 
     jrx_accept_id rc = 0;
@@ -164,7 +164,7 @@ std::pair<int32_t, uint64_t> regexp::MatchState::_advance(const stream::View& da
         // At least one could match with more data.
         _pimpl->_acc = -1;
 
-    return std::make_pair(_pimpl->_acc, 0);
+    return std::make_pair(_pimpl->_acc, data.offset());
 }
 
 RegExp::RegExp(std::string pattern, regexp::Flags flags) : _flags(flags) {

--- a/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
@@ -120,8 +120,13 @@ struct Visitor : public hilti::visitor::PreOrder<Expression, Visitor> {
 
                 auto no_match_try_again = switch_.addCase(builder::integer(-1));
                 pushBuilder(no_match_try_again);
-                pb->waitForInput("end of data while matching regular expression", c.meta().location());
-                no_match_try_again->addContinue();
+                auto pstate = pb->state();
+                pstate.self = hilti::expression::UnresolvedID(ID("self"));
+                pstate.cur = builder::id("ncur");
+                pb->pushState(std::move(pstate));
+                builder()->addLocal(ID("more_data"), pb->waitForInputOrEod());
+                pb->popState();
+                builder()->addContinue();
                 popBuilder();
 
                 auto no_match_error = switch_.addCase(builder::integer(0));

--- a/tests/Baseline/spicy.types.sink.write-open-end-regexp/output
+++ b/tests/Baseline/spicy.types.sink.write-open-end-regexp/output
@@ -1,0 +1,4 @@
+A, [$length=4, $data=b"ABC\x0a", $b=<sink>]
+B, [$x=b"ABC"]
+A, [$length=4, $data=b"ABCD", $b=<sink>]
+B, [$x=b"ABCD"]

--- a/tests/spicy/types/sink/write-open-end-regexp.spicy
+++ b/tests/spicy/types/sink/write-open-end-regexp.spicy
@@ -1,0 +1,24 @@
+# @TEST-EXEC:  spicyc -j -o x.hlto %INPUT
+# @TEST-EXEC:  ${SCRIPTS}/printf '\x04ABC\n' | spicy-driver -p Test::A x.hlto | sort >>output
+# @TEST-EXEC:  ${SCRIPTS}/printf '\x04ABCD' | spicy-driver -p Test::A x.hlto | sort >>output
+# @TEST-EXEC:  btest-diff output
+
+module Test;
+
+import spicy;
+
+public type A = unit {
+    on %init { self.b.connect(new B); }
+
+    length: uint8;
+    data: bytes &size=self.length { self.b.write($$); }
+
+    on %done { print "A", self; }
+
+    sink b;
+};
+
+public type B = unit {
+    x: /[^\n]+/;
+    on %done { print "B", self; }
+};


### PR DESCRIPTION
Closes #540.

We'd mess up tracking of the current offset inside the stream.