### PR TITLE
Add some missing operator<< to runtime library.

### DIFF
--- a/hilti/runtime/include/types/optional.h
+++ b/hilti/runtime/include/types/optional.h
@@ -75,3 +75,14 @@ inline std::string detail::to_string_for_print<std::optional<std::string_view>>(
 }
 
 } // namespace hilti::rt
+
+namespace std {
+
+// Provide operator<< overload for optionals that have a custom HILTI-side to_string() conversion.
+template<typename T>
+inline auto operator<<(std::ostream& out, const std::optional<T>& x) -> decltype(::hilti::rt::detail::adl::to_string(x, ::hilti::rt::detail::adl::tag()), out) {
+    out << ::hilti::rt::to_string(x);
+    return out;
+}
+
+} // namespace std

--- a/hilti/runtime/include/types/port.h
+++ b/hilti/runtime/include/types/port.h
@@ -78,10 +78,10 @@ inline std::ostream& operator<<(std::ostream& out, const Protocol& x) {
     out << to_string(x);
     return out;
 }
+
 inline std::ostream& operator<<(std::ostream& out, const Port& x) {
     out << to_string(x);
     return out;
 }
-
 
 } // namespace hilti::rt

--- a/hilti/runtime/src/tests/optional.cc
+++ b/hilti/runtime/src/tests/optional.cc
@@ -27,7 +27,7 @@ TEST_CASE("value") {
         CHECK_EQ(v, 0);
 
         v += 42;
-        CHECK_EQ(o, 42);
+        CHECK_EQ(*o, 42);
     }
 }
 
@@ -35,13 +35,13 @@ TEST_CASE("valueOrInit") {
     SUBCASE("explicit default") {
         auto o = std::optional<int8_t>();
         CHECK_EQ(optional::valueOrInit(o, int8_t(47)), 47);
-        CHECK_EQ(o, 47);
+        CHECK_EQ(*o, 47);
     }
 
     SUBCASE("implicit default") {
         auto o = std::optional<int8_t>();
         CHECK_EQ(optional::valueOrInit(o), 0);
-        CHECK_EQ(o, 0);
+        CHECK_EQ(*o, 0);
     }
 }
 

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -5,6 +5,7 @@
 #include <tuple>
 
 #include <hilti/rt/doctest.h>
+#include <hilti/rt/extension-points.h>
 #include <hilti/rt/libhilti.h>
 #include <hilti/rt/types/address.h>
 #include <hilti/rt/types/bool.h>
@@ -14,6 +15,7 @@
 #include <hilti/rt/types/interval.h>
 #include <hilti/rt/types/map.h>
 #include <hilti/rt/types/null.h>
+#include <hilti/rt/types/optional.h>
 #include <hilti/rt/types/port.h>
 #include <hilti/rt/types/regexp.h>
 #include <hilti/rt/types/set.h>
@@ -145,6 +147,16 @@ TEST_CASE("optional") {
     CHECK_EQ(to_string_for_print(std::optional<std::string>()), "(not set)");
     CHECK_EQ(to_string_for_print(std::optional<std::string_view>("abc")), "abc");
     CHECK_EQ(to_string_for_print(std::optional<std::string_view>()), "(not set)");
+
+    std::optional<Port> port1{"123/tcp"};
+    std::optional<Port> port2{};
+
+    CHECK_EQ(to_string(port1), "123/tcp");
+    CHECK_EQ(to_string(port2), "(not set)");
+
+    std::stringstream x;
+    x << port1 << " " << port2;
+    CHECK_EQ(x.str(), "123/tcp (not set)");
 }
 
 TEST_CASE("Interval") {

--- a/spicy/runtime/include/parsed-unit.h
+++ b/spicy/runtime/include/parsed-unit.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cassert>
+#include <string>
 
 #include <hilti/rt/type-info.h>
 #include <hilti/rt/types/reference.h>
@@ -71,4 +72,12 @@ private:
     const void* _ptr = nullptr;
 };
 
+} // namespace spicy::rt
+
+namespace hilti::rt::detail::adl {
+inline std::string to_string(const ::spicy::rt::ParsedUnit& u, adl::tag /*unused*/) { return "<parsed unit>"; };
+} // namespace hilti::rt::detail::adl
+
+namespace spicy::rt {
+inline std::ostream& operator<<(std::ostream& out, const ParsedUnit& u) { return out << hilti::rt::to_string(u); }
 } // namespace spicy::rt

