### PR TITLE
Optionally precompile libhilti.h.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ gcc9_ubuntu_release_no_jit_task:
     - git fetch --tags
     - git submodule update --recursive --init
 
-  configure_script:      ./ci/run-ci -b build configure release --cxx-compiler g++-9 --disable-jit
+  configure_script:      ./ci/run-ci -b build configure release --cxx-compiler g++-9 --disable-jit --disable-precompiled-headers
   build_script:          ./ci/run-ci -b build build
   install_script:        ./ci/run-ci -b build install
   cleanup_script:        ./ci/run-ci -b build cleanup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if ( USE_SANITIZERS )
    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${sanitizer_ld_flags}")
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${sanitizer_ld_flags}")
    set(EXTRA_LD_FLAGS "${EXTRA_LD_FLAGS} ${sanitizer_ld_flags}")
+
+   set(HILTI_DEV_PRECOMPILE_HEADERS "no")
 else ()
    set(HILTI_HAVE_SANITIZER "no" CACHE BOOL "Using sanitizer")
 endif()
@@ -205,6 +207,7 @@ enable_testing()
 
 add_subdirectory(hilti)
 add_subdirectory(spicy)
+add_subdirectory(scripts)
 
 if ( HAVE_ZEEK_PLUGIN )
     add_subdirectory(zeek)
@@ -268,6 +271,7 @@ message(
     "\nC++ sys include dirs:  ${CXX_SYSTEM_INCLUDE_DIRS}"
     "\nClang gcc tolchain:    ${CLANG_GCC_INSTALLATION}"
     "\nWarnings are errors:   ${USE_WERROR}"
+    "\nPrecompile headers:    ${HILTI_DEV_PRECOMPILE_HEADERS}"
     "\n"
     "\nZeek found:            ${HAVE_ZEEK}"
     "\nZeek version:          ${ZEEK_VERSION} (${ZEEK_VERSION_NUMBER})"

--- a/ci/run-ci
+++ b/ci/run-ci
@@ -45,13 +45,14 @@ Global options:
 
 Configure options:
 
-    --clang-format <path>    Path to clang-format to use (default: found in PATH)
-    --clang-tidy <path>      Path to clang-tidy to use   (default: found in PATH)
-    --cxx-compiler <path>    Path to C++ compiler to use (default: found by cmake)
-    --disable-jit            Do not compile in JIT support
-    --rpath <path>           Additional rpaths to use; will end up in LD_LIBRARY_PATH (default: none)
-    --with-zeek <path>       Path to Zeek installation to use (default: none)
-    --zeek-ld-preload <path> LD_PRELOAD library for Zeek tests (no default; needed for ASAN builds to load runtime)
+    --clang-format <path>          Path to clang-format to use (default: found in PATH)
+    --clang-tidy <path>            Path to clang-tidy to use   (default: found in PATH)
+    --cxx-compiler <path>          Path to C++ compiler to use (default: found by cmake)
+    --disable-jit                  Do not compile in support for JIT compilation
+    --disable-precompiled-headers  Disable use of precompiled headers for developer tests
+    --rpath <path>                 Additional rpaths to use; will end up in LD_LIBRARY_PATH (default: none)
+    --with-zeek <path>             Path to Zeek installation to use (default: none)
+    --zeek-ld-preload <path>       LD_PRELOAD library for Zeek tests (no default; needed for ASAN builds to load runtime)
 
 EOF
 
@@ -156,6 +157,11 @@ function run_configure {
 
             --disable-jit)
                 configure="${configure} --disable-jit"
+                shift 1;
+                ;;
+
+            --disable-precompiled-headers)
+                configure="${configure} --disable-precompiled-headers"
                 shift 1;
                 ;;
 

--- a/configure
+++ b/configure
@@ -23,6 +23,7 @@ cmake_install_prefix="/usr/local"
 cmake_llvm_root=""
 cmake_use_ccache="no"
 cmake_use_gold="yes"
+cmake_use_precompiled_headers="yes"
 cmake_use_sanitizers=""
 cmake_use_werror="false"
 cmake_zeek_have_jit="yes"
@@ -63,6 +64,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-jit                      Do not compile in support for JIT compilation
     --disable-jit-for-zeek             Do not compile support for JIT compilation into Zeek plugin
     --disable-gold                     On Linux, do not try to use the gold linker
+    --disable-precompiled-headers      Disable use of precompiled headers for developer tests
     --disable-zeek-plugin-install      Do not copy Zeek plugin into Zeek plugin path on install
     --enable-ccache                    Build using the compiler cache cache if in PATH [default: ${cmake_use_ccache}]
     --enable-debug                     Compile debug version (same as --build-type=Debug) [default: off]
@@ -122,6 +124,7 @@ while [ $# -ne 0 ]; do
         --disable-gold)                    cmake_use_gold="no";;
         --disable-jit)                     cmake_hilti_have_jit="no";;
         --disable-jit-for-zeek)            cmake_zeek_have_jit="no";;
