### PR TITLE
Speed up the compiler

### DIFF
--- a/hilti/runtime/include/3rdparty/nlohmann
+++ b/hilti/runtime/include/3rdparty/nlohmann
@@ -1,1 +1,0 @@
-../../../../3rdparty/json/single_include/nlohmann

--- a/hilti/runtime/include/3rdparty/nlohmann/json.hpp
+++ b/hilti/runtime/include/3rdparty/nlohmann/json.hpp
@@ -1,0 +1,1 @@
+../../../../../3rdparty/json/single_include/nlohmann/json.hpp

--- a/hilti/runtime/include/3rdparty/nlohmann/json_fwd.hpp
+++ b/hilti/runtime/include/3rdparty/nlohmann/json_fwd.hpp
@@ -1,0 +1,1 @@
+../../../../../3rdparty/json/include/nlohmann/json_fwd.hpp

--- a/hilti/runtime/include/json-fwd.h
+++ b/hilti/runtime/include/json-fwd.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
+#elif defined(__GNUC__)
+// Note that clang #defines __GNUC__ as well.
+#pragma GCC diagnostic push
+#endif
+
+#include <hilti/rt/3rdparty/nlohmann/json_fwd.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCES
     src/ast/expressions
     src/ast/expressions/id.cc
     src/ast/location.cc
+    src/ast/meta.cc
     src/ast/module.cc
     src/ast/node.cc
     src/ast/node_ref.cc

--- a/hilti/toolchain/include/ast/attribute.h
+++ b/hilti/toolchain/include/ast/attribute.h
@@ -9,8 +9,8 @@
 #include <utility>
 #include <vector>
 
-#include <hilti/ast/ctors/string.h>
 #include <hilti/ast/ctors/integer.h>
+#include <hilti/ast/ctors/string.h>
 #include <hilti/ast/expression.h>
 #include <hilti/ast/expressions/ctor.h>
 #include <hilti/ast/node.h>
@@ -167,7 +167,12 @@ public:
     explicit AttributeSet(std::vector<Attribute> a, Meta m = Meta()) : NodeBase(nodes(std::move(a)), std::move(m)) {}
 
     /** Returns the set's attributes. */
-    std::vector<Attribute> attributes() const { return childs<Attribute>(0, -1); }
+    const auto& attributes() const {
+        if ( _cache.attributes.empty() )
+            _cache.attributes = childs<Attribute>(0, -1);
+
+        return _cache.attributes;
+    }
 
     /**
      * Retrieves an attribute with a given name from the set. If multiple
@@ -286,6 +291,8 @@ public:
             return false;
     }
 
+    void clearCache() { _cache.attributes.clear(); }
+
 private:
     /**
      * Constructs an empty set.
@@ -296,6 +303,10 @@ private:
      * @param m meta data to associate with the node
      */
     AttributeSet(Meta m = Meta()) : NodeBase({}, std::move(m)) {}
+
+    mutable struct {
+        std::vector<Attribute> attributes;
+    } _cache;
 };
 
 /**

--- a/hilti/toolchain/include/ast/ctor.api
+++ b/hilti/toolchain/include/ast/ctor.api
@@ -46,4 +46,7 @@ class Ctor(trait::isCtor) : trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/ctors/coerced.h
+++ b/hilti/toolchain/include/ast/ctors/coerced.h
@@ -15,8 +15,8 @@ class Coerced : public NodeBase, public hilti::trait::isCtor {
 public:
     Coerced(Ctor orig, Ctor new_, Meta m = Meta()) : NodeBase({std::move(orig), std::move(new_)}, std::move(m)) {}
 
-    auto originalCtor() const { return child<Ctor>(0); }
-    auto coercedCtor() const { return child<Ctor>(1); }
+    const auto& originalCtor() const { return child<Ctor>(0); }
+    const auto& coercedCtor() const { return child<Ctor>(1); }
 
     bool operator==(const Coerced& other) const {
         return originalCtor() == other.originalCtor() && coercedCtor() == other.coercedCtor();

--- a/hilti/toolchain/include/ast/ctors/enum.h
+++ b/hilti/toolchain/include/ast/ctors/enum.h
@@ -19,7 +19,7 @@ public:
     Enum(type::enum_::Label v, NodeRef td, Meta m = Meta())
         : NodeBase({std::move(v), node::none}, std::move(m)), _type_decl(std::move(td)) {}
 
-    auto value() const { return childs()[0].as<type::enum_::Label>(); }
+    const auto& value() const { return childs()[0].as<type::enum_::Label>(); }
 
     bool operator==(const Enum& other) const { return value() == other.value(); }
 

--- a/hilti/toolchain/include/ast/ctors/exception.h
+++ b/hilti/toolchain/include/ast/ctors/exception.h
@@ -16,7 +16,7 @@ class Exception : public NodeBase, public hilti::trait::isCtor {
 public:
     Exception(Type t, Expression msg, Meta m = Meta()) : NodeBase({std::move(t), std::move(msg)}, std::move(m)) {}
 
-    auto value() const { return child<Expression>(1); }
+    const auto& value() const { return child<Expression>(1); }
 
     bool operator==(const Exception& other) const { return type() == other.type() && value() == other.value(); }
 

--- a/hilti/toolchain/include/ast/ctors/regexp.h
+++ b/hilti/toolchain/include/ast/ctors/regexp.h
@@ -20,7 +20,7 @@ public:
     RegExp(std::vector<std::string> p, std::optional<AttributeSet> attrs = {}, Meta m = Meta())
         : NodeBase(nodes(std::move(attrs)), std::move(m)), _patterns(std::move(p)) {}
 
-    auto attributes() const { return childs()[0].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[0].tryReferenceAs<AttributeSet>(); }
     const auto& value() const { return _patterns; }
 
     auto isNoSub() const { return AttributeSet::find(attributes(), "&nosub"); }

--- a/hilti/toolchain/include/ast/declaration.api
+++ b/hilti/toolchain/include/ast/declaration.api
@@ -42,4 +42,7 @@ class Declaration(trait::isDeclaration) : trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/declarations/constant.h
+++ b/hilti/toolchain/include/ast/declarations/constant.h
@@ -23,7 +23,7 @@ public:
     Constant(ID id, hilti::Expression value, Linkage linkage = Linkage::Private, Meta m = Meta())
         : NodeBase({std::move(id), node::none, std::move(value)}, std::move(m)), _linkage(linkage) {}
 
-    auto value() const { return child<hilti::Expression>(2); }
+    const auto& value() const { return child<hilti::Expression>(2); }
 
     ::hilti::Type type() const {
         if ( auto t = childs()[1].tryAs<::hilti::Type>(); t && *t != type::unknown )

--- a/hilti/toolchain/include/ast/declarations/expression.h
+++ b/hilti/toolchain/include/ast/declarations/expression.h
@@ -22,7 +22,7 @@ public:
                Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(e), std::move(attrs)), std::move(m)), _linkage(linkage) {}
 
-    auto expression() const { return child<hilti::Expression>(1); }
+    const auto& expression() const { return child<hilti::Expression>(1); }
     auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
 
     bool operator==(const Expression& other) const { return id() == other.id() && expression() == other.expression(); }

--- a/hilti/toolchain/include/ast/declarations/expression.h
+++ b/hilti/toolchain/include/ast/declarations/expression.h
@@ -23,7 +23,7 @@ public:
         : NodeBase(nodes(std::move(id), std::move(e), std::move(attrs)), std::move(m)), _linkage(linkage) {}
 
     const auto& expression() const { return child<hilti::Expression>(1); }
-    auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[2].tryReferenceAs<AttributeSet>(); }
 
     bool operator==(const Expression& other) const { return id() == other.id() && expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/declarations/function.h
+++ b/hilti/toolchain/include/ast/declarations/function.h
@@ -18,7 +18,7 @@ public:
     Function(::hilti::Function function, Linkage linkage = Linkage::Private, Meta m = Meta())
         : NodeBase({std::move(function)}, std::move(m)), _linkage(linkage) {}
 
-    auto function() const { return child<::hilti::Function>(0); }
+    const auto& function() const { return child<::hilti::Function>(0); }
 
     bool operator==(const Function& other) const { return id() == other.id() && function() == other.function(); }
 

--- a/hilti/toolchain/include/ast/declarations/global-variable.h
+++ b/hilti/toolchain/include/ast/declarations/global-variable.h
@@ -33,7 +33,7 @@ public:
     GlobalVariable(ID id, hilti::Expression init, Linkage linkage = Linkage::Private, Meta m = Meta())
         : NodeBase(nodes(std::move(id), node::none, std::move(init)), std::move(m)), _linkage(linkage) {}
 
-    auto init() const { return childs()[2].tryAs<hilti::Expression>(); }
+    auto init() const { return childs()[2].tryReferenceAs<hilti::Expression>(); }
     auto typeArguments() const { return childs<hilti::Expression>(3, -1); }
 
     ::hilti::Type type() const {

--- a/hilti/toolchain/include/ast/declarations/local-variable.h
+++ b/hilti/toolchain/include/ast/declarations/local-variable.h
@@ -30,7 +30,7 @@ public:
     LocalVariable(ID id, hilti::Expression init, bool const_ = false, Meta m = Meta())
         : NodeBase(nodes(std::move(id), node::none, std::move(init)), std::move(m)), _const(const_) {}
 
-    auto init() const { return childs()[2].tryAs<hilti::Expression>(); }
+    auto init() const { return childs()[2].tryReferenceAs<hilti::Expression>(); }
     auto typeArguments() const { return childs<hilti::Expression>(3, -1); }
 
     ::hilti::Type type() const {

--- a/hilti/toolchain/include/ast/declarations/parameter.h
+++ b/hilti/toolchain/include/ast/declarations/parameter.h
@@ -56,7 +56,7 @@ public:
 
     auto type() const { return type::effectiveType(child<hilti::Type>(1)); }
 
-    auto default_() const { return childs()[2].tryAs<hilti::Expression>(); }
+    auto default_() const { return childs()[2].tryReferenceAs<hilti::Expression>(); }
     auto kind() const { return _kind; }
     auto isStructParameter() const { return _is_struct_param; }
 

--- a/hilti/toolchain/include/ast/declarations/property.h
+++ b/hilti/toolchain/include/ast/declarations/property.h
@@ -20,7 +20,7 @@ public:
     Property(ID id, hilti::Expression attr, Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(attr)), std::move(m)) {}
 
-    auto expression() const { return childs()[1].tryAs<hilti::Expression>(); }
+    auto expression() const { return childs()[1].tryReferenceAs<hilti::Expression>(); }
 
     bool operator==(const Property& other) const { return id() == other.id() && expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/declarations/type.h
+++ b/hilti/toolchain/include/ast/declarations/type.h
@@ -23,7 +23,7 @@ public:
         : NodeBase(nodes(std::move(id), std::move(type), std::move(attrs)), std::move(m)), _linkage(linkage) {}
 
     auto type() const { return type::effectiveType(child<hilti::Type>(1)); }
-    auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[2].tryReferenceAs<AttributeSet>(); }
 
     bool isOnHeap() const {
         if ( type::isOnHeap(type()) )

--- a/hilti/toolchain/include/ast/expression.api
+++ b/hilti/toolchain/include/ast/expression.api
@@ -43,4 +43,7 @@ class Expression(hilti::trait::isExpression) : hilti::trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/expressions/assign.h
+++ b/hilti/toolchain/include/ast/expressions/assign.h
@@ -15,8 +15,8 @@ public:
     Assign(Expression target, Expression src, Meta m = Meta())
         : NodeBase({std::move(target), std::move(src)}, std::move(m)) {}
 
-    auto target() const { return child<Expression>(0); }
-    auto source() const { return child<Expression>(1); }
+    const auto& target() const { return child<Expression>(0); }
+    const auto& source() const { return child<Expression>(1); }
 
     bool operator==(const Assign& other) const { return target() == other.target() && source() == other.source(); }
 

--- a/hilti/toolchain/include/ast/expressions/coerced.h
+++ b/hilti/toolchain/include/ast/expressions/coerced.h
@@ -14,7 +14,7 @@ class Coerced : public NodeBase, public trait::isExpression {
 public:
     Coerced(Expression e, Type t, Meta m = Meta()) : NodeBase({std::move(e), std::move(t)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const Coerced& other) const { return expression() == other.expression() && type() == other.type(); }
 

--- a/hilti/toolchain/include/ast/expressions/ctor.h
+++ b/hilti/toolchain/include/ast/expressions/ctor.h
@@ -15,7 +15,7 @@ class Ctor : public NodeBase, public trait::isExpression {
 public:
     Ctor(hilti::Ctor c, Meta m = Meta()) : NodeBase({std::move(c)}, std::move(m)) {}
 
-    auto ctor() const { return child<::hilti::Ctor>(0); }
+    const auto& ctor() const { return child<::hilti::Ctor>(0); }
 
     bool operator==(const Ctor& other) const { return ctor() == other.ctor(); }
 

--- a/hilti/toolchain/include/ast/expressions/deferred.h
+++ b/hilti/toolchain/include/ast/expressions/deferred.h
@@ -21,7 +21,7 @@ public:
     Deferred(Expression e, bool catch_exception, Meta m = Meta())
         : NodeBase({std::move(e)}, std::move(m)), _catch_exception(catch_exception) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
     bool catchException() const { return _catch_exception; }
 
     bool operator==(const Deferred& other) const { return expression() == other.expression(); }

--- a/hilti/toolchain/include/ast/expressions/grouping.h
+++ b/hilti/toolchain/include/ast/expressions/grouping.h
@@ -14,7 +14,7 @@ class Grouping : public NodeBase, public trait::isExpression {
 public:
     Grouping(Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const Grouping& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/expressions/id.h
+++ b/hilti/toolchain/include/ast/expressions/id.h
@@ -22,7 +22,7 @@ public:
         assert(_node && _node->isA<Declaration>());
     }
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto declaration() const {
         assert(_node);
         return _node->as<Declaration>();
@@ -58,7 +58,7 @@ class UnresolvedID : public NodeBase, hilti::trait::isExpression {
 public:
     UnresolvedID(ID id, Meta m = Meta()) : NodeBase({std::move(id)}, std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
 
     bool operator==(const UnresolvedID& other) const { return id() == other.id(); }
 

--- a/hilti/toolchain/include/ast/expressions/list-comprehension.h
+++ b/hilti/toolchain/include/ast/expressions/list-comprehension.h
@@ -20,9 +20,9 @@ public:
         _computeType();
     }
 
-    auto input() const { return child<Expression>(0); }
-    auto output() const { return child<Expression>(1); }
-    auto id() const { return child<ID>(2); }
+    const auto& input() const { return child<Expression>(0); }
+    const auto& output() const { return child<Expression>(1); }
+    const auto& id() const { return child<ID>(2); }
     auto condition() const { return childs()[3].tryAs<Expression>(); }
 
     /**
@@ -41,7 +41,7 @@ public:
     /** Implements `Expression` interface. */
     bool isTemporary() const { return true; }
     /** Implements `Expression` interface. */
