### PR TITLE
Add new vector methods resize/sub/at.

### DIFF
--- a/doc/autogen/types/vector.rst
+++ b/doc/autogen/types/vector.rst
@@ -6,6 +6,10 @@
     less than *i* elements a sufficient number of default-initialized
     elements is added to carry out the assignment.
 
+.. spicy:method:: vector::at vector at False <iterator> (i: uint<64>)
+
+    Returns an iterator referring to the element at vector index *i*.
+
 .. spicy:method:: vector::back vector back False <type~of~element> ()
 
     Returns the last element of the vector. It throws an exception if the
@@ -25,6 +29,22 @@
     Reserves space for at least *n* elements. This operation does not
     change the vector in any observable way but provides a hint about the
     size that will be needed.
+
+.. spicy:method:: vector::resize vector resize False void (n: uint<64>)
+
+    Resizes the vector to hold exactly *n* elements. If *n* is larger than
+    the current size, the new slots are filled with default values. If *n*
+    is smaller than the current size, the excessive elements are removed.
+
+.. spicy:method:: vector::sub vector sub False vector (begin: uint<64>, end: uint<64>)
+
+    Extracts a subsequence of vector elements spanning from index *begin*
+    to (but not including) index *end*.
+
+.. spicy:method:: vector::sub vector sub False vector (end: uint<64>)
+
+    Extracts a subsequence of vector elements spanning from the beginning
+    to (but not including) the index *end* as a new vector.
 
 .. rubric:: Operators
 

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -296,6 +296,53 @@ public:
         return V::back();
     }
 
+    /**
+     * Returns an iterator referring to a specific element.
+     *
+     * @param i index of element
+     * @throw `IndexError` if the *i* is out of range.
+     */
+    const_iterator iteratorAt(uint64_t i) const {
+        if ( i >= V::size() )
+            throw IndexError(fmt("vector index %" PRIu64 " out of range", i));
+
+        return const_iterator(static_cast<size_type>(i), _control);
+    }
+
+    /**
+     * Extracts a subsequence from the vector.
+     *
+     * @param from start index
+     * @param end end index (not including)
+     * @returns new vector with a copy of the range's elements
+     */
+    Vector<T> sub(uint64_t start, uint64_t end) const {
+        if ( end <= start || start >= V::size() )
+            return {};
+
+        if ( end >= V::size() )
+            end = V::size();
+
+        Vector<T> v;
+        std::copy(V::begin() + start, V::begin() + end, std::back_inserter(v));
+        return v;
+    }
+
+    /**
+     * Extraces a subsequence from the vector.
+     *
+     * @param end end index (not including)
+     * @returns new vector with a copy of the elements from the beginning to *end*
+     */
+    Vector<T> sub(uint64_t end) const {
+        if ( end >= V::size() )
+            end = V::size();
+
+        Vector<T> v;
+        std::copy(V::begin(), V::begin() + end, std::back_inserter(v));
+        return v;
+    }
+
     /** Replaces the contents of this `Vector` with another `Vector`.
      *
      * In contrast to assignments of `std::vector` iterators remain valid and
@@ -415,6 +462,7 @@ public:
     using V::pop_back;
     using V::push_back;
     using V::reserve;
+    using V::resize;
     using V::size;
 
     friend bool operator==(const Vector& a, const Vector& b) {

--- a/hilti/runtime/src/tests/vector.cc
+++ b/hilti/runtime/src/tests/vector.cc
@@ -88,6 +88,31 @@ TEST_CASE("assignment") {
     }
 }
 
+TEST_CASE("at") {
+        Vector<int> xs;
+        xs = Vector<int>({1, 2, 3, 4, 5});
+        CHECK_EQ(*xs.iteratorAt(1), 2);
+        CHECK_THROWS_WITH_AS(xs.iteratorAt(5), "vector index 5 out of range", const IndexError&);
+}
+
+TEST_CASE("sub") {
+    SUBCASE("range") {
+        auto xs = Vector<int>({1, 2, 3, 4, 5});
+        CHECK_EQ(xs.sub(1, 4), Vector<int>({2, 3, 4}));
+        CHECK_EQ(xs.sub(1, 10), Vector<int>({2, 3, 4, 5}));
+        CHECK_EQ(xs.sub(6, 10), Vector<int>({}));
+        CHECK_EQ(xs.sub(3, 1), Vector<int>({}));
+        CHECK_EQ(xs.sub(3, 3), Vector<int>({}));
+    }
+
+    SUBCASE("end") {
+        auto xs = Vector<int>({1, 2, 3, 4, 5});
+        CHECK_EQ(xs.sub(4), Vector<int>({1, 2, 3, 4}));
+        CHECK_EQ(xs.sub(10), Vector<int>({1, 2, 3, 4, 5}));
+        CHECK_EQ(xs.sub(0), Vector<int>({}));
+    }
+}
+
 TEST_CASE("make") {
     const auto fn = std::function<int(int)>([](auto&& x) { return x * 2; });
     const auto pred = std::function<bool(int)>([](auto&& x) { return x % 2 == 0; });

--- a/hilti/toolchain/include/ast/operator.h
+++ b/hilti/toolchain/include/ast/operator.h
@@ -108,6 +108,23 @@ inline auto constantElementType(unsigned int op, const char* doc = "<type of ele
     };
 }
 
+inline auto iteratorType(unsigned int op, bool const_, const char* doc = "<iterator>") {
+    return [=](const std::vector<Expression>& /* orig_ops */,
+               const std::vector<Expression>& resolved_ops) -> std::optional<Type> {
+        if ( resolved_ops.empty() )
+            return type::DocOnly(doc);
+
+        if ( op >= resolved_ops.size() )
+            logger().internalError(util::fmt("iteratorType(): index %d out of range, only %" PRIu64 " ops available", op,
+                                             resolved_ops.size()));
+
+        if ( type::isIterable(resolved_ops[op].type()) )
+            return resolved_ops[op].type().iteratorType(const_);
+
+        return {};
+    };
+}
+
 inline auto dereferencedType(unsigned int op, const char* doc = "<dereferenced type>", bool infer_const = true) {
     return [=](const std::vector<Expression>& /* orig_ops */,
                const std::vector<Expression>& resolved_ops) -> std::optional<Type> {

--- a/hilti/toolchain/include/ast/operators/vector.h
+++ b/hilti/toolchain/include/ast/operators/vector.h
@@ -112,6 +112,59 @@ needed.
     }
 END_METHOD
 
+BEGIN_METHOD(vector, Resize)
+    auto signature() const {
+        return Signature{.self = type::Vector(type::Wildcard()),
+                         .result = type::Void(),
+                         .id = "resize",
+                         .args = {{.id = "n", .type = type::constant(type::UnsignedInteger(64))}},
+                         .doc = R"(
+Resizes the vector to hold exactly *n* elements. If *n* is larger than the
+current size, the new slots are filled with default values. If *n* is smaller
+than the current size, the excessive elements are removed.
+)"};
+    }
+END_METHOD
+
+BEGIN_METHOD(vector, At)
+    auto signature() const {
+        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                         .result = operator_::iteratorType(0, true),
+                         .id = "at",
+                         .args = {{.id = "i", .type = type::UnsignedInteger(64)}},
+                         .doc = R"(
+Returns an iterator referring to the element at vector index *i*.
+)"};
+    }
+END_METHOD
+
+BEGIN_METHOD(vector, SubRange)
+    auto signature() const {
+        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                         .result = operator_::sameTypeAs(0, "vector<*>"),
+                         .id = "sub",
+                         .args = {{.id = "begin", .type = type::UnsignedInteger(64)},
+                                  {.id = "end", .type = type::UnsignedInteger(64)}},
+                         .doc = R"(
+Extracts a subsequence of vector elements spanning from index *begin*
+to (but not including) index *end*.
+)"};
+    }
+END_METHOD
+
+BEGIN_METHOD(vector, SubEnd)
+    auto signature() const {
+        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                         .result = operator_::sameTypeAs(0, "vector<*>"),
+                         .id = "sub",
+                         .args = {{.id = "end", .type = type::UnsignedInteger(64)}},
+                         .doc = R"(
+Extracts a subsequence of vector elements spanning from the beginning
+to (but not including) the index *end* as a new vector.
+)"};
+    }
+END_METHOD
+
 } // namespace operator_
 
 } // namespace hilti

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -930,6 +930,26 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
         return fmt("%s.reserve(%s)", self, args[0]);
     }
 
