### PR TITLE
Provide has_label() method for enum values.

### DIFF
--- a/doc/autogen/types/enum.rst
+++ b/doc/autogen/types/enum.rst
@@ -1,3 +1,10 @@
+.. rubric:: Methods
+
+.. spicy:method:: enum_::has_label enum has_label False bool ()
+
+    Returns *true* if the value of *op1* corresponds to a known enum label
+    (other than ``Undef``), as defined by it's type.
+
 .. rubric:: Operators
 
 .. spicy:operator:: enum_::Call enum enum-type(uint)

--- a/hilti/runtime/include/type-info.h
+++ b/hilti/runtime/include/type-info.h
@@ -12,9 +12,16 @@
 
 #include <hilti/rt/exception.h>
 #include <hilti/rt/fmt.h>
-#include <hilti/rt/types/all.h>
+#include <hilti/rt/types/address.h>
+#include <hilti/rt/types/bool.h>
 #include <hilti/rt/types/bytes.h>
+#include <hilti/rt/types/map.h>
+#include <hilti/rt/types/network.h>
+#include <hilti/rt/types/port.h>
+#include <hilti/rt/types/reference.h>
+#include <hilti/rt/types/set.h>
 #include <hilti/rt/types/stream.h>
+#include <hilti/rt/types/vector.h>
 
 namespace hilti::rt {
 

--- a/hilti/runtime/include/types/all.h
+++ b/hilti/runtime/include/types/all.h
@@ -6,6 +6,7 @@
 #include <hilti/rt/types/any.h>
 #include <hilti/rt/types/bool.h>
 #include <hilti/rt/types/bytes.h>
+#include <hilti/rt/types/enum.h>
 #include <hilti/rt/types/error.h>
 #include <hilti/rt/types/function.h>
 #include <hilti/rt/types/integer.h>

--- a/hilti/runtime/include/types/enum.h
+++ b/hilti/runtime/include/types/enum.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include <hilti/rt/logging.h>
+#include <hilti/rt/type-info.h>
+
+namespace hilti::rt {
+
+namespace enum_ {
+
+/**
+ * Returns true if an enum value maps to a known label.
+ *
+ * @param t enum value
+ * @param ti type information corresponding to enum's type
+ * @tparam T enum type
+ */
+template<typename T>
+bool has_label(const T& t, const TypeInfo* ti) {
+    auto et = std::get_if<type_info::Enum>(&ti->aux_type_info);
+    if ( ! et )
+        internalError("unexpected type info in enum_::has_label");
+
+    for ( const auto& l : et->labels() ) {
+        if ( l.value != -1 && static_cast<int64_t>(t) == l.value )
+            return true;
+    }
+
+    return false;
+}
+} // namespace enum_
+} // namespace hilti::rt

--- a/hilti/toolchain/include/ast/operators/enum.h
+++ b/hilti/toolchain/include/ast/operators/enum.h
@@ -35,4 +35,17 @@ Instantiates an enum instance initialized from an integer value. The value does
     }
 END_CTOR
 
+BEGIN_METHOD(enum_, HasLabel)
+    auto signature() const {
+        return Signature{.self = type::constant(type::Enum(type::Wildcard())),
+                         .result = type::Bool(),
+                         .id = "has_label",
+                         .args = {},
+                         .doc = R"(
+Returns *true* if the value of *op1* corresponds to a known enum label (other
+than ``Undef``), as defined by it's type.
+)"};
+    }
+END_METHOD
+
 } // namespace hilti::operator_

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -247,6 +247,10 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
         return fmt("static_cast<%s>(%s.Ref())", cg->compile(t, codegen::TypeUsage::Storage), args[0]);
     }
 
+    result_t operator()(const operator_::enum_::HasLabel& n) {
+        return fmt("::hilti::rt::enum_::has_label(%s, %s)", op0(n), cg->typeInfo(n.op0().type()));
+    }
+
     // Exception
     result_t operator()(const operator_::exception::Ctor& n) {
         std::string type;

--- a/tests/Baseline/hilti.types.enum.basic/output
+++ b/tests/Baseline/hilti.types.enum.basic/output
@@ -3,6 +3,7 @@ Y::Undef
 X::A1
 Y::B2
 [$x1=X::Undef, $x2=(not set), $y1=(not set)]
+X::<unknown-42>
 []
 []
 [X::A1, X::A2]

--- a/tests/hilti/types/enum/basic.hlt
+++ b/tests/hilti/types/enum/basic.hlt
@@ -38,6 +38,13 @@ assert X::A1;
 assert !X::Undef;
 assert x && X::A1 ;
 
+# has_label()
+global X no_label = X(42);
+hilti::print(no_label);
+assert x.has_label();
+assert ! y.has_label();
+assert ! no_label.has_label();
+
 # Passing back from function
 function vector<X> x1() {
     return [];


### PR DESCRIPTION
Returns true if the enum maps to a known type value other than Undef.

Closes #499.

(This uses our new type information for the check. We should move enum
printing to that style as well, instead of generating dedicated
functions for each enum type.)