-    auto type() const { return child<Type>(4); }
+    const auto& type() const { return child<Type>(4); }
 
     /** Implements `Expression` interface. */
     auto isConstant() const { return input().isConstant(); }

--- a/hilti/toolchain/include/ast/expressions/list-comprehension.h
+++ b/hilti/toolchain/include/ast/expressions/list-comprehension.h
@@ -29,7 +29,7 @@ public:
      * Returns the output expressions's scope. Note that the scope is shared
      * among any copies of an instance.
      */
-    std::shared_ptr<Scope> scope() const { return childs()[1].scope(); }
+    IntrusivePtr<Scope> scope() const { return childs()[1].scope(); }
 
     bool operator==(const ListComprehension& other) const {
         return input() == other.input() && output() == other.output() && id() == other.id() &&

--- a/hilti/toolchain/include/ast/expressions/list-comprehension.h
+++ b/hilti/toolchain/include/ast/expressions/list-comprehension.h
@@ -23,7 +23,7 @@ public:
     const auto& input() const { return child<Expression>(0); }
     const auto& output() const { return child<Expression>(1); }
     const auto& id() const { return child<ID>(2); }
-    auto condition() const { return childs()[3].tryAs<Expression>(); }
+    auto condition() const { return childs()[3].tryReferenceAs<Expression>(); }
 
     /**
      * Returns the output expressions's scope. Note that the scope is shared

--- a/hilti/toolchain/include/ast/expressions/logical-and.h
+++ b/hilti/toolchain/include/ast/expressions/logical-and.h
@@ -16,8 +16,8 @@ public:
     LogicalAnd(Expression op0, Expression op1, Meta m = Meta())
         : NodeBase({std::move(op0), std::move(op1)}, std::move(m)) {}
 
-    auto op0() const { return child<Expression>(0); }
-    auto op1() const { return child<Expression>(1); }
+    const auto& op0() const { return child<Expression>(0); }
+    const auto& op1() const { return child<Expression>(1); }
 
     bool operator==(const LogicalAnd& other) const { return op0() == other.op0() && op1() == other.op1(); }
 

--- a/hilti/toolchain/include/ast/expressions/logical-not.h
+++ b/hilti/toolchain/include/ast/expressions/logical-not.h
@@ -15,7 +15,7 @@ class LogicalNot : public NodeBase, public trait::isExpression {
 public:
     LogicalNot(Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const LogicalNot& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/expressions/logical-or.h
+++ b/hilti/toolchain/include/ast/expressions/logical-or.h
@@ -16,8 +16,8 @@ public:
     LogicalOr(Expression op0, Expression op1, Meta m = Meta())
         : NodeBase({std::move(op0), std::move(op1)}, std::move(m)) {}
 
-    auto op0() const { return child<Expression>(0); }
-    auto op1() const { return child<Expression>(1); }
+    const auto& op0() const { return child<Expression>(0); }
+    const auto& op1() const { return child<Expression>(1); }
 
     bool operator==(const LogicalOr& other) const { return op0() == other.op0() && op1() == other.op1(); }
 

--- a/hilti/toolchain/include/ast/expressions/member.h
+++ b/hilti/toolchain/include/ast/expressions/member.h
@@ -20,7 +20,7 @@ public:
     Member(ID id, Type member_type, Meta m = Meta())
         : NodeBase({id, std::move(member_type), Type(type::Member(std::move(id)))}, std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto memberType() const { return type::effectiveOptionalType(childs()[1].tryAs<Type>()); }
 
     bool operator==(const Member& other) const { return id() == other.id() && type() == other.type(); }

--- a/hilti/toolchain/include/ast/expressions/move.h
+++ b/hilti/toolchain/include/ast/expressions/move.h
@@ -14,7 +14,7 @@ class Move : public NodeBase, public trait::isExpression {
 public:
     Move(Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const Move& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/expressions/pending-coerced.h
+++ b/hilti/toolchain/include/ast/expressions/pending-coerced.h
@@ -17,7 +17,7 @@ class PendingCoerced : public NodeBase, public trait::isExpression {
 public:
     PendingCoerced(Expression e, Type t, Meta m = Meta()) : NodeBase({std::move(e), std::move(t)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const PendingCoerced& other) const {
         return expression() == other.expression() && type() == other.type();

--- a/hilti/toolchain/include/ast/expressions/resolved-operator.api
+++ b/hilti/toolchain/include/ast/expressions/resolved-operator.api
@@ -72,4 +72,6 @@ class ResolvedOperator(trait::isResolvedOperator) : trait::isExpression {
     const NodeRef& originalNode() const;
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/expressions/resolved-operator.h
+++ b/hilti/toolchain/include/ast/expressions/resolved-operator.h
@@ -57,7 +57,7 @@ public:
     ResolvedOperatorBase(const Operator& op, const std::vector<Expression>& operands, Meta meta = Meta())
         : NodeBase(nodes(detail::type_to_store(op.result(operands)), operands), std::move(meta)), _operator(op) {}
 
-    auto& operator_() const { return _operator; }
+    const auto& operator_() const { return _operator; }
     auto kind() const { return _operator.kind(); }
 
     // ResolvedOperator interface with common implementation.
@@ -70,9 +70,9 @@ public:
             return _operator.result(operands());
     }
 
-    auto op0() const { return child<Expression>(1); }
-    auto op1() const { return child<Expression>(2); }
-    auto op2() const { return child<Expression>(3); }
+    const auto& op0() const { return child<Expression>(1); }
+    const auto& op1() const { return child<Expression>(2); }
+    const auto& op2() const { return child<Expression>(3); }
     auto hasOp0() const { return ! childs().empty(); }
     auto hasOp1() const { return childs().size() >= 3; }
     auto hasOp2() const { return childs().size() >= 4; }

--- a/hilti/toolchain/include/ast/expressions/ternary.h
+++ b/hilti/toolchain/include/ast/expressions/ternary.h
@@ -15,9 +15,9 @@ public:
     Ternary(Expression cond, Expression true_, Expression false_, Meta m = Meta())
         : NodeBase({std::move(cond), std::move(true_), std::move(false_)}, std::move(m)) {}
 
-    auto condition() const { return child<Expression>(0); }
-    auto true_() const { return child<Expression>(1); }
-    auto false_() const { return child<Expression>(2); }
+    const auto& condition() const { return child<Expression>(0); }
+    const auto& true_() const { return child<Expression>(1); }
+    const auto& false_() const { return child<Expression>(2); }
 
     bool operator==(const Ternary& other) const {
         return condition() == other.condition() && true_() == other.true_() && false_() == other.false_();

--- a/hilti/toolchain/include/ast/expressions/type-wrapped.h
+++ b/hilti/toolchain/include/ast/expressions/type-wrapped.h
@@ -53,7 +53,7 @@ public:
     TypeWrapped(Expression e, NodeRef t, ValidateTypeMatch _, Meta m = Meta())
         : NodeBase(nodes(std::move(e)), std::move(m)), _validate_type_match(true), _type_node_ref(std::move(t)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
     bool validateTypeMatch() const { return _validate_type_match; }
 
     bool operator==(const TypeWrapped& other) const {

--- a/hilti/toolchain/include/ast/expressions/typeinfo.h
+++ b/hilti/toolchain/include/ast/expressions/typeinfo.h
@@ -15,7 +15,7 @@ class TypeInfo : public NodeBase, public trait::isExpression {
 public:
     TypeInfo(Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
 
-    auto expression() const { return child<Expression>(0); }
+    const auto& expression() const { return child<Expression>(0); }
 
     bool operator==(const TypeInfo& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/expressions/unresolved-operator.h
+++ b/hilti/toolchain/include/ast/expressions/unresolved-operator.h
@@ -21,7 +21,12 @@ public:
     auto kind() const { return _kind; }
 
     /** Implements interfave for use with `OverloadRegistry`. */
-    auto operands() const { return childs<Expression>(0, -1); }
+    const auto& operands() const {
+        if ( _cache.operands.empty() )
+            _cache.operands = childs<Expression>(0, -1);
+
+        return _cache.operands;
+    }
 
     bool operator==(const UnresolvedOperator& other) const {
         return kind() == other.kind() && operands() == other.operands();
@@ -43,8 +48,14 @@ public:
     /** Implements `Node` interface. */
     auto properties() const { return node::Properties{{"kind", to_string(_kind)}}; }
 
+    void clearCache() { _cache.operands.clear(); }
+
 private:
     operator_::Kind _kind;
+
+    mutable struct {
+        std::vector<Expression> operands;
+    } _cache;
 };
 
 } // namespace expression