+    result_t operator()(const operator_::vector::Resize& n) {
+        auto [self, args] = methodArguments(n);
+        return fmt("%s.resize(%s)", self, args[0]);
+    }
+
+    result_t operator()(const operator_::vector::At& n) {
+        auto [self, args] = methodArguments(n);
+        return fmt("%s.iteratorAt(%s)", self, args[0]);
+    }
+
+    result_t operator()(const operator_::vector::SubRange& n) {
+        auto [self, args] = methodArguments(n);
+        return fmt("%s.sub(%s, %s)", self, args[0], args[1]);
+    }
+
+    result_t operator()(const operator_::vector::SubEnd& n) {
+        auto [self, args] = methodArguments(n);
+        return fmt("%s.sub(%s)", self, args[0]);
+    }
+
     // Weak reference
     result_t operator()(const operator_::weak_reference::Deref& n) { return fmt("(*%s)", op0(n)); }
     result_t operator()(const operator_::weak_reference::Equal& n) { return fmt("%s == %s", op0(n), op1(n)); }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -511,12 +511,11 @@ struct ProductionVisitor
                 auto __offsets = builder::member(state().self, "__offsets");
                 auto cur_offset = builder::memberCall(state().cur, "offset", {});
 
-                // Since the offset list is created empty make sure the
-                // element for the currrent field is present.
+                // Since the offset list is created empty resize the
+                // vector so that we can access the current field's index.
                 assert(field->index());
                 auto index = builder()->addTmp("index", builder::integer(*field->index()));
-                auto resize = builder()->addWhile(builder::lowerEqual(builder::size(__offsets), index));
-                resize->addMemberCall(__offsets, "push_back", {builder::null()});
+                builder()->addMemberCall(__offsets, "resize", {builder::sum(index, builder::integer(1))});
 
                 builder()->addAssign(builder::index(__offsets, *field->index()),
                                      builder::tuple({cur_offset, builder::optional(hilti::type::UnsignedInteger(64))}));

--- a/tests/hilti/types/vector/ops.hlt
+++ b/tests/hilti/types/vector/ops.hlt
@@ -27,6 +27,17 @@ v.reserve(20); # No visible change
 
 hilti::print(v);
 
+local v2 = vector("a", "b", "c", "d", "e");
+assert v2.sub(1, 3) == vector("b", "c");
+assert v2.sub(3) == vector("a", "b", "c");
+
+v2.resize(8);
+assert v2 == vector("a", "b", "c", "d", "e", "", "", "");
+v2.resize(3);
+assert v2 == vector("a", "b", "c");
+
+assert *v2.at(1) == "b";
+
 # Test const version.
 
 function void p(vector<uint<64>> v) {


### PR DESCRIPTION
Closes #584 and #535.

(Also uses new resize() method at one place in parser builder.)