### PR TITLE
Explicitly enable leak checking on test relying on it being active.

### DIFF
--- a/tests/hilti/hiltic/cc/leak.cc
+++ b/tests/hilti/hiltic/cc/leak.cc
@@ -1,7 +1,7 @@
 // @TEST-REQUIRES: have-sanitizer
 // @TEST-GROUP: no-jit
 // @TEST-EXEC: cxx-compile-and-link %INPUT
-// @TEST-EXEC-FAIL: ./a.out >output 2>&1
+// @TEST-EXEC-FAIL: ASAN_OPTIONS=detect_leaks=1 ./a.out >output 2>&1
 // @TEST-EXEC: grep -q 'detected memory leaks' output
 //
 // If we have compiled with address/leak sanitizer, make sure it's active.

--- a/tests/hilti/hiltic/jit/leak.cc
+++ b/tests/hilti/hiltic/jit/leak.cc
@@ -1,5 +1,5 @@
 // @TEST-REQUIRES: have-sanitizer
-// @TEST-EXEC-FAIL: ${HILTIC} -j %INPUT >output 2>&1
+// @TEST-EXEC-FAIL: ASAN_OPTIONS=detect_leaks=1 ${HILTIC} -j %INPUT >output 2>&1
 // @TEST-EXEC: grep -q 'detected memory leaks' output
 //
 // If we have compiled with address/leak sanitizer, make sure it's active.


### PR DESCRIPTION
Closes #94.