### PR TITLE
Fix "foreach" inside a unit hook.

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/unit-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/unit-builder.cc
@@ -124,14 +124,10 @@ struct FieldBuilder : public hilti::visitor::PreOrder<void, FieldBuilder> {
     }
 
     void operator()(const spicy::type::unit::item::UnitHook& h, const position_t /* p */) {
-        auto addHookImplementation = [&](const auto& hook, auto /* foreach */) {
-            if ( auto hook_impl =
-                     cg->compileHook(unit, ID(*unit.typeID(), h.id()), {}, false, h.hook().isDebug(),
-                                     h.hook().type().parameters(), hook.body(), hook.priority(), hook.meta()) )
-                cg->addDeclaration(*hook_impl);
-        };
-
-        addHookImplementation(h.hook(), AttributeSet::find(h.hook().attributes(), "foreach"));
+        auto hook = h.hook();
+        if ( auto hook_impl = cg->compileHook(unit, ID(*unit.typeID(), h.id()), {}, hook.isForEach(), hook.isDebug(),
+                                              hook.type().parameters(), hook.body(), hook.priority(), h.meta()) )
+            cg->addDeclaration(*hook_impl);
     }
 };
 

--- a/tests/spicy/types/vector/parse-size.spicy
+++ b/tests/spicy/types/vector/parse-size.spicy
@@ -9,10 +9,11 @@ const DASHES = b"---\n";
 public type Test = unit {
     on %init { print self; }
 
-    lines: Item[3] foreach { print "item: %s" % $$; }
+    lines: Item[3];
     dashes: DASHES;
     last: LINE;
 
+    on lines foreach { print "item: %s" % $$; }
     on %done { print self; }
     };
 


### PR DESCRIPTION
Two issues:
    1. The "foreach" attribute wasn't passed on.
    2. The '$$' lookup didn't work inside a non-inline hook.

Closes #583.