+        --disable-precompiled-headers)     cmake_use_precompiled_headers="no";;
         --disable-zeek-plugin-install)     cmake_zeek_install_plugin="no";;
         --enable-ccache)                   cmake_use_ccache="yes";;
         --enable-debug)                    cmake_build_type="Debug";;
@@ -179,6 +182,7 @@ append_cache_entry LLVM_ROOT                    PATH   "${cmake_llvm_root}"
 append_cache_entry USE_CCACHE                   BOOL   "${cmake_use_ccache}"
 append_cache_entry USE_GOLD                     BOOL   "${cmake_use_gold}"
 append_cache_entry USE_SANITIZERS               STRING "${cmake_use_sanitizers}"
+append_cache_entry HILTI_DEV_PRECOMPILE_HEADERS BOOL   "${cmake_use_precompiled_headers}"
 append_cache_entry USE_WERROR                   BOOL   "${cmake_use_werror}"
 append_cache_entry ZEEK_ROOT_DIR                PATH   "${cmake_zeek_root_dir}"
 append_cache_entry CPACK_BINARY_STGZ            BOOL   "OFF"

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -9,3 +9,23 @@ if ( HAVE_TOOLCHAIN )
 else ()
     add_custom_target(hilti-tests DEPENDS hilti-rt-tests hilti-rt-configuration-tests)
 endif ()
+
+option("HILTI_DEV_PRECOMPILE_HEADERS" "Precompile headers for developer tests" ON)
+
+if (${HILTI_DEV_PRECOMPILE_HEADERS} AND TARGET hilti-config)
+    # Precompile libhilti for use in JIT during development.
+    #
+    # We only use precompiled headers during JIT, but e.g., not to during
+    # compilation of Spicy itself. This gives us the benefits of JIT without
+    # e.g., making it harder for ccache to work during development. It also
+    # allows us to punt on some trickier cleanups of header files.
+    add_custom_command(
+        OUTPUT ${CMAKE_BINARY_DIR}/cache/spicy/precompiled_libhilti.h
+        COMMAND
+            ${CMAKE_COMMAND} -E env SPICY_CACHE=${CMAKE_BINARY_DIR}/cache/spicy
+                ${CMAKE_SOURCE_DIR}/scripts/precompile-headers.sh --hilti-config $<TARGET_FILE:hilti-config>
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include/libhilti.h hilti-config)
+    add_custom_target(precompiled-headers
+        ALL
+        DEPENDS ${CMAKE_BINARY_DIR}/cache/spicy/precompiled_libhilti.h)
+endif ()

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -143,8 +143,8 @@ if ( APPLE )
     set(addl_cxx_flags "${cxx_flags} -isysroot ${CMAKE_OSX_SYSROOT}")
 endif ()
 
