### PR TITLE
Fix "'_debug’ was not declared in this scope" build error

### DIFF
--- a/zeek/plugin/include/packet-analyzer.h
+++ b/zeek/plugin/include/packet-analyzer.h
@@ -41,7 +41,7 @@ public:
      *
      * @param msg message to record
      */
-    void DebugMsg(const std::string_view& msg) { _debug(msg); }
+    void DebugMsg(const std::string_view& msg) { debug(msg); }
 
 protected:
     // Overridden from driver::ParsingState.


### PR DESCRIPTION
Without this little fix I'm getting the following on my machine (Fedora 33, gcc 10.2.1):
```
[ 88%] Building CXX object zeek/plugin/CMakeFiles/_Zeek-Spicy.linux-x86_64.dir/src/plugin.cc.o
In file included from /home/christian/devel/zeek/spicy/zeek/plugin/src/plugin.cc:20:
/home/christian/devel/zeek/spicy/zeek/plugin/include/zeek-spicy/packet-analyzer.h: In member function ‘void spicy::zeek::rt::PacketState::DebugMsg(const string_view&)’:
/home/christian/devel/zeek/spicy/zeek/plugin/include/zeek-spicy/packet-analyzer.h:44:50: error: ‘_debug’ was not declared in this scope; did you mean ‘debug’?
   44 |     void DebugMsg(const std::string_view& msg) { _debug(msg); }
      |                                                  ^~~~~~
      |                                                  debug
make[3]: *** [zeek/plugin/CMakeFiles/_Zeek-Spicy.linux-x86_64.dir/build.make:152: zeek/plugin/CMakeFiles/_Zeek-Spicy.linux-x86_64.dir/src/plugin.cc.o] Error 1
```