### PR TITLE
Remove --include-linker option from driver.

### DIFF
--- a/doc/examples/_usage-spicyc.output
+++ b/doc/examples/_usage-spicyc.output
@@ -9,7 +9,6 @@ Options controlling code generation:
   -D | --compiler-debug <streams> Activate compile-time debugging output for given debug streams (comma-separated; 'help' for list).
   -e | --output-all-dependencies  Output list of dependencies for all compiled modules.
   -E | --output-code-dependencies Output list of dependencies for all compiled modules that require separate compilation of their own.
-  -K | --include-linker           With --output-c++, include HILTI linker glue code.
   -L | --library-path <path>      Add path to list of directories to search when importing modules.
   -O | --optimize                 Build optimized release version of generated code.
   -P | --output-prototypes        Output C++ header with prototypes for public functionality.

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -27,7 +27,6 @@ static struct option long_driver_options[] = {{"abort-on-exceptions", required_a
                                               {"debug-addl", required_argument, nullptr, 'X'},
                                               {"dump-code", no_argument, nullptr, 'C'},
                                               {"help", no_argument, nullptr, 'h'},
-                                              {"include-linker", no_argument, nullptr, 'K'},
                                               {"keep-tmps", no_argument, nullptr, 'T'},
                                               {"library-path", required_argument, nullptr, 'L'},
                                               {"optimize", no_argument, nullptr, 'O'},
@@ -97,7 +96,6 @@ void Driver::usage() {
            "(comma-separated; 'help' for list).\n"
            "  -E | --output-code-dependencies Output list of dependencies for all compiled modules that require "
            "separate compilation of their own.\n"
-           "  -K | --include-linker           With --output-c++, include HILTI linker glue code.\n"
            "  -L | --library-path <path>      Add path to list of directories to search when importing modules.\n"
            "  -O | --optimize                 Build optimized release version of generated code.\n"
            "  -P | --output-prototypes        Output C++ header with prototypes for public functionality.\n"
@@ -225,7 +223,7 @@ Result<Nothing> Driver::parseOptions(int argc, char** argv) {
     int num_output_types = 0;
 
     opterr = 0; // don't print errors
-    std::string option_string = "ABlKL:OcCpPvjJhvVdX:o:D:TUEeSR" + hookAddCommandLineOptions();
+    std::string option_string = "ABlL:OcCpPvjJhvVdX:o:D:TUEeSR" + hookAddCommandLineOptions();
 
     while ( true ) {
         int c = getopt_long(argc, argv, option_string.c_str(), long_driver_options, nullptr);
@@ -318,8 +316,6 @@ Result<Nothing> Driver::parseOptions(int argc, char** argv) {
                 _driver_options.include_linker = true;
                 ++num_output_types;
                 break;
-
-            case 'K': _driver_options.include_linker = true; break;
 
             case 'L': _compiler_options.library_paths.emplace_back(std::string(optarg)); break;
 

--- a/tests/Baseline/hilti.hiltic.print.globals/output
+++ b/tests/Baseline/hilti.hiltic.print.globals/output
@@ -1,4 +1,4 @@
-// Begin of Foo (from "/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.globals/globals.hlt")
+// Begin of Foo (from "/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.globals/globals.hlt")
 // Compiled by HILTI version 0.4.0-branch
 
 #include <hilti/rt/compiler-setup.h>
@@ -26,14 +26,14 @@ extern void __hlt::Foo::__init_globals(hilti::rt::Context* ctx) {
 }
 
 extern void __hlt::Foo::__init_module() {
-      __location__("/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.globals/globals.hlt:11:1");
+      __location__("/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.globals/globals.hlt:12:1");
     hilti::rt::print(Foo::__globals()->X, hilti::rt::Bool(true));
 }
 
 extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule({ "Foo", &__init_module, &__init_globals, &__globals_index}); }
 
 /* __HILTI_LINKER_V1__
-{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.globals/globals.hlt","version":1}
+{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.globals/globals.hlt","version":1}
 */
 
 // Begin of __linker__
@@ -43,9 +43,9 @@ extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule(
 
 // 
 // Linker code generated for modules:
-//   - Foo (/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.globals/globals.hlt)
+//   - Foo (/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.globals/globals.hlt)
 
 #include <hilti/rt/libhilti.h>
 
-const char* __hlto_library_version __attribute__((weak)) = R"({"created":1597153672.4983387,"debug":false,"hilti_version":400,"magic":"v1","optimize":false})";
+const char* __hlto_library_version __attribute__((weak)) = R"({"created":1603300886.926692,"debug":false,"hilti_version":400,"magic":"v1","optimize":false})";
 

--- a/tests/Baseline/hilti.hiltic.print.hello-world/output
+++ b/tests/Baseline/hilti.hiltic.print.hello-world/output
@@ -1,4 +1,4 @@
-// Begin of Foo (from "/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt")
+// Begin of Foo (from "/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt")
 // Compiled by HILTI version 0.4.0-branch
 
 #include <hilti/rt/compiler-setup.h>
@@ -13,14 +13,14 @@ namespace __hlt::Foo {
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 
 extern void __hlt::Foo::__init_module() {
-      __location__("/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt:9:1");
+      __location__("/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt:10:1");
     hilti::rt::print(std::string("Hello, world!"), hilti::rt::Bool(true));
 }
 
 extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule({ "Foo", &__init_module, nullptr, nullptr}); }
 
 /* __HILTI_LINKER_V1__
-{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt","version":1}
+{"module":"Foo","namespace":"__hlt::Foo","path":"/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt","version":1}
 */
 
 // Begin of __linker__
@@ -30,9 +30,9 @@ extern void __hlt::Foo::__register_module() { hilti::rt::detail::registerModule(
 
 // 
 // Linker code generated for modules:
-//   - Foo (/Users/robin/work/spicy/topic/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt)
+//   - Foo (/Users/robin/work/spicy/topic2/tests/.tmp/hilti.hiltic.print.hello-world/hello-world.hlt)
 
 #include <hilti/rt/libhilti.h>
 
-const char* __hlto_library_version __attribute__((weak)) = R"({"created":1597153675.217676,"debug":false,"hilti_version":400,"magic":"v1","optimize":false})";
+const char* __hlto_library_version __attribute__((weak)) = R"({"created":1603300890.537543,"debug":false,"hilti_version":400,"magic":"v1","optimize":false})";
 

--- a/tests/hilti/hiltic/print/empty.hlt
+++ b/tests/hilti/hiltic/print/empty.hlt
@@ -1,5 +1,6 @@
 # @TEST-GROUP: no-jit
-# @TEST-EXEC: ${HILTIC} -c -K %INPUT >output
+# @TEST-EXEC: ${HILTIC} -c %INPUT >output
+# @TEST-EXEC: ${HILTIC} -l %INPUT >>output
 # @TEST-EXEC: btest-diff output
 
 module Foo {}

--- a/tests/hilti/hiltic/print/globals.hlt
+++ b/tests/hilti/hiltic/print/globals.hlt
@@ -1,5 +1,6 @@
 # @TEST-GROUP: no-jit
-# @TEST-EXEC: ${HILTIC} -c -K %INPUT >output
+# @TEST-EXEC: ${HILTIC} -c %INPUT >output
+# @TEST-EXEC: ${HILTIC} -l %INPUT >>output
 # @TEST-EXEC: btest-diff output
 
 module Foo {

--- a/tests/hilti/hiltic/print/hello-world.hlt
+++ b/tests/hilti/hiltic/print/hello-world.hlt
@@ -1,5 +1,6 @@
 # @TEST-GROUP: no-jit
-# @TEST-EXEC: ${HILTIC} -c -K %INPUT >output
+# @TEST-EXEC: ${HILTIC} -c %INPUT >output
+# @TEST-EXEC: ${HILTIC} -l %INPUT >>output
 # @TEST-EXEC: btest-diff output
 
 module Foo {

--- a/tests/hilti/hiltic/print/import.hlt
+++ b/tests/hilti/hiltic/print/import.hlt
@@ -1,5 +1,6 @@
 # @TEST-GROUP: no-jit
-# @TEST-EXEC: ${HILTIC} -c -K foo.hlt bar.hlt >output
+# @TEST-EXEC: ${HILTIC} -c foo.hlt bar.hlt >output
+# @TEST-EXEC: ${HILTIC} -l foo.hlt bar.hlt >>output
 # @TEST-EXEC: btest-diff output
 
 @TEST-START-FILE foo.hlt

--- a/tests/spicy/doc/my-http-host-callback.cc
+++ b/tests/spicy/doc/my-http-host-callback.cc
@@ -1,6 +1,7 @@
 // @TEST-EXEC: spicyc -P my-http.spicy >my-http.h
-// @TEST-EXEC: spicyc -cK my-http.spicy >my-http.cc
-// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc my-http-callback.cc %INPUT $(spicy-config --cxxflags --ldflags)
+// @TEST-EXEC: spicyc -c my-http.spicy >my-http.cc
+// @TEST-EXEC: spicyc -l my-http.cc >my-http-linker.cc
+// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc my-http-linker.cc my-http-callback.cc %INPUT $(spicy-config --cxxflags --ldflags)
 // @TEST-EXEC: ./my-http "$(cat data)" | sort >output
 // @TEST-EXEC: btest-diff output
 //

--- a/tests/spicy/doc/my-http-host-driver.cc
+++ b/tests/spicy/doc/my-http-host-driver.cc
@@ -1,5 +1,6 @@
-// @TEST-EXEC: spicyc -cK my-http.spicy >my-http.cc
-// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc %INPUT $(spicy-config --cxxflags --ldflags)
+// @TEST-EXEC: spicyc -c my-http.spicy >my-http.cc
+// @TEST-EXEC: spicyc -l my-http.cc >my-http-linker.cc
+// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc my-http-linker.cc %INPUT $(spicy-config --cxxflags --ldflags)
 // @TEST-EXEC: ./my-http "$(cat data)" >output
 // @TEST-EXEC: btest-diff output
 //

--- a/tests/spicy/doc/my-http-host-parse1.cc
+++ b/tests/spicy/doc/my-http-host-parse1.cc
@@ -1,6 +1,7 @@
 // @TEST-EXEC: spicyc -P my-http.spicy >my-http.h
-// @TEST-EXEC: spicyc -cK my-http.spicy >my-http.cc
-// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc %INPUT $(spicy-config --cxxflags --ldflags)
+// @TEST-EXEC: spicyc -c my-http.spicy >my-http.cc
+// @TEST-EXEC: spicyc -l my-http.cc >my-http-linker.cc
+// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc my-http-linker.cc %INPUT $(spicy-config --cxxflags --ldflags)
 // @TEST-EXEC: ./my-http "$(cat data)" >output
 // @TEST-EXEC: btest-diff output
 //

--- a/tests/spicy/doc/my-http-host-parse2.cc
+++ b/tests/spicy/doc/my-http-host-parse2.cc
@@ -1,6 +1,7 @@
 // @TEST-EXEC: spicyc -P my-http.spicy >my-http.h
-// @TEST-EXEC: spicyc -cK my-http.spicy >my-http.cc
-// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc %INPUT $(spicy-config --cxxflags --ldflags)
+// @TEST-EXEC: spicyc -c my-http.spicy >my-http.cc
+// @TEST-EXEC: spicyc -l my-http.cc >my-http-linker.cc
+// @TEST-EXEC: $(spicy-config --cxx) -o my-http my-http.cc my-http-linker.cc %INPUT $(spicy-config --cxxflags --ldflags)
 // @TEST-EXEC: ./my-http "$(cat data)" >output
 // @TEST-EXEC: btest-diff output
 //


### PR DESCRIPTION
This option used to print the linker glue code along with the main,
generated C++ code. The problem is that the linker code was produced
as if it were a standalone C++ unit. However, by concatening it with
the main code, that didn't hold and we'd run into problems like
duplicaste type definitions. This wasn't salvagable easily, and
conceptually it looks kind of wrong anyways, so removing it.

The better way to do all this is using "-l" to generate *just* the
linker code, then compile the two together as two compilation units.
If one insists, one can also still "cat" the two and will be back to
what "-cK" used to produce, with the same issues obviously.

Closes #500.