### PR TITLE
Use "default" compiler if possible in Docker images.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -216,7 +216,7 @@ macos_catalina_task:
     - pip3 install "btest>=0.66" sphinx_rtd_theme
 
   configure_script:
-    - ./configure --generator=Ninja --with-cxx-compiler=/usr/local/opt/llvm/bin/clang++ --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache
+    - ./configure --generator=Ninja --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache
   build_script:
     - ninja -C build all check
   test_build_script:
@@ -325,9 +325,9 @@ docker_alpine_3_12_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - LDFLAGS="-lucontext" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++
+    - LDFLAGS="-lucontext" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -364,9 +364,9 @@ docker_centos_7_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - source scl_source enable devtoolset-9 && LDFLAGS="-static-libstdc++ -static-libgcc" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=/opt/rh/devtoolset-9/root/usr/bin/clang++
+    - source scl_source enable devtoolset-9 && LDFLAGS="-static-libstdc++ -static-libgcc" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - source scl_source enable devtoolset-9 && ninja -j5 -C build install
+    - source scl_source enable devtoolset-9 && ninja -j4 -C build install
   test_script:
     - cd tests && source scl_source enable devtoolset-9 && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -403,9 +403,9 @@ docker_centos_8_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -442,7 +442,7 @@ docker_debian9_task:
   container:
     dockerfile: docker/Dockerfile.debian-9
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -467,7 +467,7 @@ docker_debian9_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -482,7 +482,7 @@ docker_debian10_task:
   container:
     dockerfile: docker/Dockerfile.debian-10
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -507,7 +507,7 @@ docker_debian10_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -522,7 +522,7 @@ docker_ubuntu16_task:
   container:
     dockerfile: docker/Dockerfile.ubuntu-16
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -547,7 +547,7 @@ docker_ubuntu16_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -562,7 +562,7 @@ docker_ubuntu18_task:
   container:
     dockerfile: docker/Dockerfile.ubuntu-18
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -587,7 +587,7 @@ docker_ubuntu18_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -602,7 +602,7 @@ docker_ubuntu20_task:
   container:
     dockerfile: docker/Dockerfile.ubuntu-20
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -627,7 +627,7 @@ docker_ubuntu20_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -642,7 +642,7 @@ docker_fedora32_task:
   container:
     dockerfile: docker/Dockerfile.fedora-32
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -667,7 +667,7 @@ docker_fedora32_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -682,7 +682,7 @@ docker_fedora33_task:
   container:
     dockerfile: docker/Dockerfile.fedora-33
     cpu: 4
-    memory: 8G
+    memory: 12G
     docker_arguments:
       - SKIP_BUILD: 1
 
@@ -707,7 +707,7 @@ docker_fedora33_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -808,7 +808,7 @@ freebsd11_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:
@@ -847,7 +847,7 @@ freebsd12_task:
   configure_script:
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local
   build_script:
-    - ninja -j5 -C build install
+    - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
   packaging_script:

--- a/docker/Dockerfile.alpine-3.12
+++ b/docker/Dockerfile.alpine-3.12
@@ -14,7 +14,7 @@ RUN apk update
 RUN apk add ccache cmake curl g++ gcc gdb git make ninja python3 vim
 
 # Install Spicy dependencies.
-RUN apk add bash bison clang clang-dev clang-libs clang-static flex flex-dev flex-libs libucontext-dev llvm10-dev llvm10-static py3-pip py3-sphinx py3-sphinx_rtd_theme doxygen
+RUN apk add bash bison flex flex-dev flex-libs libucontext-dev py3-pip py3-sphinx py3-sphinx_rtd_theme doxygen
 RUN pip3 install "btest>=0.66"
 
 # Install Zeek dependencies.
@@ -29,4 +29,4 @@ WORKDIR /root
 
 # Install Spicy.
 ADD . /opt/spicy/src
-RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && LDFLAGS="-lucontext" ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++ && ninja -C build install && rm -rf build)
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && LDFLAGS="-lucontext" ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -11,10 +11,11 @@ ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
 RUN yum install -y epel-release yum-utils
 RUN yum update -y
 
