### PR TITLE
Make generated grammar symbols globally unique during Spicy codegen.

### DIFF
--- a/spicy/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/codegen.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -10,6 +11,7 @@
 #include <hilti/ast/declarations/function.h>
 #include <hilti/ast/declarations/property.h>
 #include <hilti/ast/node.h>
+#include <hilti/base/uniquer.h>
 #include <hilti/compiler/unit.h>
 
 #include <spicy/ast/types/unit-items/field.h>
@@ -52,6 +54,7 @@ public:
     NodeRef preserveNode(Expression x);
     NodeRef preserveNode(Statement x);
     NodeRef preserveNode(Type x);
+    auto uniquer() { return &_uniquer; }
 
     const auto& moduleProperties() const { return _properties; }
     void recordModuleProperty(hilti::declaration::Property p) { _properties.emplace_back(std::move(p)); }
@@ -75,6 +78,7 @@ private:
     hilti::Node* _root = nullptr;
     std::vector<Declaration> _new_decls;
     std::unordered_set<ID> _decls_added;
+    hilti::util::Uniquer<std::string> _uniquer;
 };
 
 } // namespace spicy::detail

--- a/spicy/toolchain/include/compiler/detail/codegen/grammar-builder.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/grammar-builder.h
@@ -30,7 +30,7 @@ public:
      * Generates the grammar for a unit type. The grammar will afterwards be
      * available through `grammar()`.
      */
