### PR TITLE
Remove manual installation of Zeek CMake files on FreeBSD CI.

### DIFF
--- a/ci/prepare_freebsd.sh
+++ b/ci/prepare_freebsd.sh
@@ -15,9 +15,3 @@ pkg install -y bash git cmake flex bison python3 ninja llvm11 zeek base64 ccache
 pyver=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')
 pkg install -y "$pyver"-pip
 pip install btest
-
-# While the Zeek port does contain the Zeek CMake files, that package version
-# is still not present in Cirrus CI images, so we patch the files in by hand.
-# The branch we pick here roughly matches the version of zeek packaged in above
-# port.
-git clone --branch release/zeek-3.0 https://github.com/zeek/cmake /usr/local/share/zeek/cmake


### PR DESCRIPTION
Cirrus CI have bumped their FreeBSD instance images so this step is not
necessary anymore (and would in fact fail as the files are already
present).