--- a/hilti/toolchain/include/ast/function.h
+++ b/hilti/toolchain/include/ast/function.h
@@ -48,7 +48,7 @@ public:
 
     Function() : NodeBase(nodes(node::none, node::none, node::none, node::none), Meta()) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto type() const { return type::effectiveType(child<Type>(1)).as<type::Function>(); }
     auto body() const { return childs()[2].tryAs<Statement>(); }
     auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }

--- a/hilti/toolchain/include/ast/function.h
+++ b/hilti/toolchain/include/ast/function.h
@@ -64,7 +64,7 @@ public:
     auto properties() const { return node::Properties{{"cc", to_string(_cc)}}; }
 
     /**
-     * Returns a new funnction with the body replaced.
+     * Returns a new function with the body replaced.
      *
      * @param d original function
      * @param b new body

--- a/hilti/toolchain/include/ast/function.h
+++ b/hilti/toolchain/include/ast/function.h
@@ -50,8 +50,8 @@ public:
 
     const auto& id() const { return child<ID>(0); }
     auto type() const { return type::effectiveType(child<Type>(1)).as<type::Function>(); }
-    auto body() const { return childs()[2].tryAs<Statement>(); }
-    auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
+    auto body() const { return childs()[2].tryReferenceAs<Statement>(); }
+    auto attributes() const { return childs()[3].tryReferenceAs<AttributeSet>(); }
     auto callingConvention() const { return _cc; }
     auto isStatic() const { return AttributeSet::find(attributes(), "&static"); }
 

--- a/hilti/toolchain/include/ast/id.h
+++ b/hilti/toolchain/include/ast/id.h
@@ -15,7 +15,7 @@
 namespace hilti {
 
 /** AST node representing an identifier. */