-# Install and activate devtoolsset-9.
+# Install and activate devtoolset-9.
 RUN yum install -y centos-release-scl && yum-config-manager --enable rhel-server-rhscl-7-rpms && yum install -y devtoolset-9
 SHELL [ "/usr/bin/scl", "enable", "devtoolset-9"]
 RUN echo ". scl_source enable devtoolset-9" >> /etc/profile
+ENV PATH="/opt/rh/devtoolset-9/root/usr/bin:${PATH}"
 
 # Install development tools.
 RUN yum install -y ccache git make ninja-build python3 python3-pip vim doxygen diffutils m4
@@ -23,18 +24,6 @@ RUN yum install -y ccache git make ninja-build python3 python3-pip vim doxygen d
 WORKDIR /usr/local/cmake
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - -C /usr/local/cmake --strip-components 1
 ENV PATH="/usr/local/cmake/bin:${PATH}"
-
-# Need to compile Clang, there don't seem to be packages out there for v11.
-RUN mkdir -p /opt/clang11/src && \
-    cd /opt/clang11/src && \
-    git clone --branch llvmorg-11.0.0 --single-branch --recursive --depth=1 https://github.com/llvm/llvm-project.git && \
-    cd llvm-project && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/opt/rh/devtoolset-9/root/usr -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -G Ninja ../llvm && \
-    ninja install && \
-    cd ../../.. && \
-    rm -rf /opt/clang11
 
 # Install Spicy dependencies.
 RUN yum install -y python3-sphinx
@@ -60,4 +49,4 @@ WORKDIR /root
 
 # Install Spicy.
 ADD . /opt/spicy/src
-RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=/opt/rh/devtoolset-9/root/usr/bin/clang++ && ninja -C build install && rm -rf build)
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -15,22 +15,11 @@ RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
 RUN yum install -y epel-release yum-utils && yum-config-manager --set-enabled powertools
 
 # Install development tools.
-RUN yum install -y ccache gcc gcc-c++ gdb git make ninja-build python3 python3-pip vim doxygen diffutils
+RUN yum install -y ccache gdb git make ninja-build python3 python3-pip vim doxygen diffutils gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:$PATH
 
 # Need a more recent CMake than available.
 RUN cd /usr/local && curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - && ln -s /usr/local/cmake-3.16.4-Linux-x86_64/bin/cmake /usr/local/bin
-
-# Need to compile Clang, there don't seem to be packages out there for v9.
-RUN mkdir -p /opt/clang9/src && \
-    cd /opt/clang9/src && \
-    git clone --branch llvmorg-9.0.1 --single-branch --recursive https://github.com/llvm/llvm-project.git && \
-    cd llvm-project && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -G Ninja ../llvm && \
-    ninja install && \
-    cd ../../.. && \
-    rm -rf /opt/clang9
 
 # Install Spicy dependencies.
 RUN yum install -y flex python3-sphinx
@@ -56,4 +45,4 @@ WORKDIR /root
 
 # Install Spicy.
 ADD . /opt/spicy/src
-RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++ && ninja -C build install && rm -rf build)
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)

--- a/docker/Dockerfile.debian-10
+++ b/docker/Dockerfile.debian-10
@@ -13,7 +13,9 @@ ENV CCACHE_COMPRESS 1
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 
-# using clang instead of gcc because Spicy depends on it
+# We use clang to build as Spicy requires a C++17-capable compiler. Buster
+# ships with gcc-8.3.0, but we require at least gcc-9 which is only available
+# in testing here. Use an LLVM stack instead.
 ENV LLVM_VERSION "11"
 ENV CC "clang-${LLVM_VERSION}"
 ENV CXX "clang++-${LLVM_VERSION}"

--- a/docker/Dockerfile.debian-9
+++ b/docker/Dockerfile.debian-9
@@ -12,7 +12,9 @@ ENV CCACHE_COMPRESS 1
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.17.2"
 
-# using clang instead of gcc because Spicy depends on it
+# We use clang to build as Spicy requires a C++17-capable compiler. Strech
+# ships with gcc-6.3.0, but we require at least gcc-9 which is only available
+# in testing here. Use an LLVM stack instead.
 ENV LLVM_VERSION "11"
 ENV CC "clang-${LLVM_VERSION}"
 ENV CXX "clang++-${LLVM_VERSION}"

