### PR TITLE
Add additional tuple constructor expression.

### DIFF
--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -464,6 +464,7 @@ Tuples are heterogeneous containers of a fixed, ordered set of types.
 .. rubric:: Constants
 
 - ``(1, "string", True)``, ``(1, )``, ``()``
+- ``tuple(1, "string", True)``, ``tuple(1)``, ``tuple()``
 
 .. include:: /autogen/types/tuple.rst
 

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -29,8 +29,8 @@ namespace spicy { namespace detail { class Parser; } }
 %verbose
 
 %glr-parser
-%expect 87
-%expect-rr 139
+%expect 88
+%expect-rr 141
 
 %union {}
 %{
@@ -956,6 +956,7 @@ const_uint    : CUINTEGER                        { $$ = $1; }
               | '+' CUINTEGER                    { $$ = $2; }
 
 tuple         : '(' opt_tuple_elems1 ')'         { $$ = hilti::ctor::Tuple(std::move($2), __loc__); }
+              | TUPLE '(' opt_exprs ')'          { $$ = hilti::ctor::Tuple(std::move($3), __loc__); }
 
 opt_tuple_elems1
               : tuple_elem ',' opt_tuple_elems2  { $$ = std::vector<hilti::Expression>{std::move($1)}; $$.insert($$.end(), $3.begin(), $3.end()); }

--- a/tests/spicy/types/tuple/operators.spicy
+++ b/tests/spicy/types/tuple/operators.spicy
@@ -6,8 +6,12 @@ module Test;
 
 global t = (1, 2, 3);
 global t2: tuple<uint64, uint64, uint64> = (1, 2, 3);
+global t3 = tuple(1, 2, 3);
 
 assert t == (1, 2, 3);
 assert t == t2;
+assert t == t3;
 assert (1.0, 2.0, 3.0) == (1, 2, 3);
 assert t[1] == 2;
+assert tuple(1) == (1, );
+assert tuple() == ();


### PR DESCRIPTION
In Spicy, `tuple(1,2,3)` is now the same as `(1,2,3)`, and `tuple(1)` is the
same as `(1,)`. This is for consistency with other types, and to get around the
awkward syntax for single-element tuples.

Closes #389.