-set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG   "-std=c++17 -g ${addl_cxx_flags} ${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE "-std=c++17 -g -O3 -DNDEBUG ${addl_cxx_flags} ${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG   "-fPIC -std=c++17 -g ${addl_cxx_flags} ${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE "-fPIC -std=c++17 -g -O3 -DNDEBUG ${addl_cxx_flags} ${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 # Libraries
 string(REPLACE "-l" "" threadslib "${CMAKE_THREAD_LIBS_INIT}")

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -40,6 +40,8 @@ void __internal_error(const std::string& s);
 
 namespace hilti {
 
+struct Configuration;
+
 /**
  * Helper macro to mark variables that are intentionally unused. This
  * silences the compiler warning. From
@@ -659,6 +661,14 @@ constexpr auto to_string(Enum value, const Value<Enum> (&values)[Size]) {
 };
 
 } // namespace enum_
+
+/** Computes path to directory for cached artifacts
+ *
+ * @param configuration the configuration to use
+ * @return a valid path to the directory or nothing
+ * \note While the returned path is valid, it might not exist yet.
+ */
+std::optional<hilti::rt::filesystem::path> cacheDirectory(const hilti::Configuration& configuration);
 
 } // namespace util
 

--- a/hilti/toolchain/src/compiler/clang.cc
+++ b/hilti/toolchain/src/compiler/clang.cc
@@ -668,9 +668,6 @@ std::unique_ptr<clang::CompilerInvocation> ClangJIT::Implementation::createInvoc
     // FIXME: Find a cleaner way to force the driver into restricted modes.
     args.emplace_back("-fsyntax-only");
 
-    // Compile position-independent code so we can use the code in a shared library later.
-    args.emplace_back("-fPIC");
-
     std::vector<const char*> cargs = util::transform(args, [](auto& s) -> const char* { return s.c_str(); });
     std::unique_ptr<clang::driver::Compilation> C(driver->BuildCompilation(cargs));
     if ( ! C )

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -10,6 +10,27 @@ using namespace hilti;
 const auto flatten = util::flattenParts;
 const auto prefix = util::prefixParts;
 
+namespace {
+std::optional<hilti::rt::filesystem::path> precompiled_libhilti(const Configuration& configuration, bool debug) {
+    // We disable use of precompiled headers for sanitizers builds since the
+    // sanitizer flags are not exposed on the config level.
+    //
+    // TODO(bbannier): Allow using of precompiled headers for sanitizer builds.
+#ifdef HILTI_HAVE_SANITIZER
+    return {};
+#endif
+
+    if ( auto&& cache = util::cacheDirectory(configuration) ) {
+        const rt::filesystem::path file_name = rt::fmt("precompiled_libhilti%s.h.pch", (debug ? "_debug" : ""));
+
+        if ( auto pch = (*cache) / file_name; rt::filesystem::exists(pch) )
+            return pch.replace_extension();
+    }
+
+    return {};
+}
+} // namespace
+
 hilti::Configuration::Configuration() { initLocation(util::currentExecutable().native()); }
 
 void hilti::Configuration::initLocation(bool use_build_directory) { init(use_build_directory); }
@@ -67,8 +88,14 @@ void Configuration::init(bool use_build_directory) {
     runtime_cxx_flags_debug = flatten({prefix("${HILTI_CONFIG_RUNTIME_INCLUDE_DIRS}", "-I", installation_tag),
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});
 
+    if ( auto libhilti_pch = precompiled_libhilti(*this, true) )
+        runtime_cxx_flags_debug.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
+
     runtime_cxx_flags_release = flatten({prefix("${HILTI_CONFIG_RUNTIME_INCLUDE_DIRS}", "-I", installation_tag),
                                          prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag)});
+
+    if ( auto libhilti_pch = precompiled_libhilti(*this, false) )
+        runtime_cxx_flags_release.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
 
     runtime_ld_flags_debug =
         flatten({prefix("${HILTI_CONFIG_RUNTIME_LIBRARY_DIRS_DEBUG}", "-L", installation_tag),

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,0 +1,3 @@
+install(PROGRAMS precompile-headers.sh
+        RENAME spicy-precompile-headers
+        TYPE BIN)

--- a/scripts/precompile-headers.sh
+++ b/scripts/precompile-headers.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+while [ $# -ne 0 ]; do
+    case "$1" in
+        --hilti-config) HILTI_CONFIG=$2; shift 2;;
+    esac
+done
+
+if [ -z "${HILTI_CONFIG+x}" ]; then
+    BIN=$(dirname "$0")/
+    HILTI_CONFIG=${BIN}/hilti-config
+fi
+
+if [ ! -x "${HILTI_CONFIG}" ]; then
+    echo "cannot determine path 'hilti-config'"
+    exit 1
+fi
+
+for flag in $(${HILTI_CONFIG} --cxxflags); do
+    if ! echo "${flag}" | grep -q '^-I'; then
+        continue
+    fi
+    dir=${flag#??}
+    if [ -e "${dir}"/hilti/rt/libhilti.h ]; then
+        LIBHILTI=${dir}/hilti/rt/libhilti.h
+    fi
+done
+
+if [ -z "${LIBHILTI+x}" ]; then
+    echo "Error: could not determine location of libhilti.h"
+    exit 1
+fi
+
+VERSION=$(${HILTI_CONFIG} --version | cut -d ' ' -f1)
+
+# The cache is read from the environment variable `SPICY_CACHE`
+# if set; else a patch under the user's home directory is used.
+CACHE=${SPICY_CACHE:-$HOME/.cache/spicy/${VERSION}}
+
+echo "Clearing cache directory $CACHE"
+rm -rf "${CACHE}"
+mkdir -p "${CACHE}"
+
+# NOTE: The compiler invocation here should be kept in sync
+# with what we do in `hilti/runtime/CMakeLists.txt`.
+cp "${LIBHILTI}" "${CACHE}/precompiled_libhilti_debug.h"
+echo "Creating ${CACHE}/precompiled_libhilti_debug.h.pch"
+$("${HILTI_CONFIG}" --cxx --cxxflags --debug) -x c++-header "${LIBHILTI}" -o "${CACHE}/precompiled_libhilti_debug.h.pch"
+
+cp "${LIBHILTI}" "${CACHE}/precompiled_libhilti.h"
+echo "Creating ${CACHE}/precompiled_libhilti.h.pch"
+$("${HILTI_CONFIG}" --cxx --cxxflags) -x c++-header "${LIBHILTI}" -o "${CACHE}/precompiled_libhilti.h.pch"

--- a/spicy/runtime/include/global-state.h
+++ b/spicy/runtime/include/global-state.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This patch adds precompilation for libhilti.h. This header is included
in all files during JIT, and precompiling it can for individual files
reduce JIT time by up to 30%.

In this patch we enable use of the precompiled header only during JIT,
but e.g., not when building Spicy targets. This allows us to profit from
faster JIT while still making efficient use of e.g., ccache.
Additionally, this approach allows us to punt on fixing a number of
issues in header files which get exposed during JIT (JIT artifacts are
not affected at the moment).

The original goal was to precompile lihilti.h before installation which
is not reached. In general, it seems that precompiled headers are not
intended to be moved after creation. This poses a challenge when the
header gets installed: while we could in principle generate the
precompiled header at the final location during install time, this seems
not reliably possible when generating packages which can be expanded in
arbitrary locations.