### PR TITLE
Fix padding handling when formatting nan and inf values.

### DIFF
--- a/hilti/runtime/src/tests/fmt.cc
+++ b/hilti/runtime/src/tests/fmt.cc
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
 
+#include <limits>
+
 #include <hilti/rt/doctest.h>
 #include <hilti/rt/fmt.h>
 
@@ -14,6 +16,15 @@ TEST_CASE("fmt") {
     // TODO(bbannier): Extend this suite with other test cases once we
     // have determined a proper subset we want to officially support.
     CHECK_EQ(fmt("%s", 123), "123");
+}
+
+TEST_CASE("padding") {
+    // This is regression test for https://github.com/zeek/spicy/issues/571.
+    CHECK_EQ(fmt("%.16d", 1), "0000000000000001");
+    CHECK_EQ(fmt("%.16d", 0.5), "00000000000000.5");
+    CHECK_EQ(fmt("%.16d", -0.5), "-0000000000000.5");
+    CHECK_EQ(fmt("%.16d", std::numeric_limits<double>::quiet_NaN()), "             nan");
+    CHECK_EQ(fmt("%.16d", std::numeric_limits<double>::infinity()), "             inf");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This patch bumps tinyformat to a version containing the upstream fix for
https://github.com/c42f/tinyformat/issues/76 (and the follow up fix
https://github.com/c42f/tinyformat/pull/80).

We also add a regression test.

Closes #571.