-    Result<Nothing> run(const type::Unit& unit, Node* node);
+    Result<Nothing> run(const type::Unit& unit, Node* node, CodeGen* cg);
 
     /**
      * Returns the grammar for a unit type. The type must have been computed

--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -95,7 +95,7 @@ struct VisitorPassInit : public hilti::visitor::PreOrder<void, VisitorPassInit> 
         replaceNode(&p, nt);
 
         // Build the unit's grammar.
-        if ( auto r = cg->grammarBuilder()->run(nu, &p.node); ! r ) {
+        if ( auto r = cg->grammarBuilder()->run(nu, &p.node, cg); ! r ) {
             hilti::logger().error(r.error().description(), p.node.location());
             return;
         }

--- a/tests/Baseline/spicy.types.unit.switch-nested/output
+++ b/tests/Baseline/spicy.types.unit.switch-nested/output
@@ -1,0 +1,3 @@
+[$a=(not set), $b=[$val=b"abc"]]
+[$a=[$x=[$val=b"xyz"], $y=(not set)], $b=(not set)]
+[$a=[$x=(not set), $y=[$val=b"XYZ"]], $b=(not set)]

--- a/tests/Baseline/spicy.types.unit.trimming/.stderr
+++ b/tests/Baseline/spicy.types.unit.trimming/.stderr
@@ -1,217 +1,217 @@
-[spicy-verbose] - state: type=Mini::Test input="1234567890..." stream=0x603000bbab48 offsets=0/0/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="1234567890..." stream=0x603000bbab48 offsets=0/0/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="1234567890..." stream=0x7fb782506908 offsets=0/0/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="1234567890..." stream=0x7fb782506908 offsets=0/0/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="34567890ab..." stream=0x603000bbab48 offsets=2/2/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="34567890ab..." stream=0x7fb782506908 offsets=2/2/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="567890abcd" stream=0x603000bbab48 offsets=4/4/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="567890abcd" stream=0x7fb782506908 offsets=4/4/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="90abcd" stream=0x603000bbab48 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="90abcd" stream=0x603000bbab48 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="90abcd" stream=0x603000bbab48 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="90abcd" stream=0x7fb782506908 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="90abcd" stream=0x7fb782506908 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="90abcd" stream=0x7fb782506908 offsets=8/8/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="bcd" stream=0x603000bbab48 offsets=11/11/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="bcd" stream=0x7fb782506908 offsets=11/11/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'
 [spicy-verbose]     - setting field 'f4' to '[$x=b"90a", $y=b"bcd"]'
-[spicy-verbose] - state: type=Mini::Test input="1" stream=0x603000cadc98 offsets=0/0/1 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="1" stream=0x603000cadc98 offsets=0/0/1 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="1" stream=0x7fb287106328 offsets=0/0/1 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="1" stream=0x7fb287106328 offsets=0/0/1 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 1
-[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x603000cadc98
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 1
+[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x7fb287106328
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000cadc98 offsets=2/2/2 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fb287106328 offsets=2/2/2 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 0
-[spicy-verbose]     resuming after insufficient input, now have 1 for stream 0x603000cadc98
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 1
-[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x603000cadc98
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 0
+[spicy-verbose]     resuming after insufficient input, now have 1 for stream 0x7fb287106328
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 1
+[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x7fb287106328
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000cadc98 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fb287106328 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 0
-[spicy-verbose]     resuming after insufficient input, now have 1 for stream 0x603000cadc98
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 1
-[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x603000cadc98
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 2
-[spicy-verbose]     resuming after insufficient input, now have 3 for stream 0x603000cadc98
-[spicy-verbose]     suspending to wait for more input for stream 0x603000cadc98, currently have 3
-[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x603000cadc98
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 0
+[spicy-verbose]     resuming after insufficient input, now have 1 for stream 0x7fb287106328
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 1
+[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x7fb287106328
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 2
+[spicy-verbose]     resuming after insufficient input, now have 3 for stream 0x7fb287106328
+[spicy-verbose]     suspending to wait for more input for stream 0x7fb287106328, currently have 3
+[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x7fb287106328
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000cadc98 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="" stream=0x603000cadc98 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x603000cadc98 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fb287106328 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="" stream=0x7fb287106328 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x7fb287106328 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 0
-[spicy-verbose]         resuming after insufficient input, now have 1 for stream 0x603000cadc98
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x603000cadc98
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 2
-[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x603000cadc98
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 0
+[spicy-verbose]         resuming after insufficient input, now have 1 for stream 0x7fb287106328
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x7fb287106328
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 2
+[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x7fb287106328
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x603000cadc98 offsets=11/11/11 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x7fb287106328 offsets=11/11/11 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 0
-[spicy-verbose]         resuming after insufficient input, now have 1 for stream 0x603000cadc98
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x603000cadc98
-[spicy-verbose]         suspending to wait for more input for stream 0x603000cadc98, currently have 2
-[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x603000cadc98
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 0
+[spicy-verbose]         resuming after insufficient input, now have 1 for stream 0x7fb287106328
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x7fb287106328
+[spicy-verbose]         suspending to wait for more input for stream 0x7fb287106328, currently have 2
+[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x7fb287106328
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'
 [spicy-verbose]     - setting field 'f4' to '[$x=b"90a", $y=b"bcd"]'
-[spicy-verbose] - state: type=Mini::Test input="12" stream=0x603000b25e68 offsets=0/0/2 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="12" stream=0x603000b25e68 offsets=0/0/2 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="12" stream=0x7fbf7d506908 offsets=0/0/2 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="12" stream=0x7fbf7d506908 offsets=0/0/2 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000b25e68 offsets=2/2/2 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fbf7d506908 offsets=2/2/2 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000b25e68, currently have 0
-[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x603000b25e68
+[spicy-verbose]     suspending to wait for more input for stream 0x7fbf7d506908, currently have 0
+[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x7fbf7d506908
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000b25e68 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fbf7d506908 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000b25e68, currently have 0
-[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x603000b25e68
-[spicy-verbose]     suspending to wait for more input for stream 0x603000b25e68, currently have 2
-[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x603000b25e68
+[spicy-verbose]     suspending to wait for more input for stream 0x7fbf7d506908, currently have 0
+[spicy-verbose]     resuming after insufficient input, now have 2 for stream 0x7fbf7d506908
+[spicy-verbose]     suspending to wait for more input for stream 0x7fbf7d506908, currently have 2
+[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x7fbf7d506908
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x603000b25e68 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="" stream=0x603000b25e68 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x603000b25e68 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7fbf7d506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="" stream=0x7fbf7d506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x7fbf7d506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000b25e68, currently have 0
-[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x603000b25e68
-[spicy-verbose]         suspending to wait for more input for stream 0x603000b25e68, currently have 2
-[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x603000b25e68
+[spicy-verbose]         suspending to wait for more input for stream 0x7fbf7d506908, currently have 0
+[spicy-verbose]         resuming after insufficient input, now have 2 for stream 0x7fbf7d506908
+[spicy-verbose]         suspending to wait for more input for stream 0x7fbf7d506908, currently have 2
+[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x7fbf7d506908
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x603000b25e68 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x7fbf7d506908 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000b25e68, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x603000b25e68
+[spicy-verbose]         suspending to wait for more input for stream 0x7fbf7d506908, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x7fbf7d506908
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'
 [spicy-verbose]     - setting field 'f4' to '[$x=b"90a", $y=b"bcd"]'
-[spicy-verbose] - state: type=Mini::Test input="123" stream=0x603000436a38 offsets=0/0/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="123" stream=0x603000436a38 offsets=0/0/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="123" stream=0x7fc1be4292e8 offsets=0/0/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="123" stream=0x7fc1be4292e8 offsets=0/0/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="3" stream=0x603000436a38 offsets=2/2/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="3" stream=0x7fc1be4292e8 offsets=2/2/3 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000436a38, currently have 1
-[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x603000436a38
+[spicy-verbose]     suspending to wait for more input for stream 0x7fc1be4292e8, currently have 1
+[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x7fc1be4292e8
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="56" stream=0x603000436a38 offsets=4/4/6 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="56" stream=0x7fc1be4292e8 offsets=4/4/6 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000436a38, currently have 2
-[spicy-verbose]     resuming after insufficient input, now have 5 for stream 0x603000436a38
+[spicy-verbose]     suspending to wait for more input for stream 0x7fc1be4292e8, currently have 2
+[spicy-verbose]     resuming after insufficient input, now have 5 for stream 0x7fc1be4292e8
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="9" stream=0x603000436a38 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="9" stream=0x603000436a38 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="9" stream=0x603000436a38 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="9" stream=0x7fc1be4292e8 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="9" stream=0x7fc1be4292e8 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="9" stream=0x7fc1be4292e8 offsets=8/8/9 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000436a38, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x603000436a38
+[spicy-verbose]         suspending to wait for more input for stream 0x7fc1be4292e8, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x7fc1be4292e8
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x603000436a38 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x7fc1be4292e8 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000436a38, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x603000436a38
+[spicy-verbose]         suspending to wait for more input for stream 0x7fc1be4292e8, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x7fc1be4292e8
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'
 [spicy-verbose]     - setting field 'f4' to '[$x=b"90a", $y=b"bcd"]'
-[spicy-verbose] - state: type=Mini::Test input="1234" stream=0x6030000c1b28 offsets=0/0/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="1234" stream=0x6030000c1b28 offsets=0/0/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="1234" stream=0x7f94d3506908 offsets=0/0/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="1234" stream=0x7f94d3506908 offsets=0/0/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="34" stream=0x6030000c1b28 offsets=2/2/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="34" stream=0x7f94d3506908 offsets=2/2/4 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x6030000c1b28 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7f94d3506908 offsets=4/4/4 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x6030000c1b28, currently have 0
-[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x6030000c1b28
+[spicy-verbose]     suspending to wait for more input for stream 0x7f94d3506908, currently have 0
+[spicy-verbose]     resuming after insufficient input, now have 4 for stream 0x7f94d3506908
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="" stream=0x6030000c1b28 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="" stream=0x6030000c1b28 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x6030000c1b28 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="" stream=0x7f94d3506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="" stream=0x7f94d3506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="" stream=0x7f94d3506908 offsets=8/8/8 chunks=0 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x6030000c1b28, currently have 0
-[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x6030000c1b28
+[spicy-verbose]         suspending to wait for more input for stream 0x7f94d3506908, currently have 0
+[spicy-verbose]         resuming after insufficient input, now have 4 for stream 0x7f94d3506908
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x6030000c1b28 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="b" stream=0x7f94d3506908 offsets=11/11/12 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x6030000c1b28, currently have 1
-[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x6030000c1b28
+[spicy-verbose]         suspending to wait for more input for stream 0x7f94d3506908, currently have 1
+[spicy-verbose]         resuming after insufficient input, now have 3 for stream 0x7f94d3506908
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'
 [spicy-verbose]     - setting field 'f4' to '[$x=b"90a", $y=b"bcd"]'
-[spicy-verbose] - state: type=Mini::Test input="12345" stream=0x603000330778 offsets=0/0/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub
-[spicy-verbose]   - state: type=Mini::Test input="12345" stream=0x603000330778 offsets=0/0/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - state: type=Mini::Test input="12345" stream=0x7fdd01106388 offsets=0/0/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose] - parsing production: Unit: Mini_Test -> f1 f2 f3 Mini_Sub_2
+[spicy-verbose]   - state: type=Mini::Test input="12345" stream=0x7fdd01106388 offsets=0/0/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f1  -> b"12" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f1' to '12'
-[spicy-verbose]   - state: type=Mini::Test input="345" stream=0x603000330778 offsets=2/2/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="345" stream=0x7fdd01106388 offsets=2/2/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f2  -> b"34" (bytes)
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f2' to '34'
-[spicy-verbose]   - state: type=Mini::Test input="5" stream=0x603000330778 offsets=4/4/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="5" stream=0x7fdd01106388 offsets=4/4/5 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]   - parsing production: Ctor: f3  -> b"5678" (bytes)
-[spicy-verbose]     suspending to wait for more input for stream 0x603000330778, currently have 1
-[spicy-verbose]     resuming after insufficient input, now have 6 for stream 0x603000330778
+[spicy-verbose]     suspending to wait for more input for stream 0x7fdd01106388, currently have 1
+[spicy-verbose]     resuming after insufficient input, now have 6 for stream 0x7fdd01106388
 [spicy-verbose]     - trimming input
 [spicy-verbose]   - setting field 'f3' to '5678'
-[spicy-verbose]   - state: type=Mini::Test input="90" stream=0x603000330778 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]   - parsing production: Resolved: Mini_Sub -> Mini_Sub
-[spicy-verbose]     - state: type=Mini::Test input="90" stream=0x603000330778 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
-[spicy-verbose]     - parsing production: Unit: Mini_Sub -> x y
-[spicy-verbose]       - state: type=Mini::Sub input="90" stream=0x603000330778 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - state: type=Mini::Test input="90" stream=0x7fdd01106388 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]   - parsing production: Resolved: Mini_Sub_2 -> Mini_Sub_2
+[spicy-verbose]     - state: type=Mini::Test input="90" stream=0x7fdd01106388 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]     - parsing production: Unit: Mini_Sub_2 -> x_2 y_2
+[spicy-verbose]       - state: type=Mini::Sub input="90" stream=0x7fdd01106388 offsets=8/8/10 chunks=1 frozen=no mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: x   -> b"90a" (bytes)
-[spicy-verbose]         suspending to wait for more input for stream 0x603000330778, currently have 2
-[spicy-verbose]         resuming after insufficient input, now have 6 for stream 0x603000330778
+[spicy-verbose]         suspending to wait for more input for stream 0x7fdd01106388, currently have 2
+[spicy-verbose]         resuming after insufficient input, now have 6 for stream 0x7fdd01106388
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'x' to '90a'
-[spicy-verbose]       - state: type=Mini::Sub input="bcd" stream=0x603000330778 offsets=11/11/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
+[spicy-verbose]       - state: type=Mini::Sub input="bcd" stream=0x7fdd01106388 offsets=11/11/14 chunks=1 frozen=yes mode=default trim=yes lah=n/a lah_token="n/a"
 [spicy-verbose]       - parsing production: Ctor: y   -> b"bcd" (bytes)
 [spicy-verbose]         - trimming input
 [spicy-verbose]       - setting field 'y' to 'bcd'

--- a/tests/spicy/types/unit/switch-nested.spicy
+++ b/tests/spicy/types/unit/switch-nested.spicy
@@ -1,0 +1,37 @@
+# @TEST-EXEC: spicyc %INPUT -j -o %INPUT.hlto
+# @TEST-EXEC: echo abc | spicy-driver %INPUT.hlto >output
+# @TEST-EXEC: echo xyz | spicy-driver %INPUT.hlto >>output
+# @TEST-EXEC: echo XYZ | spicy-driver %INPUT.hlto >>output
+# @TEST-EXEC: btest-diff output
+
+module Test;
+
+import spicy;
+
+public type Line = unit {
+  switch {
+     -> a  : A;
+     -> b  : B;
+  };
+
+  on %done { print self; }
+};
+
+type A = unit {
+  switch {
+    -> x : X;
+    -> y : Y;
+  };
+};
+
+type B = unit {
+  val: /abc/;
+};
+
+type X = unit {
+  val: /xyz/;
+};
+
+type Y = unit {
+  val: /XYZ/;
+};


### PR DESCRIPTION
With nested productions, we could end up generating colissions.

Closes #531.