### PR TITLE
Let test 'spicy.rt.time' work for the next 4 years.

### DIFF
--- a/tests/spicy/rt/time.spicy
+++ b/tests/spicy/rt/time.spicy
@@ -6,4 +6,4 @@ module Test;
 import spicy;
 
 global t = hilti::current_time();
-assert t > time(1564617600) && t < time(1609372800);
+assert t > time(1564617600) && t < time(1735689600);


### PR DESCRIPTION
This test hardcodes an expected range for the current time. With this
patch we widen the acceptable range to New Year's Day 2025.