### PR TITLE
Zeek plugin: Add functions to access UIDs and FUIDs.

### DIFF
--- a/doc/autogen/zeek-functions.spicy
+++ b/doc/autogen/zeek-functions.spicy
@@ -16,6 +16,12 @@ Triggers a DPD protocol violation for the current connection.
 
 Returns true if we're currently parsing the originator side of a connection.
 
+.. _spicy_uid:
+
+.. rubric:: ``function zeek::uid() : string``
+
+Returns the current connection's UID.
+
 .. _spicy_flip_roles:
 
 .. rubric:: ``function zeek::flip_roles()``
@@ -33,6 +39,12 @@ Returns the number of packets seen so far on the current side of the current con
 .. rubric:: ``function zeek::file_begin()``
 
 Signals the beginning of a file to Zeek's file analysis, associating it with the current connection.
+
+.. _spicy_fuid:
+
+.. rubric:: ``function zeek::fuid() : string``
+
+Returns the current file's FUID.
 
 .. _spicy_file_set_size:
 

--- a/tests/zeek/evt/file-analyzer.zeek
+++ b/tests/zeek/evt/file-analyzer.zeek
@@ -13,8 +13,15 @@ event text::data(f: fa_file, data: string)
 # @TEST-START-FILE text.spicy
 module Text;
 
+import zeek;
+
 public type Data = unit {
     data: bytes &eod;
+
+    on %done {
+        # File ID isn't stable across platforms, so just check expected length.
+        assert |zeek::fuid()| == 18;
+    }
 };
 # @TEST-END-FILE
 

--- a/tests/zeek/evt/ssh-banner.zeek
+++ b/tests/zeek/evt/ssh-banner.zeek
@@ -36,7 +36,7 @@ public type Banner = unit {
     dash    : /-/;
     software: /[^\r\n]*/;
 
-    on %done { zeek::confirm_protocol(); }
+    on %done { zeek::confirm_protocol(); assert zeek::uid() == "CHhAvVGS1DHFjwGM9"; }
     on %error { zeek::reject_protocol("kaputt"); }
 };
 # @TEST-END-FILE

--- a/zeek/plugin/include/runtime-support.h
+++ b/zeek/plugin/include/runtime-support.h
@@ -161,6 +161,11 @@ void debug(const std::string& msg);
  */
 hilti::rt::Bool is_orig();
 
+/**
+ * Returns the current connection's UID.
+ */
+std::string uid();
+
 /** Instructs to Zeek to flip the directionality of the current connecction. */
 void flip_roles();
 
@@ -190,6 +195,11 @@ void reject_protocol(const std::string& reason);
  * with the current connection.
  */
 void file_begin();
+
+/**
+ * Returns the current file's FUID.
+ */
+std::string fuid();
 
 /**
  * Signals the expected size of a file to Zeek's file analysis.

--- a/zeek/plugin/spicy/zeek.spicy
+++ b/zeek/plugin/spicy/zeek.spicy
@@ -15,6 +15,9 @@ public function reject_protocol(reason: string) : void &cxxname="spicy::zeek::rt
 ## Returns true if we're currently parsing the originator side of a connection.
 public function is_orig() : bool &cxxname="spicy::zeek::rt::is_orig";
 
+## Returns the current connection's UID.
+public function uid() : string &cxxname="spicy::zeek::rt::uid";
+
 ## Instructs Zeek to flip the directionality of the current connection.
 public function flip_roles() : void &cxxname="spicy::zeek::rt::flip_roles";
 
@@ -23,6 +26,9 @@ public function number_packets() : uint64 &cxxname="spicy::zeek::rt::number_pack
 
 ## Signals the beginning of a file to Zeek's file analysis, associating it with the current connection.
 public function file_begin() : void &cxxname="spicy::zeek::rt::file_begin";
+
+## Returns the current file's FUID.
+public function fuid() : string &cxxname="spicy::zeek::rt::fuid";
 
 ## Signals the expected size of a file to Zeek's file analysis.
 public function file_set_size(size: uint64) : void &cxxname="spicy::zeek::rt::file_set_size";

--- a/zeek/plugin/src/runtime-support.cc
+++ b/zeek/plugin/src/runtime-support.cc
@@ -165,6 +165,15 @@ hilti::rt::Bool rt::is_orig() {
     else
         throw ValueUnavailable("is_orig() not available in current context");
 }
+std::string rt::uid() {
+    auto cookie = static_cast<Cookie*>(hilti::rt::context::cookie());
+    assert(cookie);
+
+    if ( auto c = std::get_if<cookie::ProtocolAnalyzer>(cookie) )
+        return c->analyzer->Conn()->GetUID().Base62("C");
+    else
+        throw ValueUnavailable("uid() not available in current context");
+}
 
 void rt::flip_roles() {
     auto cookie = static_cast<Cookie*>(hilti::rt::context::cookie());
@@ -218,6 +227,18 @@ static std::string _file_id(const rt::cookie::ProtocolAnalyzer& c) {
 
 void rt::file_begin() {
     // Nothing todo.
+}
+
+std::string rt::fuid() {
+    auto cookie = static_cast<Cookie*>(hilti::rt::context::cookie());
+    assert(cookie);
+
+    if ( auto f = std::get_if<cookie::FileAnalyzer>(cookie) ) {
+        if ( auto file = f->analyzer->GetFile() )
+            return file->GetID();
+    }
+
+    throw ValueUnavailable("fuid() not available in current context");
 }
 
 void rt::file_set_size(const hilti::rt::integer::safe<uint64_t>& size) {


### PR DESCRIPTION
zeek::uid() and zeek::fuid() return the current connection UID and file
FUID, respectively.

Closes #688.