### PR TITLE
Fix construction of Bytes.

### DIFF
--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -171,9 +171,9 @@ public:
      */
     Bytes(std::string s, bytes::Charset cs);
 
-    Bytes(Base&& str) : Base(std::move(str)) {}
-    Bytes(const Bytes&) = default;
-    Bytes(Bytes&&) = default;
+    Bytes(Base&& str) : Base(std::move(str)), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
+    Bytes(const Bytes& xs) : Base(xs), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
+    Bytes(Bytes&& xs) : Base(std::move(xs)), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
 
     /** Replaces the contents of this `Bytes` with another `Bytes`.
      *
@@ -507,7 +507,7 @@ public:
 
 private:
     friend bytes::Iterator;
-    std::shared_ptr<Base*> _control = std::make_shared<Base*>(static_cast<Base*>(this));
+    std::shared_ptr<Base*> _control;
 
     void invalidateIterators() { _control = std::make_shared<Base*>(static_cast<Base*>(this)); }
 };

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -164,14 +164,14 @@ TEST_CASE("find") {
         }
 
         SUBCASE("start at target") {
-            CHECK_EQ(b.find("23", b.at(1)), std::make_tuple(true, b.at(1)));
-            CHECK_EQ(b.find("ab", b.at(1)), std::make_tuple(false, b.end()));
+            CHECK_EQ(b.find("23"_b, b.at(1)), std::make_tuple(true, b.at(1)));
+            CHECK_EQ(b.find("ab"_b, b.at(1)), std::make_tuple(false, b.end()));
         }
 
         SUBCASE("start beyond target") {
-            CHECK_EQ(b.find("23", b.at(2)), std::make_tuple(false, b.end()));
-            CHECK_EQ(b.find("ab", b.at(2)), std::make_tuple(false, b.end()));
-            CHECK_EQ(b.find("ab", b.end()), std::make_tuple(false, b.end()));
+            CHECK_EQ(b.find("23"_b, b.at(2)), std::make_tuple(false, b.end()));
+            CHECK_EQ(b.find("ab"_b, b.at(2)), std::make_tuple(false, b.end()));
+            CHECK_EQ(b.find("ab"_b, b.end()), std::make_tuple(false, b.end()));
         }
     }
 }
@@ -538,6 +538,15 @@ TEST_CASE("Iterator") {
                                  const InvalidArgument&);
         }
     }
+}
+
+TEST_CASE("issue 599") {
+    // This is a regression test for #599.
+    std::optional<Bytes> a;
+    a = "31"_b;
+    REQUIRE(a);
+    CHECK_EQ(*a, "31"_b);
+    CHECK_EQ(a->toInt(), 31);
 }
 
 TEST_SUITE_END();

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -890,7 +890,7 @@ TEST_CASE("View") {
         // Trimmed view expands when data is added.
         stream.append("123"_b);
         CHECK_EQ(trimmed.size(), input.size() - 3 + 3);
-        CHECK(trimmed.startsWith("4567890123"));
+        CHECK(trimmed.startsWith("4567890123"_b));
     }
 
     SUBCASE("trimmed view inherits limit") {

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -38,7 +38,7 @@ std::tuple<bool, Bytes::const_iterator> Bytes::find(const Bytes& v, const const_
     }
 }
 
-Bytes::Bytes(std::string s, bytes::Charset cs) {
+Bytes::Bytes(std::string s, bytes::Charset cs) : _control(std::make_shared<Base*>(static_cast<Base*>(this))) {
     switch ( cs ) {
         case bytes::Charset::UTF8:
             // Data is already in UTF-8, just need to copy it over.


### PR DESCRIPTION
We were using a member initializer for the `Bytes` control block which
was accessing `this`. Since member initializers are executed before
`this` is fully formed and could contain random garbage. This patch
moves the initialization of the control block into `Bytes` constructors.

We also tightened up how we create temporary `Bytes` objects since they
might now in some places correctly expired before being used.

This closes #599.