--- a/docker/Dockerfile.fedora-32
+++ b/docker/Dockerfile.fedora-32
@@ -20,15 +20,11 @@ RUN yum install -y libpcap-devel openssl-devel zlib-devel \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
 # Install Spicy build dependencies
- && yum install -y ccache git ninja-build cmake clang flex bison llvm-devel findutils diffutils python3-pip which \
+ && yum install -y ccache git ninja-build cmake flex bison gcc-c++ findutils diffutils python3-pip which \
  && pip3 install "btest>=0.66"
-
-ENV CXX clang++
-ENV CC clang
-ENV ASM clang
 
 WORKDIR /root
 
 # Install Spicy.
 ADD . /opt/spicy/src
-RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++ && ninja -C build install && rm -rf build)
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)

--- a/docker/Dockerfile.fedora-33
+++ b/docker/Dockerfile.fedora-33
@@ -20,15 +20,11 @@ RUN yum install -y libpcap-devel openssl-devel zlib-devel \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
 # Install Spicy build dependencies
- && yum install -y ccache git ninja-build cmake clang flex bison llvm-devel findutils diffutils python3-pip which \
+ && yum install -y ccache git ninja-build cmake flex bison gcc-c++ findutils diffutils python3-pip which \
  && pip3 install "btest>=0.66"
-
-ENV CXX clang++
-ENV CC clang
-ENV ASM clang
 
 WORKDIR /root
 
 # Install Spicy.
 ADD . /opt/spicy/src
-RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek --with-cxx-compiler=clang++ && ninja -C build install && rm -rf build)
+RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)

--- a/docker/Dockerfile.ubuntu-16
+++ b/docker/Dockerfile.ubuntu-16
@@ -12,6 +12,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV CCACHE_DIR=/var/spool/ccache
 ENV CCACHE_COMPRESS=1
 
+# We use clang to build as Spicy requires a C++17-capable compiler. Xenial
+# ships with gcc-6.0.0, but we require at least gcc-9 which is only available
+# in testing here. Use an LLVM stack instead.
 ENV CXX clang++-11
 ENV CC clang-11
 ENV ASM clang-11

--- a/docker/Dockerfile.ubuntu-18
+++ b/docker/Dockerfile.ubuntu-18
@@ -12,6 +12,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV CCACHE_DIR=/var/spool/ccache
 ENV CCACHE_COMPRESS=1
 
+# We use clang to build as Spicy requires a C++17-capable compiler. Bionic
+# ships with gcc-8.4.0, but we require at least gcc-9 which is only available
+# in testing here. Use an LLVM stack instead.
+ENV CXX=clang++-9
+ENV CC=clang-9
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
  # Zeek.
@@ -50,9 +56,6 @@ RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.15.0/cmake-3.1
 ENV PATH="/usr/local/cmake/bin:${PATH}"
 
 WORKDIR /root
-
-ENV CXX=clang++-9
-ENV CC=clang-9
 
 # Install Spicy.
 ADD . /opt/spicy/src

--- a/docker/Dockerfile.ubuntu-20
+++ b/docker/Dockerfile.ubuntu-20
@@ -27,16 +27,10 @@ RUN apt-get update \
  && cd - \
  && rm -rf /tmp/zeek-packages \
  # Spicy build and test dependencies.
- && apt-get install -y --no-install-recommends git cmake ninja-build ccache bison flex libfl-dev python3 python3-pip zlib1g-dev jq locales-all python3-setuptools python3-wheel make \
+ && apt-get install -y --no-install-recommends git cmake ninja-build ccache bison flex g++ libfl-dev python3 python3-pip zlib1g-dev jq locales-all python3-setuptools python3-wheel make \
  && pip3 install "btest>=0.66" pre-commit \
- # Clang-9.
- && apt-get install -y --no-install-recommends llvm-9-dev clang-9 libclang-9-dev libc++-dev libc++1 libc++abi-dev libc++abi1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-ENV CXX clang++-9
-ENV CC clang-9
-ENV ASM clang-9
 
 # Install Spicy.
 ADD . /opt/spicy/src


### PR DESCRIPTION
Since we now compile directly with the system compiler we do not
strictly require LLVM anymore. This patch simplifies the in-tree Docker
images so they use the default compiler for the platform if possible;
since we require a C++17-capable compiler we still need to install
custom compilers on a number of platforms.