### PR TITLE
Make Docker images standalone.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -330,6 +330,7 @@ docker_alpine_3_12_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -369,6 +370,7 @@ docker_centos_7_task:
     - source scl_source enable devtoolset-9 && ninja -j4 -C build install
   test_script:
     - cd tests && source scl_source enable devtoolset-9 && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - source scl_source enable devtoolset-9 && ninja -C build package
 
@@ -408,6 +410,7 @@ docker_centos_8_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -511,6 +514,7 @@ docker_debian9_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -552,6 +556,7 @@ docker_debian10_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -592,6 +597,7 @@ docker_ubuntu16_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -632,6 +638,7 @@ docker_ubuntu18_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -672,6 +679,7 @@ docker_ubuntu20_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -712,6 +720,7 @@ docker_fedora32_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 
@@ -752,6 +761,7 @@ docker_fedora33_task:
     - ninja -j4 -C build install
   test_script:
     - cd tests && SPICY_INSTALLATION_DIRECTORY=/opt/spicy btest -a installation -j -d
+    - zeek -N | grep Spicy
   packaging_script:
     - ninja -C build package
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -33,7 +33,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: docker/Dockerfile.ubuntu-18
+        file: docker/Dockerfile.ubuntu-20
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/spicy:latest

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -35,7 +35,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: docker/Dockerfile.ubuntu-18
+        file: docker/Dockerfile.ubuntu-20
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/spicy:${{ steps.version.outputs.RELEASE_VERSION }}

--- a/docker/Dockerfile.alpine-3.12
+++ b/docker/Dockerfile.alpine-3.12
@@ -6,7 +6,7 @@ ARG zeek_version=v3.0.3
 WORKDIR /root
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"
 
 RUN apk update
 

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -6,7 +6,7 @@ ARG ZEEK_VERSION=3.0.11-2.2
 WORKDIR /root
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"
 
 RUN yum install -y epel-release yum-utils
 RUN yum update -y

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -6,7 +6,7 @@ ARG ZEEK_VERSION=3.0.11-2.2
 WORKDIR /root
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"
 
 RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LC_ALL="C"' >> /etc/locale.conf \

--- a/docker/Dockerfile.fedora-32
+++ b/docker/Dockerfile.fedora-32
@@ -4,7 +4,7 @@ ARG SKIP_BUILD=
 ARG ZEEK_VERSION=3.0.11-2.1
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/:/opt/spicy/lib/spicy"
 
 RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LC_ALL="C"' >> /etc/locale.conf \

--- a/docker/Dockerfile.fedora-33
+++ b/docker/Dockerfile.fedora-33
@@ -4,7 +4,7 @@ ARG SKIP_BUILD=
 ARG ZEEK_VERSION=3.0.11-2.1
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/:/opt/spicy/lib/spicy"
 
 RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LC_ALL="C"' >> /etc/locale.conf \

--- a/docker/Dockerfile.ubuntu-16
+++ b/docker/Dockerfile.ubuntu-16
@@ -65,3 +65,6 @@ WORKDIR /root
 # Install Spicy.
 ADD . /opt/spicy/src
 RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)
+
+ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"

--- a/docker/Dockerfile.ubuntu-18
+++ b/docker/Dockerfile.ubuntu-18
@@ -62,4 +62,4 @@ ADD . /opt/spicy/src
 RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)
 
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
-ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy/"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"

--- a/docker/Dockerfile.ubuntu-20
+++ b/docker/Dockerfile.ubuntu-20
@@ -35,3 +35,6 @@ RUN apt-get update \
 # Install Spicy.
 ADD . /opt/spicy/src
 RUN test ! -z "${SKIP_BUILD}" || (cd /opt/spicy/src && ./configure --generator=Ninja --prefix=/opt/spicy --with-zeek=/opt/zeek && ninja -C build install && rm -rf build)
+
+ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
+ENV ZEEK_PLUGIN_PATH="/opt/spicy/lib64/spicy:/opt/spicy/lib/spicy"


### PR DESCRIPTION
This changeset updates the included Docker images so that the included
Zeek installation is usable with Spicy without further configuration.
