### PR TITLE
Add script to create release tarball.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Create Release
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Prepare archive
+        run: |
+          ./scripts/make-tarball.sh
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+      - name: Get release version
+        id: get_version
+        uses: battila7/get-version-action@v2
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./spicy.tar.bz
+          asset_name: spicy-${{ steps.get_version.outputs.version }}.tar.bz
+          asset_content_type: application/x-tar

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 compile_commands.json
 .clangd
 .cache
+VERSION

--- a/scripts/autogen-version
+++ b/scripts/autogen-version
@@ -4,8 +4,10 @@
 # --short a short one. Or alternatively with --header, a version.h file with
 # various constants defined accordingly.
 
+set -e
+
 usage() {
-    echo "usage $(basename $0) [--short|--header <file>|--cmake] [--git-root <dir>] [<commit>]"
+    echo "usage $(basename "$0") [--short|--header <file>|--cmake] [--git-root <dir>] [<commit>]"
 }
 
 output=long
@@ -25,13 +27,13 @@ while [ $# -ge 1 ]; do
         shift
     elif [ "$1" = "--git-root" ]; then
         test $# -lt 2 && usage && exit 1
-        cd $2
+        cd "$2" || exit
         shift
         shift
     fi
 done
 
-if [ $# != 0 -a $# != 1 ]; then
+if [ $# != 0 ] && [ $# != 1 ]; then
     usage
     exit 1
 fi
@@ -93,7 +95,7 @@ test -z "${major}" && major=0
 test -z "${minor}" && minor=0
 test -z "${patch}" && patch=0
 
-version_number=$((${major} * 10000 + ${minor} * 100 + ${patch}))
+version_number=$((major * 10000 + minor * 100 + patch))
 
 if [ "${output}" = "long" ]; then
     echo "${version}${str_prerelease} (${str_branch}${hash})"

--- a/scripts/autogen-version
+++ b/scripts/autogen-version
@@ -38,12 +38,26 @@ if [ $# != 0 ] && [ $# != 1 ]; then
     exit 1
 fi
 
-ref=HEAD
-describe_arg="--dirty"
+get_version() {
+    if git rev-parse --git-dir > /dev/null 2>&1; then
+        ref=HEAD
+        describe_arg="--dirty"
 
-test -n "$1" && test "$1" != "HEAD" && ref="$1" && describe_arg="$1"
+        test -n "$1" && test "$1" != "HEAD" && ref="$1" && describe_arg="$1"
 
-branch=$(git symbolic-ref --short "${ref}" 2>/dev/null)
+        hash=$(git rev-parse --short "${ref}")
+        branch=$(git symbolic-ref --short "${ref}" 2>/dev/null || echo "${hash}")
+        git_version=$(git describe --always --match "v*" "${describe_arg}" | sed 's/^v//g')
+    elif [ -f ./VERSION ]; then
+        # Read information from VERSION file which contains values for `branch`, `hash`, and `git_version`.
+        . ./VERSION
+    else
+        >&2 echo "Cannot extract version information: neither git repository nor VERSION file present"
+        exit 1
+    fi
+}
+
+get_version "$@"
 
 # When running from CI, for geting the branch name we prefer what
 # might be passed in through environment variables as we may not
@@ -51,12 +65,9 @@ branch=$(git symbolic-ref --short "${ref}" 2>/dev/null)
 test -n "${CI_COMMIT_REF_NAME}" && branch=${CI_COMMIT_REF_NAME} # GitLab
 test -n "${CIRRUS_BRANCH}" && branch=${CIRRUS_BRANCH} # Cirrus CI
 
-describe=$(git describe --always --match "v*" "${describe_arg}" | sed 's/^v//g')
-
-version=$(echo "${describe}" | awk -F - '{print $1}' | sed 's/^v//g')
-commit=$(echo "${describe}" | awk -F - '{print $2}')
-hash=$(git rev-parse --short "${ref}")
-dirty=$(echo "${describe}" | awk -F - '{print $4}')
+version=$(echo "${git_version}" | awk -F - '{print $1}' | sed 's/^v//g')
+commit=$(echo "${git_version}" | awk -F - '{print $2}')
+dirty=$(echo "${git_version}" | awk -F - '{print $4}')
 
 test -n "${commit}" -a -n "${dirty}" && commit="${commit}.${dirty}"
 

--- a/scripts/autogen-version
+++ b/scripts/autogen-version
@@ -7,7 +7,7 @@
 set -e
 
 usage() {
-    echo "usage $(basename "$0") [--short|--header <file>|--cmake] [--git-root <dir>] [<commit>]"
+    echo "usage $(basename "$0") [--short | --header <file> | --cmake | --store] [--git-root <dir>] [<commit>]"
 }
 
 output=long
@@ -24,6 +24,9 @@ while [ $# -ge 1 ]; do
         shift
     elif [ "$1" = "--cmake" ]; then
         output=cmake
+        shift
+    elif [ "$1" = "--store" ]; then
+        output=store
         shift
     elif [ "$1" = "--git-root" ]; then
         test $# -lt 2 && usage && exit 1
@@ -135,4 +138,10 @@ EOF
 elif [ "${output}" = "cmake" ]; then
     echo "${version}"
 
+elif [ "${output}" = "store" ]; then
+    {
+        echo "branch=$branch"
+        echo "hash=$hash"
+        echo "git_version=$git_version"
+    } > VERSION
 fi

--- a/scripts/make-tarball.sh
+++ b/scripts/make-tarball.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+TARBALL=spicy.tar
+
+# Create archive for the main repo.
+rm -f "$TARBALL"
+git archive -o "${TARBALL}" HEAD
+
+# Add all submodules to archive.
+git submodule foreach --quiet 'cd $toplevel && tar rf '"${TARBALL}"' $sm_path'
+
+# Add a VERSION file to the archive.
+./scripts/autogen-version --store
+tar rf "${TARBALL}" VERSION
+
+# Compress archive.
+bzip2 -9 "${TARBALL}"


### PR DESCRIPTION
This PR adds a script to create a release tarball and a GH action
attaching which creates and attaches the tarball to any release tags
pushed to the repo. We assume that that release tags are of the form
`v*`.

Closes #650.