-class ID : public detail::IDBase<ID>, public NodeBase {
+class ID : public detail::IDBase<ID>, public NodeBase, public util::type_erasure::trait::Singleton {
 public:
     using detail::IDBase<ID>::IDBase;
     ID(std::string name, Meta m) : IDBase(std::move(name)), NodeBase(std::move(m)) {}

--- a/hilti/toolchain/include/ast/meta.h
+++ b/hilti/toolchain/include/ast/meta.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,16 +20,21 @@ public:
     /** List of comments. */
     using Comments = std::vector<std::string>;
 
-    Meta(Location location, Comments comments = {}) : _location(std::move(location)), _comments(std::move(comments)) {}
+    Meta(Location location, Comments comments = {}) : _comments(std::move(comments)) {
+        setLocation(std::move(location));
+    }
 
     /** Constructor that leaves location unset. */
     Meta(Comments comments = {}) : _comments(std::move(comments)) {}
 
-    const Location& location() const { return _location; }
     const Comments& comments() const { return _comments; }
+    const Location& location() const {
+        static Location null;
+        return _location ? *_location : null;
+    }
 
-    void setLocation(const Location& l) { _location = l; }
-    void setComments(const Comments& c) { _comments = c; }
+    void setLocation(Location l) { _location = &*_cache()->insert(std::move(l)).first; }
+    void setComments(Comments c) { _comments = std::move(c); }
 
     /**
      * Returns true if the location does not equal a default constructed
@@ -37,7 +43,9 @@ public:
     explicit operator bool() const { return _location || _comments.size(); }
 
 private:
-    Location _location;
+    std::set<Location>* _cache();
+
+    const Location* _location = nullptr;
     Comments _comments;
 };
 

--- a/hilti/toolchain/include/ast/module.h
+++ b/hilti/toolchain/include/ast/module.h
@@ -29,7 +29,13 @@ public:
 
     const auto& id() const { return child<ID>(0); }
     const auto& statements() const { return child<statement::Block>(1); }
-    auto declarations() const { return childs<Declaration>(2, -1); }
+    const auto& declarations() const {
+        if ( _cache.declarations.empty() )
+            _cache.declarations = childs<Declaration>(2, -1);
+
+        return _cache.declarations;
+    }
+
     const auto& preserved() const { return _preserved; }
     auto& preserved() { return _preserved; }
 
@@ -103,8 +109,12 @@ public:
     /** Implements the `Node` interface. */
     auto properties() const { return node::Properties{}; }
 
+    void clearCache() { _cache.declarations.clear(); }
+
 private:
     std::vector<Node> _preserved;
+
+    mutable struct { std::vector<Declaration> declarations; } _cache;
 };
 
 /** Creates an AST node representing a `Module`. */

--- a/hilti/toolchain/include/ast/module.h
+++ b/hilti/toolchain/include/ast/module.h
@@ -27,8 +27,8 @@ public:
     Module(ID id, std::vector<Declaration> decls, std::vector<Statement> stmts, const Meta& m = Meta())
         : NodeBase(nodes(std::move(id), statement::Block(std::move(stmts), m), std::move(decls)), m) {}
 
-    auto id() const { return child<ID>(0); }
-    auto statements() const { return child<statement::Block>(1); }
+    const auto& id() const { return child<ID>(0); }
+    const auto& statements() const { return child<statement::Block>(1); }
     auto declarations() const { return childs<Declaration>(2, -1); }
     const auto& preserved() const { return _preserved; }
     auto& preserved() { return _preserved; }

--- a/hilti/toolchain/include/ast/node.api
+++ b/hilti/toolchain/include/ast/node.api
@@ -26,4 +26,7 @@ class Node(trait::isNode) {
     /** Associates an original, pre-transformation node with this node. */
     void setOriginalNode(const NodeRef& n);
 
+    /** Clears any dynamically computed information that the node might have cached for reuse. */
+    void clearCache();
+
 };

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -111,7 +111,7 @@ public:
 
     Node() = delete;
 
-    explicit Node(std::shared_ptr<hilti::node::detail::Concept> data) : node::detail::Node(std::move(data)) {}
+    explicit Node(IntrusivePtr<hilti::node::detail::Concept> data) : node::detail::Node(std::move(data)) {}
 
     ~Node() final {
         if ( _control_ptr )
@@ -140,9 +140,9 @@ public:
      * scope. However, scopes can be shared across nodes through
      * `setScope()`.
      */
-    std::shared_ptr<Scope> scope() const {
+    IntrusivePtr<Scope> scope() const {
         if ( ! _scope )
-            _scope = std::make_shared<Scope>();
+            _scope = make_intrusive<Scope>();
 
         return _scope;
     }
@@ -150,7 +150,7 @@ public:
     /**
      * Resets the node's scope to point to another one. Nodes
      */
-    void setScope(std::shared_ptr<Scope> new_scope) { _scope = std::move(new_scope); }
+    void setScope(IntrusivePtr<Scope> new_scope) { _scope = std::move(new_scope); }
 
     /** Returns any error messages associated with the node. */
     std::vector<node::Error> errors() const {
@@ -290,15 +290,15 @@ private:
 
     // Returns (and potentially) created the control block for this node that
     // NodeRef uses to maintain links to it.
-    std::shared_ptr<node_ref::detail::Control> _control() {
+    IntrusivePtr<node_ref::detail::Control> _control() {
         if ( ! _control_ptr )
-            _control_ptr = std::make_shared<node_ref::detail::Control>(this);
+            _control_ptr = make_intrusive<node_ref::detail::Control>(this);
 
         return _control_ptr;
     }
 
-    std::shared_ptr<node_ref::detail::Control> _control_ptr = nullptr;
-    mutable std::shared_ptr<Scope> _scope = nullptr;
+    IntrusivePtr<node_ref::detail::Control> _control_ptr = nullptr;
+    mutable IntrusivePtr<Scope> _scope = nullptr;
     std::unique_ptr<std::vector<node::Error>> _errors = nullptr;
 };
 

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -445,6 +445,8 @@ public:
     const NodeRef& originalNode() const { return _orig; }
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n) { _orig = n; }
+    /** Implements the `Node` interface. */
+    void clearCache() {}
 
 private:
     std::vector<::hilti::Node> _childs;

--- a/hilti/toolchain/include/ast/node_ref.h
+++ b/hilti/toolchain/include/ast/node_ref.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <hilti/base/util.h>
+#include <hilti/base/intrusive-ptr.h>
 
 namespace hilti {
 
@@ -16,7 +17,7 @@ namespace node_ref {
 namespace detail {
 
 // Control block for refering to nodes.
-class Control {
+class Control : public hilti::intrusive_ptr::ManagedObject {
 public:
     Control(Node* n) : _node(n), _rid(++_rid_counter) {}
     Node* _node;
@@ -88,7 +89,7 @@ public:
 
 private:
     Node* _node() const;
-    std::shared_ptr<node_ref::detail::Control> _control;
+    IntrusivePtr<node_ref::detail::Control> _control;
 };
 
 } // namespace hilti

--- a/hilti/toolchain/include/ast/nodes.decl
+++ b/hilti/toolchain/include/ast/nodes.decl
@@ -23,6 +23,7 @@ hilti::type::union_::Field : isNode
 hilti::type::struct_::Field : isNode
 hilti::statement::switch_::Case : isNode
 hilti::statement::try_::Catch : isNode
+hilti::type::enum_::Label : isNode
 
 hilti::ctor::Address : isCtor
 hilti::ctor::Bool : isCtor
@@ -149,7 +150,6 @@ hilti::type::Void : isType
 hilti::type::WeakReference : isType
 hilti::type::ValueReference : isType
 hilti::type::bytes::Iterator : isType
-hilti::type::enum_::Label : isType
 hilti::type::list::Iterator : isType
 hilti::type::map::Iterator : isType
 hilti::type::set::Iterator : isType

--- a/hilti/toolchain/include/ast/scope.h
+++ b/hilti/toolchain/include/ast/scope.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <hilti/base/intrusive-ptr.h>
 #include <hilti/ast/node_ref.h>
 
 namespace hilti {
@@ -20,7 +21,7 @@ class ID;
  * to referneces to AST nodes). An identifier can be mapped to more than one
  * node.
  */
-class Scope {
+class Scope : public intrusive_ptr::ManagedObject {
 public:
     Scope() = default;
     ~Scope() = default;

--- a/hilti/toolchain/include/ast/statement.api
+++ b/hilti/toolchain/include/ast/statement.api
@@ -25,4 +25,7 @@ class Statement(trait::isStatement) : trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/statements/assert.h
+++ b/hilti/toolchain/include/ast/statements/assert.h
@@ -46,7 +46,7 @@ public:
         : NodeBase(nodes(std::move(expr), std::move(excpt), std::move(msg)), std::move(m)), _expects_exception(true) {}
 
     bool expectsException() const { return _expects_exception; }
-    auto expression() const { return child<::hilti::Expression>(0); }
+    const auto& expression() const { return child<::hilti::Expression>(0); }
     auto exception() const { return type::effectiveOptionalType(childs()[1].tryAs<Type>()); }
     auto message() const { return childs()[2].tryAs<::hilti::Expression>(); }
 

--- a/hilti/toolchain/include/ast/statements/assert.h
+++ b/hilti/toolchain/include/ast/statements/assert.h
@@ -48,7 +48,7 @@ public:
     bool expectsException() const { return _expects_exception; }
     const auto& expression() const { return child<::hilti::Expression>(0); }
     auto exception() const { return type::effectiveOptionalType(childs()[1].tryAs<Type>()); }
-    auto message() const { return childs()[2].tryAs<::hilti::Expression>(); }
+    auto message() const { return childs()[2].tryReferenceAs<::hilti::Expression>(); }
 
     bool operator==(const Assert& other) const {
         return _expects_exception == other._expects_exception && expression() == other.expression() &&

--- a/hilti/toolchain/include/ast/statements/declaration.h
+++ b/hilti/toolchain/include/ast/statements/declaration.h
@@ -15,7 +15,7 @@ class Declaration : public NodeBase, public hilti::trait::isStatement {
 public:
     Declaration(hilti::Declaration d, Meta m = Meta()) : NodeBase({std::move(d)}, std::move(m)) {}
 
-    auto declaration() const { return child<::hilti::Declaration>(0); }
+    const auto& declaration() const { return child<::hilti::Declaration>(0); }
 
     bool operator==(const Declaration& other) const { return declaration() == other.declaration(); }
 

--- a/hilti/toolchain/include/ast/statements/expression.h
+++ b/hilti/toolchain/include/ast/statements/expression.h
@@ -15,7 +15,7 @@ class Expression : public NodeBase, public hilti::trait::isStatement {
 public:
     Expression(hilti::Expression e, Meta m = Meta()) : NodeBase({std::move(e)}, std::move(m)) {}
 
-    auto expression() const { return child<::hilti::Expression>(0); }
+    const auto& expression() const { return child<::hilti::Expression>(0); }
 
     bool operator==(const Expression& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/statements/for.h
+++ b/hilti/toolchain/include/ast/statements/for.h
@@ -18,9 +18,9 @@ public:
     For(hilti::ID id, hilti::Expression seq, Statement body, Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(seq), std::move(body)), std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
-    auto sequence() const { return child<hilti::Expression>(1); }
-    auto body() const { return child<hilti::Statement>(2); }
+    const auto& id() const { return child<ID>(0); }
+    const auto& sequence() const { return child<hilti::Expression>(1); }
+    const auto& body() const { return child<hilti::Statement>(2); }
 
     /**
      * Returns the body's scope. Note that the scope is shared among any

--- a/hilti/toolchain/include/ast/statements/for.h
+++ b/hilti/toolchain/include/ast/statements/for.h
@@ -26,7 +26,7 @@ public:
      * Returns the body's scope. Note that the scope is shared among any
      * copies of an instance.
      */
-    std::shared_ptr<Scope> scope() const { return childs()[2].scope(); }
+    IntrusivePtr<Scope> scope() const { return childs()[2].scope(); }
 
     bool operator==(const For& other) const {
         return id() == other.id() && sequence() == other.sequence() && body() == other.body();

--- a/hilti/toolchain/include/ast/statements/if.h
+++ b/hilti/toolchain/include/ast/statements/if.h
@@ -25,10 +25,10 @@ public:
     If(hilti::Expression cond, Statement true_, std::optional<Statement> false_, Meta m = Meta())
         : NodeBase(nodes(node::none, std::move(cond), std::move(true_), std::move(false_)), std::move(m)) {}
 
-    auto init() const { return childs()[0].tryAs<hilti::Declaration>(); }
-    auto condition() const { return childs()[1].tryAs<hilti::Expression>(); }
+    auto init() const { return childs()[0].tryReferenceAs<hilti::Declaration>(); }
+    auto condition() const { return childs()[1].tryReferenceAs<hilti::Expression>(); }
     const auto& true_() const { return child<hilti::Statement>(2); }
-    auto false_() const { return childs()[3].tryAs<Statement>(); }
+    auto false_() const { return childs()[3].tryReferenceAs<Statement>(); }
 
     bool operator==(const If& other) const {
         return init() == other.init() && condition() == other.condition() && true_() == other.true_() &&

--- a/hilti/toolchain/include/ast/statements/if.h
+++ b/hilti/toolchain/include/ast/statements/if.h
@@ -27,7 +27,7 @@ public:
 
     auto init() const { return childs()[0].tryAs<hilti::Declaration>(); }
     auto condition() const { return childs()[1].tryAs<hilti::Expression>(); }
-    auto true_() const { return child<hilti::Statement>(2); }
+    const auto& true_() const { return child<hilti::Statement>(2); }
     auto false_() const { return childs()[3].tryAs<Statement>(); }
 
     bool operator==(const If& other) const {

--- a/hilti/toolchain/include/ast/statements/switch.h
+++ b/hilti/toolchain/include/ast/statements/switch.h
@@ -95,8 +95,8 @@ public:
         _preprocessCases(init.id());
     }
 
-    auto init() const { return childs()[0].tryAs<hilti::Declaration>(); }
-    auto expression() const { return childs()[1].as<hilti::Expression>(); }
+    auto init() const { return childs()[0].tryReferenceAs<hilti::Declaration>(); }
+    const auto& expression() const { return childs()[1].as<hilti::Expression>(); }
     auto type() const {
         if ( auto i = init() )
             return i->as<declaration::LocalVariable>().type();

--- a/hilti/toolchain/include/ast/statements/switch.h
+++ b/hilti/toolchain/include/ast/statements/switch.h
@@ -43,7 +43,7 @@ public:
 
     auto expressions() const { return childs<hilti::Expression>(1, _end_exprs); }
     auto preprocessedExpressions() const { return childs<hilti::Expression>(_end_exprs, -1); }
-    auto body() const { return child<Statement>(0); }
+    const auto& body() const { return child<Statement>(0); }
 
     bool isDefault() const { return expressions().empty(); }
 

--- a/hilti/toolchain/include/ast/statements/throw.h
+++ b/hilti/toolchain/include/ast/statements/throw.h
@@ -16,7 +16,7 @@ public:
     Throw(Meta m = Meta()) : NodeBase({node::none}, std::move(m)) {}
     Throw(hilti::Expression excpt, Meta m = Meta()) : NodeBase({std::move(excpt)}, std::move(m)) {}
 
-    auto expression() const { return childs()[0].tryAs<hilti::Expression>(); }
+    auto expression() const { return childs()[0].tryReferenceAs<hilti::Expression>(); }
 
     bool operator==(const Throw& other) const { return expression() == other.expression(); }
 

--- a/hilti/toolchain/include/ast/statements/try.h
+++ b/hilti/toolchain/include/ast/statements/try.h
@@ -35,7 +35,7 @@ public:
         return {};
     }
 
-    auto body() const { return child<hilti::Statement>(1); }
+    const auto& body() const { return child<hilti::Statement>(1); }
 
     /** Internal method for use by builder API only. */
     auto& _bodyNode() { return childs()[1]; }
@@ -54,7 +54,7 @@ public:
     Try(hilti::Statement body, std::vector<try_::Catch> catches, Meta m = Meta())
         : NodeBase(nodes(std::move(body), std::move(catches)), std::move(m)) {}
 
-    auto body() const { return child<hilti::Statement>(0); }
+    const auto& body() const { return child<hilti::Statement>(0); }
     auto catches() const { return childs<try_::Catch>(1, -1); }
 
     bool operator==(const Try& other) const { return body() == other.body() && catches() == other.catches(); }

--- a/hilti/toolchain/include/ast/statements/while.h
+++ b/hilti/toolchain/include/ast/statements/while.h
@@ -27,10 +27,10 @@ public:
     While(hilti::Expression cond, Statement body, std::optional<Statement> else_, Meta m = Meta())
         : NodeBase(nodes(node::none, std::move(cond), std::move(body), std::move(else_)), std::move(m)) {}
 
-    auto init() const { return childs()[0].tryAs<hilti::Declaration>(); }
-    auto condition() const { return childs()[1].tryAs<hilti::Expression>(); }
+    auto init() const { return childs()[0].tryReferenceAs<hilti::Declaration>(); }
+    auto condition() const { return childs()[1].tryReferenceAs<hilti::Expression>(); }
     const auto& body() const { return child<hilti::Statement>(2); }
-    auto else_() const { return childs()[3].tryAs<Statement>(); }
+    auto else_() const { return childs()[3].tryReferenceAs<Statement>(); }
 
     bool operator==(const While& other) const {
         return init() == other.init() && condition() == other.condition() && body() == other.body() &&

--- a/hilti/toolchain/include/ast/statements/while.h
+++ b/hilti/toolchain/include/ast/statements/while.h
@@ -29,7 +29,7 @@ public:
 
     auto init() const { return childs()[0].tryAs<hilti::Declaration>(); }
     auto condition() const { return childs()[1].tryAs<hilti::Expression>(); }
-    auto body() const { return child<hilti::Statement>(2); }
+    const auto& body() const { return child<hilti::Statement>(2); }
     auto else_() const { return childs()[3].tryAs<Statement>(); }
 
     bool operator==(const While& other) const {

--- a/hilti/toolchain/include/ast/type.api
+++ b/hilti/toolchain/include/ast/type.api
@@ -117,4 +117,7 @@ class Type(hilti::trait::isType) : hilti::trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/hilti/toolchain/include/ast/types/enum.h
+++ b/hilti/toolchain/include/ast/types/enum.h
@@ -14,7 +14,7 @@ namespace type {
 
 namespace enum_ {
 /** AST node for an enum label. */
-class Label : public NodeBase {
+class Label : public NodeBase, public util::type_erasure::trait::Singleton {
 public:
     Label() : NodeBase({ID("<no id>")}, Meta()) {}
     Label(ID id, Meta m = Meta()) : NodeBase({std::move(id)}, std::move(m)) {}

--- a/hilti/toolchain/include/ast/types/enum.h
+++ b/hilti/toolchain/include/ast/types/enum.h
@@ -20,7 +20,7 @@ public:
     Label(ID id, Meta m = Meta()) : NodeBase({std::move(id)}, std::move(m)) {}
     Label(ID id, int v, Meta m = Meta()) : NodeBase({std::move(id)}, std::move(m)), _value(v) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto value() const { return _value; }
 
     bool operator==(const Label& other) const { return id() == other.id() && value() == other.value(); }

--- a/hilti/toolchain/include/ast/types/id.h
+++ b/hilti/toolchain/include/ast/types/id.h
@@ -21,7 +21,7 @@ public:
         assert(_node && _node->isA<declaration::Type>());
     }
 
-    auto id() const { return child<::hilti::ID>(0); }
+    const auto& id() const { return child<::hilti::ID>(0); }
     auto declaration() const {
         assert(_node);
         return _node->as<Declaration>();
@@ -54,7 +54,7 @@ class UnresolvedID : public TypeBase {
 public:
     UnresolvedID(::hilti::ID id, Meta m = Meta()) : TypeBase({std::move(id)}, std::move(m)) {}
 
-    auto id() const { return child<::hilti::ID>(0); }
+    const auto& id() const { return child<::hilti::ID>(0); }
 
     bool operator==(const UnresolvedID& other) const { return id() == other.id(); }
 

--- a/hilti/toolchain/include/ast/types/member.h
+++ b/hilti/toolchain/include/ast/types/member.h
@@ -18,7 +18,7 @@ public:
     Member(Wildcard /*unused*/, Meta m = Meta()) : TypeBase({ID("<wildcard>")}, std::move(m)), _wildcard(true) {}
     Member(::hilti::ID id, Meta m = Meta()) : TypeBase({std::move(id)}, std::move(m)) {}
 
-    auto id() const { return child<::hilti::ID>(0); }
+    const auto& id() const { return child<::hilti::ID>(0); }
 
     bool operator==(const Member& other) const { return id() == other.id(); }
 

--- a/hilti/toolchain/include/ast/types/struct.h
+++ b/hilti/toolchain/include/ast/types/struct.h
@@ -30,8 +30,14 @@ public:
           Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(ft), node::none, std::move(attrs)), std::move(m)), _cc(cc) {}
 
-    auto id() const { return child<ID>(0); }
-    auto type() const { return type::effectiveType(child<Type>(1)); }
+    const auto& id() const { return child<ID>(0); }
+    const auto& type() const {
+        if ( ! _cache.type )
+            _cache.type = type::effectiveType(child<Type>(1));
+
+        return *_cache.type;
+    }
+
     auto callingConvention() const { return _cc; }
     auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
 
@@ -83,8 +89,14 @@ public:
         return x;
     }
 
+    void clearCache() { _cache.type.reset(); }
+
 private:
     ::hilti::function::CallingConvention _cc = ::hilti::function::CallingConvention::Standard;
+
+    mutable struct {
+        std::optional<Type> type;
+    } _cache;
 }; // namespace struct_
 
 inline Node to_node(Field f) { return Node(std::move(f)); }

--- a/hilti/toolchain/include/ast/types/struct.h
+++ b/hilti/toolchain/include/ast/types/struct.h
@@ -39,7 +39,7 @@ public:
     }
 
     auto callingConvention() const { return _cc; }
-    auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[3].tryReferenceAs<AttributeSet>(); }
 
     /**
      * Returns the auxiliary type as passed into the corresponding

--- a/hilti/toolchain/include/ast/types/union.h
+++ b/hilti/toolchain/include/ast/types/union.h
@@ -26,7 +26,7 @@ public:
 
     const auto& id() const { return child<ID>(0); }
     auto type() const { return type::effectiveType(child<Type>(1)); }
-    auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[2].tryReferenceAs<AttributeSet>(); }
 
     /** Implements the `Node` interface. */
     auto properties() const { return node::Properties{}; }

--- a/hilti/toolchain/include/ast/types/union.h
+++ b/hilti/toolchain/include/ast/types/union.h
@@ -24,7 +24,7 @@ public:
     Field(ID id, Type t, std::optional<AttributeSet> attrs = {}, Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(t), std::move(attrs)), std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto type() const { return type::effectiveType(child<Type>(1)); }
     auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
 

--- a/hilti/toolchain/include/base/intrusive-ptr.h
+++ b/hilti/toolchain/include/base/intrusive-ptr.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <utility>
+
+#include <hilti/rt/intrusive-ptr.h>
+
+namespace hilti {
+
+template<class T>
+using IntrusivePtr = hilti::rt::IntrusivePtr<T>;
+
+namespace intrusive_ptr {
+using AdoptRef = ::hilti::rt::intrusive_ptr::AdoptRef;
+using NewRef = ::hilti::rt::intrusive_ptr::NewRef;
+using ManagedObject = ::hilti::rt::intrusive_ptr::ManagedObject;
+} // namespace intrusive_ptr
+
+template<class T, class... Ts>
+IntrusivePtr<T> make_intrusive(Ts&&... args) {
+    // Assumes that objects start with a reference count of 1!
+    return {intrusive_ptr::AdoptRef{}, new T(std::forward<Ts>(args)...)};
+}
+
+template<class T, class U>
+IntrusivePtr<T> cast_intrusive(IntrusivePtr<U> p) noexcept {
+    return {intrusive_ptr::AdoptRef{}, static_cast<T*>(p.release())};
+}
+
+} // namespace hilti

--- a/hilti/toolchain/include/base/optional-ref.h
+++ b/hilti/toolchain/include/base/optional-ref.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+//
+// This was originally inspired by the version in
+// https://github.com/Chlorie/clu, but it turned into pretty much a rewrite. (That
+// code comes with an MIT license, FWIW).
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace hilti {
+
+/**
+ * Similar to `std::optional<>T` but storing a reference to the wrapped
+ * instance instead of a full copy. The caller must ensure that the
+ * underlying instance remains valid as long as necessary.
+ **/
+template<typename T>
+class optional_ref {
+public:
+    using nonConstT = typename std::remove_const<T>::type;
+
+    optional_ref() = default;
+    optional_ref(const optional_ref<T>& other) = default;
+    optional_ref(optional_ref<T>&& other) = default;
+    optional_ref(std::nullopt_t) {}
+    optional_ref(T& other) : _ptr(&other) {}
+    optional_ref(T&& other) = delete; // to avoid easy mistakes
+
+    bool has_value() const { return _ptr; }
+
+    T& value() const {
+        if ( ! _ptr )
+            throw std::bad_optional_access();
+
+        return *_ptr;
+    }
+
+    T& value_or(T& default_) const { return _ptr ? *_ptr : default_; }
+    void reset() { _ptr = nullptr; }
+
+    T* operator->() const { return _ptr; }
+    T& operator*() const { return *_ptr; }
+
+    optional_ref& operator=(const optional_ref<T>& other) = default;
+    optional_ref& operator=(optional_ref<T>&& other) = default;
+
+    optional_ref& operator=(std::nullopt_t) {
+        _ptr = nullptr;
+        return *this;
+    }
+
+    optional_ref& operator=(T& t) {
+        _ptr = &t;
+        return *this;
+    }
+
+    optional_ref& operator=(T&& t) = delete; // to avoid easy mistakes
+
+    explicit operator bool() const { return _ptr; }
+
+    bool operator==(const optional_ref<T>& other) const {
+        if ( has_value() && other.has_value() )
+            return value() == other.value();
+
+        return ! (has_value() || other.has_value());
+    }
+
+    bool operator!=(const optional_ref<T>& other) const { return ! (*this == other); }
+
+    operator std::optional<nonConstT>() const {
+        if ( has_value() )
+            return value();
+        else
+            return std::nullopt;
+    }
+
+private:
+    T* _ptr = nullptr;
+};
+
+} // namespace hilti

--- a/hilti/toolchain/include/base/type_erase.h
+++ b/hilti/toolchain/include/base/type_erase.h
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include <hilti/base/util.h>
+#include <hilti/base/optional-ref.h>
 #include <hilti/base/intrusive-ptr.h>
 
 namespace hilti::util::type_erasure {
@@ -217,6 +218,15 @@ public:
     /** Attempts to cast the contained object into a specified type. */
     template<typename T>
     std::optional<T> tryAs() const {
+        if ( auto p = _tryAs<T>() )
+            return *p;
+
+        return {};
+    }
+
+    /** Attempts to cast the contained object into a specified type. */
+    template<typename T>
+    optional_ref<const T> tryReferenceAs() const {
         if ( auto p = _tryAs<T>() )
             return *p;
 

--- a/hilti/toolchain/include/compiler/detail/cxx/elements.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/elements.h
@@ -9,7 +9,7 @@
 #include <variant>
 #include <vector>
 
-#include <hilti/rt/json.h>
+#include <hilti/rt/json-fwd.h>
 
 #include <hilti/ast/id.h>
 #include <hilti/base/id-base.h>

--- a/hilti/toolchain/include/compiler/detail/cxx/unit.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/unit.h
@@ -13,7 +13,8 @@
 #include <vector>
 
 #include <hilti/rt/filesystem.h>
-#include <hilti/rt/json.h>
+#include <hilti/rt/json-fwd.h>
+#include <hilti/rt/types/reference.h>
 
 #include <hilti/ast/ctor.h>
 #include <hilti/ast/expression.h>
@@ -36,7 +37,7 @@ class Linker;
 
 namespace linker {
 
-using MetaData = nlohmann::json;
+using MetaData = hilti::rt::ValueReference<nlohmann::json>;
 
 /**
  * Function joined by the linker.

--- a/hilti/toolchain/include/compiler/detail/visitors.h
+++ b/hilti/toolchain/include/compiler/detail/visitors.h
@@ -58,12 +58,6 @@ void renderNode(const Node& n, std::ostream& out, bool include_scopes = false);
 void renderNode(const Node& n, logging::DebugStream stream, bool include_scopes = false);
 
 /**
- * Resets dynamically built state in an AST. Currently, this clears all the
- * scopes and any errors.
- */
-void resetNodes(Node* root);
-
-/**
  * Clears any errors currentluy set in an AST.
  */
 void clearErrors(Node* root);

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -318,6 +318,8 @@ private:
     void _dumpASTs(std::ostream& stream, const std::string& prefix, int round = 0);
     // Records a debug dump of all modules parsed so far to disk.
     void _saveIterationASTs(const std::string& prefix, int round = 0);
+    // Clear any previously computed AST state before beginning a pass over the AST.
+    void _resetNodes(const ID& id, Node* root);
 
     // Parses a source file with the appropiate plugin.
     static Result<hilti::Module> parse(const std::shared_ptr<Context>& context,

--- a/hilti/toolchain/src/ast/meta.cc
+++ b/hilti/toolchain/src/ast/meta.cc
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
+
+#include <hilti/ast/meta.h>
+
+using namespace hilti;
+
+std::set<Location>* Meta::_cache() {
+    static std::set<Location> cache;
+    return &cache;
+}

--- a/hilti/toolchain/src/base/type_erase.cc
+++ b/hilti/toolchain/src/base/type_erase.cc
@@ -9,7 +9,7 @@
 using namespace hilti::util;
 
 #ifdef HILTI_TYPE_ERASURE_PROFILE
-namespace util::type_erasure::detail {
+namespace hilti::util::type_erasure::detail {
 inline bool operator<(const Counters& x, const Counters& y) { return x.max >= y.max; }
 } // namespace util::type_erasure::detail
 #endif

--- a/hilti/toolchain/src/compiler/clang.cc
+++ b/hilti/toolchain/src/compiler/clang.cc
@@ -248,7 +248,7 @@ ClangJIT::Implementation::Implementation(std::shared_ptr<Context> context)
 ClangJIT::Implementation::~Implementation() { llvm::llvm_shutdown(); }
 
 bool ClangJIT::Implementation::compile(const std::string& file, std::optional<std::string> code) {
-    util::timing::Collector _("hilti/jit/clang/compile");
+    util::timing::Collector _("hilti/jit/compile/clang");
 
     // Build standard clang++ arguments.
     std::vector<std::string> args = {hilti::configuration().jit_clang_executable};
@@ -336,7 +336,7 @@ bool ClangJIT::Implementation::compile(const std::string& file, std::optional<st
 }
 
 std::pair<std::unique_ptr<llvm::Module>, std::string> ClangJIT::Implementation::link() {
-    util::timing::Collector _("hilti/jit/clang/link");
+    util::timing::Collector _("hilti/jit/codegen/clang/link");
 
     // First, link all the modules in the queue together. Not doing this
     // causes illegal LLVM IR to be added to the JIT because we compile every
@@ -406,7 +406,7 @@ std::pair<std::unique_ptr<llvm::Module>, std::string> ClangJIT::Implementation::
 }
 
 Result<Nothing> ClangJIT::Implementation::jit() {
-    util::timing::Collector _("hilti/jit/clang/jit");
+    util::timing::Collector _("hilti/jit/codegen/clang");
 
     if ( module_queue.size() ) {
         // Link all the pending modules together.
@@ -455,6 +455,8 @@ Result<Nothing> ClangJIT::Implementation::jit() {
 }
 
 void ClangJIT::Implementation::optimizeModule(llvm::Module* m) {
+    util::timing::Collector _("hilti/jit/codegen/clang/optimize");
+
     HILTI_DEBUG(logging::debug::Jit, util::fmt("optimizing module %s", m->getModuleIdentifier()));
 
     auto fpm = std::make_unique<llvm::legacy::FunctionPassManager>(m);
@@ -521,7 +523,7 @@ void ClangJIT::Implementation::saveBitcode(const llvm::Module& module, std::stri
 }
 
 Result<Library> ClangJIT::Implementation::compileModule(llvm::Module&& module) {
-    util::timing::Collector _("hilti/jit/clang/save_library");
+    util::timing::Collector _("hilti/jit/codegen/clang/codegen");
 
 #ifdef HILTI_HAVE_SANITIZER
     // TODO(robin): Something in LLVM is leaking but I can't figure out

--- a/hilti/toolchain/src/compiler/coercion.cc
+++ b/hilti/toolchain/src/compiler/coercion.cc
@@ -205,7 +205,7 @@ Result<std::pair<bool, std::vector<Expression>>> hilti::coerceOperands(const std
     if ( exprs.size() > operands.size() )
         return result::Error("more expressions than operands");
 
-    for ( auto [i, op] : util::enumerate(operands) ) {
+    for ( const auto& [i, op] : util::enumerate(operands) ) {
         if ( i >= exprs.size() ) {
             // Running out of operands, must have a default or be optional.
             if ( op.default_ ) {
@@ -254,7 +254,7 @@ Result<std::pair<bool, std::vector<Expression>>> hilti::coerceOperands(const std
             changed = true;
     }
 
-    return std::make_pair(changed, transformed);
+    return std::make_pair(changed, std::move(transformed));
 }
 
 static CoercedExpression _coerceExpression(const Expression& e, const Type& src_, const Type& dst_,

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -5,6 +5,8 @@
 #include <hilti/compiler/detail/cxx/elements.h>
 #include <hilti/compiler/detail/cxx/formatter.h>
 
+#include <hilti/rt/json.h>
+
 using namespace hilti;
 using namespace hilti::detail;
 using namespace hilti::detail::cxx::formatter;

--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -19,22 +19,22 @@ inline const DebugStream Compiler("compiler");
 } // namespace hilti::logging::debug
 
 void cxx::Linker::add(const linker::MetaData& md) {
-    auto id = md.at("module").get<std::string>();
-    auto path = md.at("path").get<std::string>();
-    auto ns = md.at("namespace").get<std::string>();
+    auto id = md->at("module").get<std::string>();
+    auto path = md->at("path").get<std::string>();
+    auto ns = md->at("namespace").get<std::string>();
     _modules.emplace(id, path);
 
     // Continues logging from CodeGen::linkUnits.
     HILTI_DEBUG(logging::debug::Compiler, fmt("  - module %s (%s)", id, path));
 
-    for ( const auto& j : md.value("joins", json::object_t()) ) {
+    for ( const auto& j : md->value("joins", json::object_t()) ) {
         for ( auto& s : j.second ) {
             auto& joins = _joins[j.first];
             joins.push_back(s.get<cxx::linker::Join>());
         }
     }
 
-    if ( auto idx = md.value("globals-index", cxx::declaration::Constant()); ! idx.id.empty() )
+    if ( auto idx = md->value("globals-index", cxx::declaration::Constant()); ! idx.id.empty() )
         _globals.insert(std::move(idx));
 }
 

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -296,7 +296,7 @@ void Unit::_generateCode(Formatter& f, bool prototypes_only) {
     if ( auto meta = linkerMetaData() ) {
         f << separator();
         f << "/* __HILTI_LINKER_V1__" << eol();
-        f << meta->dump(-1) << eol();
+        f << (*meta)->dump(-1) << eol();
         f << "*/" << eol() << separator();
     }
 }
@@ -412,7 +412,7 @@ hilti::Result<linker::MetaData> Unit::linkerMetaData() const {
     if ( ! joins.empty() )
         j["joins"] = joins;
 
-    return j;
+    return {j};
 }
 
 std::pair<bool, std::optional<linker::MetaData>> Unit::readLinkerMetaData(std::istream& input) {

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include <hilti/rt/libhilti.h>
+#include <hilti/rt/json.h>
 
 #include <hilti/hilti.h>
 
@@ -722,7 +723,7 @@ Result<Nothing> Driver::linkUnits() {
 
     HILTI_DEBUG(logging::debug::Driver, "linking modules");
     for ( const auto& md : _mds ) {
-        auto id = md.at("module").template get<std::string>();
+        auto id = md->at("module").template get<std::string>();
         HILTI_DEBUG(logging::debug::Driver, fmt("  - %s", id));
     }
 

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -109,7 +109,7 @@ void JIT::setDumpCode() {
 }
 
 hilti::Result<Nothing> JIT::jit() {
-    util::timing::Collector _("hilti/jit/jit");
+    util::timing::Collector _("hilti/jit/codegen");
 
     if ( ! _jit )
         return result::Error("jit not initialized");

--- a/hilti/toolchain/src/compiler/visitors/apply-coercions.cc
+++ b/hilti/toolchain/src/compiler/visitors/apply-coercions.cc
@@ -375,10 +375,11 @@ struct Visitor : public visitor::PreOrder<void, Visitor> {
     }
 
     void operator()(const type::struct_::Field& f, position_t p) {
-        if ( auto attrs = f.attributes() ) {
-            if ( auto x = attrs->coerceValueTo("&default", f.type()) ) {
+        if ( auto a = f.attributes() ) {
+            AttributeSet attrs = *a;
+            if ( auto x = attrs.coerceValueTo("&default", f.type()) ) {
                 if ( *x ) {
-                    auto nattrs = type::struct_::Field::setAttributes(f, *attrs);
+                    auto nattrs = type::struct_::Field::setAttributes(f, std::move(attrs));
                     replaceNode(&p, std::move(nattrs));
                 }
 

--- a/hilti/toolchain/src/compiler/visitors/scope-builder.cc
+++ b/hilti/toolchain/src/compiler/visitors/scope-builder.cc
@@ -281,13 +281,6 @@ struct VisitorPass3 : public visitor::PostOrder<void, VisitorPass3> {
 
 } // anonymous namespace
 
-void hilti::detail::resetNodes(Node* root) {
-    for ( const auto& i : hilti::visitor::PreOrder<>().walk(root) ) {
-        i.node.scope()->clear();
-        i.node.clearErrors();
-    }
-}
-
 void hilti::detail::clearErrors(Node* root) {
     for ( const auto& i : hilti::visitor::PreOrder<>().walk(root) )
         i.node.clearErrors();

--- a/scripts/autogen-type-erased
+++ b/scripts/autogen-type-erased
@@ -15,7 +15,7 @@ public:
     $concept_methods
     $concept_operators
     virtual $class _clone() const = 0;
-    virtual std::shared_ptr<Concept> _clone_ptr() const = 0;
+    virtual hilti::IntrusivePtr<Concept> _clone_ptr() const = 0;
 private:
     $concept_private_attrs
 };
@@ -31,7 +31,7 @@ public:
 
     $model_methods
     $class _clone() const final;
-    std::shared_ptr<Concept> _clone_ptr() const final;
+    hilti::IntrusivePtr<Concept> _clone_ptr() const final;
 };
 
 using ErasedBase = hilti::util::type_erasure::ErasedBase<$class_requires, Concept, Model${attrs_types}>;
@@ -49,7 +49,7 @@ public:
     $class_methods
     $class _clone() const;
 
-    std::shared_ptr<Concept> _clone_ptr() const;
+    hilti::IntrusivePtr<Concept> _clone_ptr() const;
 };
 
 $model_methods_impl
@@ -57,17 +57,17 @@ template<typename T>
 $class Model<T>::_clone() const { return T(data()); }
 
 template<typename T>
-std::shared_ptr<Concept> Model<T>::_clone_ptr() const {
+hilti::IntrusivePtr<Concept> Model<T>::_clone_ptr() const {
     if constexpr ( std::is_base_of<hilti::util::type_erasure::trait::Singleton, T>::value )
         return nullptr;
     else
-        return std::make_shared<Model>(T(data()));
+        return hilti::make_intrusive<Model>(T(data()));
 }
 
 $class_methods_impl
 inline $class $class::_clone() const { return data() ? data()->_clone() : $class(); }
 
-inline std::shared_ptr<Concept> $class::_clone_ptr() const {
+inline hilti::IntrusivePtr<Concept> $class::_clone_ptr() const {
     if ( data() )
         return data()->_clone_ptr();
     else

--- a/spicy/toolchain/bin/spicy-dump/printer-json.cc
+++ b/spicy/toolchain/bin/spicy-dump/printer-json.cc
@@ -6,6 +6,7 @@
 
 #include <hilti/rt/libhilti.h>
 
+#include <hilti/rt/json.h>
 #include <spicy/rt/util.h>
 
 using namespace hilti::rt;

--- a/spicy/toolchain/bin/spicy-dump/printer-json.h
+++ b/spicy/toolchain/bin/spicy-dump/printer-json.h
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <utility>
 
-#include <hilti/rt/json.h>
+#include <hilti/rt/json-fwd.h>
 #include <hilti/rt/type-info.h>
 #include <hilti/rt/types/integer.h>
 

--- a/spicy/toolchain/include/ast/declarations/unit-hook.h
+++ b/spicy/toolchain/include/ast/declarations/unit-hook.h
@@ -39,7 +39,7 @@ public:
         return {};
     }
 
-    auto unitHook() const { return child<type::unit::item::UnitHook>(2); }
+    const auto& unitHook() const { return child<type::unit::item::UnitHook>(2); }
 
     bool operator==(const UnitHook& other) const {
         return unitType() == other.unitType() && unitHook() == other.unitHook();
@@ -48,7 +48,7 @@ public:
     /** Implements `Declaration` interface. */
     bool isConstant() const { return true; }
     /** Implements `Declaration` interface. */
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     /** Implements `Declaration` interface. */
     Linkage linkage() const { return Linkage::Private; }
     /** Implements `Declaration` interface. */

--- a/spicy/toolchain/include/ast/types/bitfield.h
+++ b/spicy/toolchain/include/ast/types/bitfield.h
@@ -35,7 +35,7 @@ public:
     auto lower() const { return _lower; }
     auto upper() const { return _upper; }
     Type type() const;
-    auto attributes() const { return childs()[1].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[1].tryReferenceAs<AttributeSet>(); }
 
     /** Implements the `Node` interface. */
     auto properties() const {

--- a/spicy/toolchain/include/ast/types/bitfield.h
+++ b/spicy/toolchain/include/ast/types/bitfield.h
@@ -31,7 +31,7 @@ public:
           _upper(upper),
           _field_width(field_width) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto lower() const { return _lower; }
     auto upper() const { return _upper; }
     Type type() const;

--- a/spicy/toolchain/include/ast/types/unit-item.api
+++ b/spicy/toolchain/include/ast/types/unit-item.api
@@ -27,4 +27,7 @@ class Item(trait::isUnitItem) : hilti::trait::isNode {
 
     /** Implements the `Node` interface. */
     void setOriginalNode(const NodeRef& n);
+
+    /** Implements the `Node` interface. */
+    void clearCache();
 };

--- a/spicy/toolchain/include/ast/types/unit-items/field.h
+++ b/spicy/toolchain/include/ast/types/unit-items/field.h
@@ -71,13 +71,13 @@ public:
           _sinks_start(_args_end),
           _sinks_end(_sinks_start + static_cast<int>(sinks.size())) {}
 
-    auto id() const { return childs()[0].as<ID>(); }
+    const auto& id() const { return childs()[0].as<ID>(); }
     auto index() const { return _index; }
-    auto ctor() const { return childs()[2].tryAs<Ctor>(); }
-    auto vectorItem() const { return childs()[2].tryAs<Item>(); }
-    auto repeatCount() const { return childs()[3].tryAs<Expression>(); }
-    auto attributes() const { return childs()[4].tryAs<AttributeSet>(); }
-    auto condition() const { return childs()[5].tryAs<Expression>(); }
+    auto ctor() const { return childs()[2].tryReferenceAs<Ctor>(); }
+    auto vectorItem() const { return childs()[2].tryReferenceAs<Item>(); }
+    auto repeatCount() const { return childs()[3].tryReferenceAs<Expression>(); }
+    auto attributes() const { return childs()[4].tryReferenceAs<AttributeSet>(); }
+    auto condition() const { return childs()[5].tryReferenceAs<Expression>(); }
     auto arguments() const { return childs<Expression>(_args_start, _args_end); }
     auto sinks() const { return childs<Expression>(_sinks_start, _sinks_end); }
     auto hooks() const { return childs<Hook>(_sinks_end, -1); }

--- a/spicy/toolchain/include/ast/types/unit-items/property.h
+++ b/spicy/toolchain/include/ast/types/unit-items/property.h
@@ -22,8 +22,8 @@ public:
         : NodeBase(nodes(std::move(id), std::move(expr), std::move(attrs)), std::move(m)), _inherited(inherited) {}
 
     const auto& id() const { return child<ID>(0); }
-    auto expression() const { return childs()[1].tryAs<Expression>(); }
-    auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
+    auto expression() const { return childs()[1].tryReferenceAs<Expression>(); }
+    auto attributes() const { return childs()[2].tryReferenceAs<AttributeSet>(); }
     bool interited() const { return _inherited; }
 
     bool operator==(const Property& other) const {

--- a/spicy/toolchain/include/ast/types/unit-items/property.h
+++ b/spicy/toolchain/include/ast/types/unit-items/property.h
@@ -21,7 +21,7 @@ public:
     Property(ID id, Expression expr, std::optional<AttributeSet> attrs = {}, bool inherited = false, Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(expr), std::move(attrs)), std::move(m)), _inherited(inherited) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto expression() const { return childs()[1].tryAs<Expression>(); }
     auto attributes() const { return childs()[2].tryAs<AttributeSet>(); }
     bool interited() const { return _inherited; }

--- a/spicy/toolchain/include/ast/types/unit-items/sink.h
+++ b/spicy/toolchain/include/ast/types/unit-items/sink.h
@@ -21,7 +21,7 @@ public:
         : NodeBase(nodes(std::move(id), std::move(attrs)), std::move(m)) {}
 
     const auto& id() const { return child<ID>(0); }
-    auto attributes() const { return childs()[1].tryAs<AttributeSet>(); }
+    auto attributes() const { return childs()[1].tryReferenceAs<AttributeSet>(); }
 
     bool operator==(const Sink& other) const { return id() == other.id() && attributes() == other.attributes(); }
 

--- a/spicy/toolchain/include/ast/types/unit-items/sink.h
+++ b/spicy/toolchain/include/ast/types/unit-items/sink.h
@@ -20,7 +20,7 @@ public:
     Sink(ID id, std::optional<AttributeSet> attrs = {}, Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(attrs)), std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto attributes() const { return childs()[1].tryAs<AttributeSet>(); }
 
     bool operator==(const Sink& other) const { return id() == other.id() && attributes() == other.attributes(); }

--- a/spicy/toolchain/include/ast/types/unit-items/switch.h
+++ b/spicy/toolchain/include/ast/types/unit-items/switch.h
@@ -73,7 +73,7 @@ public:
         ;
     }
     Engine engine() const { return _engine; }
-    auto condition() const { return childs()[1].tryAs<Expression>(); }
+    auto condition() const { return childs()[1].tryReferenceAs<Expression>(); }
     auto cases() const { return childs<switch_::Case>(_cases_start, _cases_end); }
     auto cases() { return childs<switch_::Case>(_cases_start, _cases_end); }
     auto casesNodes() { return nodesOfType<switch_::Case>(); }

--- a/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
+++ b/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
@@ -15,8 +15,8 @@ class UnitHook : public hilti::NodeBase, public spicy::trait::isUnitItem {
 public:
     UnitHook(ID id, Hook hook, Meta m = Meta()) : NodeBase(nodes(std::move(id), std::move(hook)), std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
-    auto hook() const { return child<Hook>(1); }
+    const auto& id() const { return child<ID>(0); }
+    const auto& hook() const { return child<Hook>(1); }
     auto location() const { return childs()[0].location(); }
 
     bool operator==(const UnitHook& other) const { return id() == other.id() && hook() == other.hook(); }

--- a/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
+++ b/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
@@ -17,7 +17,7 @@ public:
 
     const auto& id() const { return child<ID>(0); }
     const auto& hook() const { return child<Hook>(1); }
-    auto location() const { return childs()[0].location(); }
+    const auto& location() const { return childs()[0].location(); }
 
     bool operator==(const UnitHook& other) const { return id() == other.id() && hook() == other.hook(); }
 

--- a/spicy/toolchain/include/ast/types/unit-items/unresolved-field.h
+++ b/spicy/toolchain/include/ast/types/unit-items/unresolved-field.h
@@ -73,19 +73,19 @@ public:
           _sinks_start(_args_end),
           _sinks_end(_sinks_start + static_cast<int>(sinks.size())) {}
 
-    auto fieldID() const { return childs()[1].tryAs<ID>(); }
+    auto fieldID() const { return childs()[1].tryReferenceAs<ID>(); }
 
     const auto& index() const { return _index; }
 
     // Only one of these will have return value.
-    auto unresolvedID() const { return childs()[0].tryAs<ID>(); }
-    auto type() const { return childs()[0].tryAs<Type>(); }
-    auto ctor() const { return childs()[0].tryAs<Ctor>(); }
-    auto item() const { return childs()[0].tryAs<Item>(); }
+    auto unresolvedID() const { return childs()[0].tryReferenceAs<ID>(); }
+    auto type() const { return childs()[0].tryReferenceAs<Type>(); }
+    auto ctor() const { return childs()[0].tryReferenceAs<Ctor>(); }
+    auto item() const { return childs()[0].tryReferenceAs<Item>(); }
 
-    auto repeatCount() const { return childs()[2].tryAs<Expression>(); }
-    auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
-    auto condition() const { return childs()[4].tryAs<Expression>(); }
+    auto repeatCount() const { return childs()[2].tryReferenceAs<Expression>(); }
+    auto attributes() const { return childs()[3].tryReferenceAs<AttributeSet>(); }
+    auto condition() const { return childs()[4].tryReferenceAs<Expression>(); }
     auto arguments() const { return childs<Expression>(_args_start, _args_end); }
     auto sinks() const { return childs<Expression>(_sinks_start, _sinks_end); }
     auto hooks() const { return childs<Hook>(_sinks_end, -1); }

--- a/spicy/toolchain/include/ast/types/unit-items/variable.h
+++ b/spicy/toolchain/include/ast/types/unit-items/variable.h
@@ -24,7 +24,7 @@ public:
              Meta m = Meta())
         : NodeBase(nodes(std::move(id), std::move(type), default_, std::move(attrs)), std::move(m)) {}
 
-    auto id() const { return child<ID>(0); }
+    const auto& id() const { return child<ID>(0); }
     auto default_() const { return childs()[2].tryAs<Expression>(); }
     auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
 

--- a/spicy/toolchain/include/ast/types/unit-items/variable.h
+++ b/spicy/toolchain/include/ast/types/unit-items/variable.h
@@ -25,8 +25,8 @@ public:
         : NodeBase(nodes(std::move(id), std::move(type), default_, std::move(attrs)), std::move(m)) {}
 
     const auto& id() const { return child<ID>(0); }
-    auto default_() const { return childs()[2].tryAs<Expression>(); }
-    auto attributes() const { return childs()[3].tryAs<AttributeSet>(); }
+    auto default_() const { return childs()[2].tryReferenceAs<Expression>(); }
+    auto attributes() const { return childs()[3].tryReferenceAs<AttributeSet>(); }
 
     auto isOptional() const { return AttributeSet::find(attributes(), "&optional"); }
 

--- a/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
@@ -37,7 +37,7 @@ struct Visitor : public hilti::visitor::PreOrder<Production, Visitor> {
     bool haveField() { return ! fields.empty(); }
 
     std::optional<Production> productionForItem(std::reference_wrapper<hilti::Node> node) {
-        auto field = node.get().tryAs<const spicy::type::unit::item::Field>();
+        auto field = node.get().tryAs<spicy::type::unit::item::Field>();
         if ( field )
             pushField({*field, node});
 


### PR DESCRIPTION
This branch provides a major speed boost to the Spicy-side of the compiler: generating C++ code is much improved for more complex code. Most of the speed-up comes from a single change (the caching of operator results). The branch contains a series of other smaller improvements as well, including a couple to help with compile time of the toolchain itself.

Best reviewed by individual commits.