### PR TITLE
Disable precompiled headers if we are building with GCC. 

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -384,6 +384,10 @@ In order to speed up precompilation of Spicy parsers, users can create a cache o
 precompiled files. This cache is tied to a specific Spicy version, and needs to
 be recreated each time Spicy is updated.
 
+.. note::
+
+    Precompiled headers are supported only when building Spicy with Clang.
+
 To precompile the files execute the following command::
 
     # spicy-precompile-headers

--- a/hilti/toolchain/include/config.h.in
+++ b/hilti/toolchain/include/config.h.in
@@ -59,6 +59,7 @@ struct Configuration {
 
     bool uses_build_directory; /**< True if all information pertains to running outside of the build directory. */
 
+    std::string compiler_id;                     /**< Identifier of the compiler */
     hilti::rt::filesystem::path cxx;             /**< Full path to C++ compiler */
     hilti::rt::filesystem::path distbase;        /**< base directory of HILTI source distribution */
     hilti::rt::filesystem::path hiltic;          /**< Full path to `hiltic` binary */

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -1,5 +1,8 @@
 // Copyright (c) 2020 by the Zeek Project. See LICENSE for details.
 
+#include <algorithm>
+#include <cctype>
+
 #include <hilti/rt/autogen/version.h>
 
 #include <hilti/autogen/config.h>
@@ -19,6 +22,16 @@ std::optional<hilti::rt::filesystem::path> precompiled_libhilti(const Configurat
 #ifdef HILTI_HAVE_SANITIZER
     return {};
 #endif
+
+    // Precompiled headers are only supported if we build with Clang.
+    //
+    // JIT always uses Clang to compile, but e.g., `hilti-config --cxx` will
+    // report the compiler used to build Spicy. Since precompiled headers
+    // created by Clang cannot be used by GCC and vice versa, we currently
+    // cannot support precompiled headers for both JIT and AOT compilation
+    // if we build with GCC. Disable them completely in that case.
+    if ( configuration.compiler_id != "clang" )
+        return {};
 
     if ( auto&& cache = util::cacheDirectory(configuration) ) {
         const rt::filesystem::path file_name = rt::fmt("precompiled_libhilti%s.h.pch", (debug ? "_debug" : ""));
@@ -46,6 +59,10 @@ void hilti::Configuration::initLocation(const std::string_view& argv0) {
 void Configuration::init(bool use_build_directory) {
     uses_build_directory = use_build_directory;
     std::string installation_tag = (use_build_directory ? "BUILD" : "INSTALL");
+
+    compiler_id = "${CMAKE_CXX_COMPILER_ID}";
+    std::transform(compiler_id.begin(), compiler_id.end(), compiler_id.begin(),
+                   [](auto& c) { return std::tolower(c); });
 
     cxx = "${CMAKE_CXX_COMPILER}";
     distbase = "${CMAKE_SOURCE_DIR}";


### PR DESCRIPTION
JIT needs precompiled headers created by Clang while AOT compilation
probably needs them to be created by GCC (`spicy-config --cxx` would
always report the compiler used to build Spicy).

Closes #603.