### PR TITLE
Fetch full history when building documentation in readthedocs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,8 +74,11 @@ linkcheck_ignore = [
     r'http://download.zeek.org',
     r'https://download.zeek.org']
 
-# Generate Doxygen output if we are building in readthedocs. Outside of
-# readthedocs this is done by `docs/Makefile`.
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    subprocess.call('doxygen', shell=True)
+    # Fetch complete history if we are build in readthedocs. This is required
+    # for `scripts/autogen-version` to work.
+    subprocess.run(['git', 'fetch', '--unshallow'], shell=True)
+    # Generate Doxygen output if we are building in readthedocs. Outside of
+    # readthedocs this is done by `docs/Makefile`.
+    subprocess.run(['doxygen'], shell=True)


### PR DESCRIPTION
Calculating version information requires an undeterministic extended
amount of Git history. Since the readthedocs build process by default
clones only up to of 50, this means that often we will not be able to
compute the expected history format (e.g., `d2e94ba8 (master d2e94ba8)`
instead of `0.4.0-1330 (master d2e94ba8)`).

With this patch we now fetch the full history in readthedocs.

Closes #707.