### PR TITLE
Extend spicy-doc to document begin/end operators.

### DIFF
--- a/doc/autogen/types/bytes.rst
+++ b/doc/autogen/types/bytes.rst
@@ -123,6 +123,14 @@
 
 .. rubric:: Operators
 
+.. spicy:operator:: bytes::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
+.. spicy:operator:: bytes::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
+
 .. spicy:operator:: bytes::Equal bool t:bytes <sp> op:== <sp> t:bytes
 
     Compares two bytes values lexicographically.

--- a/doc/autogen/types/list.rst
+++ b/doc/autogen/types/list.rst
@@ -1,5 +1,13 @@
 .. rubric:: Operators
 
+.. spicy:operator:: list::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
+.. spicy:operator:: list::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
+
 .. spicy:operator:: list::Equal bool t:list <sp> op:== <sp> t:list
 
     Compares two lists element-wise.

--- a/doc/autogen/types/map.rst
+++ b/doc/autogen/types/map.rst
@@ -12,9 +12,17 @@
 
 .. rubric:: Operators
 
+.. spicy:operator:: map::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
 .. spicy:operator:: map::Delete void delete <sp> t:map[element]
 
     Removes an element from the map.
+
+.. spicy:operator:: map::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
 
 .. spicy:operator:: map::Equal bool t:map <sp> op:== <sp> t:map
 

--- a/doc/autogen/types/set.rst
+++ b/doc/autogen/types/set.rst
@@ -10,9 +10,17 @@
 
     Adds an element to the set.
 
+.. spicy:operator:: set::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
 .. spicy:operator:: set::Delete void delete <sp> t:set[element]
 
     Removes an element from the set.
+
+.. spicy:operator:: set::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
 
 .. spicy:operator:: set::Equal bool t:set <sp> op:== <sp> t:set
 

--- a/doc/autogen/types/stream.rst
+++ b/doc/autogen/types/stream.rst
@@ -34,6 +34,14 @@
 
 .. rubric:: Operators
 
+.. spicy:operator:: stream::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
+.. spicy:operator:: stream::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
+
 .. spicy:operator:: stream::Size uint<64> op:| t:stream op:|
 
     Returns the number of stream the value contains.

--- a/doc/autogen/types/vector.rst
+++ b/doc/autogen/types/vector.rst
@@ -48,6 +48,14 @@
 
 .. rubric:: Operators
 
+.. spicy:operator:: vector::Begin <iterator> begin(<container>)
+
+    Returns an iterator to the beginning of the container's content.
+
+.. spicy:operator:: vector::End <iterator> end(<container>)
+
+    Returns an iterator to the end of the container's content.
+
 .. spicy:operator:: vector::Equal bool t:vector <sp> op:== <sp> t:vector
 
     Compares two vectors element-wise.

--- a/hilti/toolchain/include/ast/operators/generic.h
+++ b/hilti/toolchain/include/ast/operators/generic.h
@@ -46,7 +46,7 @@ END_OPERATOR_CUSTOM
 BEGIN_OPERATOR_CUSTOM(generic, Begin)
     Type result(const std::vector<Expression>& ops) const {
         if ( ops.empty() )
-            return type::DocOnly("<iterable>");
+            return type::DocOnly("<iterator>");
 
         return type::isIterable(ops[0].type()) ? ops[0].type().iteratorType(ops[0].isConstant()) : type::unknown;
     }
@@ -55,7 +55,7 @@ BEGIN_OPERATOR_CUSTOM(generic, Begin)
 
     std::vector<Operand> operands() const {
         return {
-            {.type = type::Any()},
+            {.type = type::Any(), .doc = "<container>"},
         };
     }
 
@@ -64,13 +64,13 @@ BEGIN_OPERATOR_CUSTOM(generic, Begin)
             p.node.addError("not an iterable type");
     }
 
-    std::string doc() const { return "Returns an iterator to the beginning of a container's content."; }
+    std::string doc() const { return "Returns an iterator to the beginning of the container's content."; }
 END_OPERATOR_CUSTOM
 
 BEGIN_OPERATOR_CUSTOM(generic, End)
     Type result(const std::vector<Expression>& ops) const {
         if ( ops.empty() )
-            return type::DocOnly("<iterable>");
+            return type::DocOnly("<iterator>");
 
         return type::isIterable(ops[0].type()) ? ops[0].type().iteratorType(ops[0].isConstant()) : type::unknown;
     }
@@ -79,7 +79,7 @@ BEGIN_OPERATOR_CUSTOM(generic, End)
 
     std::vector<Operand> operands() const {
         return {
-            {.type = type::Any()},
+            {.type = type::Any(), .doc = "<container>"},
         };
     }
 
@@ -88,7 +88,7 @@ BEGIN_OPERATOR_CUSTOM(generic, End)
             p.node.addError("not an iterable type");
     }
 
-    std::string doc() const { return "Returns an iterator to the end of a container's content."; }
+    std::string doc() const { return "Returns an iterator to the end of the container's content."; }
 END_OPERATOR_CUSTOM
 
 BEGIN_OPERATOR_CUSTOM(generic, New)


### PR DESCRIPTION
This needs to hardcode the list of iterable container type unfortunately
as we don't have a way to enumerate them automatically.

Closes #640.