--- a/spicy/runtime/src/tests/parsed-unit.cc
+++ b/spicy/runtime/src/tests/parsed-unit.cc
@@ -66,4 +66,16 @@ TEST_CASE("value") {
         CHECK_EQ(p.value(), type_info::Value(ref.get(), &type_info, p));
     }
 }
+
+TEST_CASE("to_string") {
+    ParsedUnit p;
+
+    CHECK_EQ(to_string(p), "<parsed unit>");
+
+    std::stringstream x;
+    x << p;
+    CHECK_EQ(x.str(), "<parsed unit>");
+
+}
+
 TEST_SUITE_END();

--- a/tests/Baseline/spicy.rt.debug-trace/.stderr
+++ b/tests/Baseline/spicy.rt.debug-trace/.stderr
@@ -1,0 +1,57 @@
+[hilti-trace] : Mini::Test::__parser = [$name="Mini::Test", $parse1=Mini::Test::parse1, $parse2=Mini::Test::parse2, $parse3=Mini::Test::parse3, $type_info=typeinfo(Mini::Test), $description="", $mime_types=vector(), $ports=vector()]; 
+[hilti-trace] : spicy_rt::registerParser(Mini::Test::__parser, Null); 
+[hilti-trace] : local auto unit = value_ref(default<Mini::Test>())value_ref(default<Mini::Test>()); 
+[hilti-trace] : spicy_rt::initializeParsedUnit(gunit, unit, typeinfo(Mini::Test)); 
+[hilti-trace] : local view<stream> ncur = cur ? (*cur) : cast<view<stream>>((*data)); 
+[hilti-trace] : local int<64> lahead = 0; 
+[hilti-trace] : local iterator<stream> lahead_end; 
+[hilti-trace] :  # Begin parsing production: Unit: Mini_Test -> f1 f2 
+[hilti-trace] : spicy_rt::printParserState("Mini::Test", data, ncur, lahead, lahead_end, "default", True); 
+[hilti-trace] : hilti::debug("spicy-verbose", "- parsing production: Unit: Mini_Test -> f1 f2"); 
+[hilti-trace] : hilti::debugIndent("spicy-verbose"); 
+[hilti-trace] : (ncur, lahead, lahead_end) = (*unit).__parse_stage1(data, ncur, True, lahead, lahead_end); 
+[hilti-trace] : try {     hilti::debug("spicy", "Mini::Test");     hilti::debugIndent("spicy");     (*self).__on_0x25_init();      if ( local auto filtered = spicy_rt::filter_init(self, __data, __cur); filtered ) {         local value_ref<stream> filtered_data = filtered;         (*self).__parse_Mini_Test_stage2(filtered_data, (*filtered_data), __trim, __lah, __lahe);         __cur = __cur.advance(|__cur|);          if ( __trim ) {             hilti::debug("spicy-verbose", "- trimming input");             (*__data).trim(begin(__cur));         }          return (__cur, __lah, __lahe);     }      return (*self).__parse_Mini_Test_stage2(__data, __cur, __trim, __lah, __lahe); } catch ( exception e ) {     (*self).__on_0x25_error();     spicy_rt::filter_disconnect(self);     throw; }  
+[hilti-trace] : hilti::debug("spicy", "Mini::Test"); 
+[hilti-trace] : hilti::debugIndent("spicy"); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:8:20-13:2: (*self).__on_0x25_init(); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:9:18: hilti::print(self, True); 
+[hilti-trace] :  if ( local auto filtered = spicy_rt::filter_init(self, __data, __cur); filtered ) {     local value_ref<stream> filtered_data = filtered;     (*self).__parse_Mini_Test_stage2(filtered_data, (*filtered_data), __trim, __lah, __lahe);     __cur = __cur.advance(|__cur|);      if ( __trim ) {         hilti::debug("spicy-verbose", "- trimming input");         (*__data).trim(begin(__cur));     }      return (__cur, __lah, __lahe); }  
+[hilti-trace] : return (*self).__parse_Mini_Test_stage2(__data, __cur, __trim, __lah, __lahe); 
+[hilti-trace] :  # Begin parsing production: Variable: f1  -> uint<32> 
+[hilti-trace] : spicy_rt::printParserState("Mini::Test", __data, __cur, __lah, __lahe, "default", __trim); 
+[hilti-trace] : hilti::debug("spicy-verbose", "- parsing production: Variable: f1  -> uint<32>"); 
+[hilti-trace] : hilti::debugIndent("spicy-verbose"); 
+[hilti-trace] : spicy_rt::waitForInput(__data, __cur, 4, "expecting 4 bytes for unpacking value", "/Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:10:9", (*self).__filters); 
+[hilti-trace] : ((*self).f1, __cur) = (*unpack<uint<32>>((__cur, hilti::ByteOrder::Network))); 
+[hilti-trace] :  if ( __trim ) {     hilti::debug("spicy-verbose", "- trimming input");     (*__data).trim(begin(__cur)); }  
+[hilti-trace] : hilti::debug("spicy-verbose", "- trimming input"); 
+[hilti-trace] : (*__data).trim(begin(__cur)); 
+[hilti-trace] : hilti::debugDedent("spicy-verbose"); 
+[hilti-trace] : # End parsing production: Variable: f1  -> uint<32>  
+[hilti-trace] : hilti::debug("spicy", "f1 = %s" % (*self).f1); 
+[hilti-trace] : hilti::debug("spicy-verbose", "- setting field 'f1' to '%s'" % (*self).f1); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:10:5: (*self).__on_f1((*self).f1); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:10:18: hilti::print((*self).f1, True); 
+[hilti-trace] :  # Begin parsing production: Variable: f2  -> uint<8> 
+[hilti-trace] : spicy_rt::printParserState("Mini::Test", __data, __cur, __lah, __lahe, "default", __trim); 
+[hilti-trace] : hilti::debug("spicy-verbose", "- parsing production: Variable: f2  -> uint<8>"); 
+[hilti-trace] : hilti::debugIndent("spicy-verbose"); 
+[hilti-trace] : spicy_rt::waitForInput(__data, __cur, 1, "expecting 1 bytes for unpacking value", "/Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:11:9", (*self).__filters); 
+[hilti-trace] : ((*self).f2, __cur) = (*unpack<uint<8>>((__cur, hilti::ByteOrder::Network))); 
+[hilti-trace] :  if ( __trim ) {     hilti::debug("spicy-verbose", "- trimming input");     (*__data).trim(begin(__cur)); }  
+[hilti-trace] : hilti::debug("spicy-verbose", "- trimming input"); 
+[hilti-trace] : (*__data).trim(begin(__cur)); 
+[hilti-trace] : hilti::debugDedent("spicy-verbose"); 
+[hilti-trace] : # End parsing production: Variable: f2  -> uint<8>  
+[hilti-trace] : hilti::debug("spicy", "f2 = %s" % (*self).f2); 
+[hilti-trace] : hilti::debug("spicy-verbose", "- setting field 'f2' to '%s'" % (*self).f2); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:11:5: (*self).__on_f2((*self).f2); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:11:18: hilti::print((*self).f2, True); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:8:20-13:2: (*self).__on_0x25_done(); 
+[hilti-trace] /Users/robin/work/spicy/topic2/tests/.tmp/spicy.rt.debug-trace/debug-trace.spicy:12:18: hilti::print(self, True); 
+[hilti-trace] : spicy_rt::filter_disconnect(self); 
+[hilti-trace] : hilti::debugDedent("spicy"); 
+[hilti-trace] : return (__cur, __lah, __lahe); 
+[hilti-trace] : hilti::debugDedent("spicy-verbose"); 
+[hilti-trace] : # End parsing production: Unit: Mini_Test -> f1 f2  
+[hilti-trace] : return ncur; 

--- a/tests/spicy/rt/debug-trace.spicy
+++ b/tests/spicy/rt/debug-trace.spicy
@@ -1,0 +1,13 @@
+# @TEST-EXEC: ${SCRIPTS}/printf '\x00\x00\x27\x10\x2a' | HILTI_DEBUG=hilti-trace spicy-driver -X trace -d %INPUT >output
+# @TEST-EXEC: btest-diff .stderr
+
+module Mini;
+
+import spicy;
+
+public type Test = unit {
+    on %init   { print self; }
+    f1: uint32 { print self.f1; }
+    f2: uint8  { print self.f2; }
+    on %done   { print self; }
+};


### PR DESCRIPTION
This now lets "-X trace" work for Spocy parsers.

Closes #159.