### PR TITLE
Fix dynamic loading flags on FreeBSD.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -734,6 +734,7 @@ freebsd11_task:
     image_family: freebsd-11-4
     cpu: 8
     memory: 8GB
+
   prepare_script: ./ci/prepare_freebsd.sh
 
   timeout_in: 120m
@@ -768,11 +769,11 @@ freebsd11_task:
     type: application/gzip
 
 freebsd12_task:
-  trigger_type: manual
   freebsd_instance:
     image_family: freebsd-12-2
     cpu: 8
     memory: 8GB
+
   prepare_script: ./ci/prepare_freebsd.sh
 
   timeout_in: 120m

--- a/ci/prepare_freebsd.sh
+++ b/ci/prepare_freebsd.sh
@@ -5,6 +5,10 @@ sysctl hw.model hw.machine hw.ncpu
 set -e
 set -x
 
+# Detection of whether we run in the build directory requires `/proc`.
+echo "proc /proc procfs rw,noauto 0 0" >> /etc/fstab
+mount /proc
+
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
 pkg install -y bash git cmake flex bison python3 ninja llvm11 zeek base64 ccache
 

--- a/hilti/toolchain/bin/hilti-config.cc
+++ b/hilti/toolchain/bin/hilti-config.cc
@@ -160,9 +160,7 @@ int main(int argc, char** argv) {
             if ( want_dynamic_linking ) {
 #if __APPLE__
                 result.push_back("-Wl,-all_load");
-#endif
-
-#if __linux__
+#else
                 result.push_back("-Wl,--export-dynamic");
                 result.push_back("-Wl,--whole-archive");
 #endif
@@ -176,9 +174,7 @@ int main(int argc, char** argv) {
             if ( want_dynamic_linking ) {
 #if __APPLE__
                 result.push_back("-Wl,-noall_load");
-#endif
-
-#if __linux__
+#else
                 result.push_back("-Wl,--no-whole-archive");
 #endif
             }

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -53,7 +53,7 @@ void hilti::Configuration::initLocation(const char* argv0) { initLocation(std::s
 void hilti::Configuration::initLocation(const std::string_view& argv0) {
     auto exec = hilti::rt::filesystem::absolute(argv0).native();
     auto prefix = hilti::rt::filesystem::absolute("${CMAKE_BINARY_DIR}").native();
-    init(util::startsWith(exec, prefix));
+    init(util::startsWith(hilti::rt::normalizePath(exec), hilti::rt::normalizePath(prefix)));
 }
 
 void Configuration::init(bool use_build_directory) {

--- a/spicy/toolchain/bin/spicy-config.cc
+++ b/spicy/toolchain/bin/spicy-config.cc
@@ -263,9 +263,7 @@ int main(int argc, char** argv) {
             if ( want_dynamic_linking ) {
 #if __APPLE__
                 result.push_back("-Wl,-all_load");
-#endif
-
-#if __linux__
+#else
                 result.push_back("-Wl,--export-dynamic");
                 result.push_back("-Wl,--whole-archive");
 #endif
@@ -279,9 +277,7 @@ int main(int argc, char** argv) {
             if ( want_dynamic_linking ) {
 #if __APPLE__
                 result.push_back("-Wl,-noall_load");
-#endif
-
-#if __linux__
+#else
                 result.push_back("-Wl,--no-whole-archive");
 #endif
             }

--- a/tests/spicy/doc/my-http-host-driver-hlto.cc
+++ b/tests/spicy/doc/my-http-host-driver-hlto.cc
@@ -1,5 +1,5 @@
 // @TEST-EXEC: spicyc -j my-http.spicy -o my-http.hlto
-// @TEST-EXEC: $(spicy-config --cxx) -o my-http %INPUT $(spicy-config --cxxflags --ldflags --dynamic-loading)
+// @TEST-EXEC: $(spicy-config --cxx) -o my-http %INPUT $(spicy-config --cxxflags --ldflags --dynamic-loading --debug)
 // @TEST-EXEC: ./my-http my-http.hlto MyHTTP::RequestLine "$(cat data)" >output
 // @TEST-EXEC: btest-diff output
 //


### PR DESCRIPTION
We previously were adding logic for either Apple or Linux platforms
which left this broken on FreeBSD. This patch simplifies the logic so
that we now only perform special handling on Apple and use the same
behavior elsewhere.

Closes #634.