### PR TITLE
Fix compatibility with Zeek 4.1 API changes/removals

### DIFF
--- a/zeek/plugin/include/runtime-support.h
+++ b/zeek/plugin/include/runtime-support.h
@@ -438,7 +438,7 @@ inline ::zeek::ValPtr to_val(const hilti::rt::Vector<T>& v, ::zeek::TypePtr targ
         throw TypeMismatch("expected vector or list", target, location);
 
     auto vt = target->AsVectorType();
-    auto zv = std::make_unique<::zeek::VectorVal>(vt);
+    auto zv = std::make_unique<::zeek::VectorVal>(zeek::compat::ToValCtorType(vt));
     for ( auto i : v )
         zv->Assign(zv->Size(), to_val(i, zeek::compat::VectorType_Yield(vt), location));
 
@@ -464,7 +464,7 @@ inline ::zeek::ValPtr to_val(const hilti::rt::Map<K, V>& m, ::zeek::TypePtr targ
     if ( zeek::compat::TableType_GetIndexTypesLength(tt) != 1 )
         throw TypeMismatch("map with non-tuple elements", target, location);
 
-    auto zv = std::make_unique<::zeek::TableVal>(tt);
+    auto zv = std::make_unique<::zeek::TableVal>(zeek::compat::ToValCtorType(tt));
 
     for ( auto i : m ) {
         auto k = to_val(i.first, zeek::compat::TableType_GetIndexTypes(tt)[0], location);
@@ -489,7 +489,7 @@ inline ::zeek::ValPtr to_val(const hilti::rt::Set<T>& s, ::zeek::TypePtr target,
     if ( ! tt->IsSet() )
         throw TypeMismatch("set", target, location);
 
-    auto zv = std::make_unique<::zeek::TableVal>(tt);
+    auto zv = std::make_unique<::zeek::TableVal>(zeek::compat::ToValCtorType(tt));
 
     for ( auto i : s ) {
         if constexpr ( hilti::rt::is_tuple<T>::value )
@@ -521,7 +521,7 @@ inline ::zeek::ValPtr to_val(const T& t, ::zeek::TypePtr target, const std::stri
     if ( std::tuple_size<T>::value != rtype->NumFields() )
         throw TypeMismatch("tuple", target, location);
 
-    auto rval = std::make_unique<::zeek::RecordVal>(rtype);
+    auto rval = std::make_unique<::zeek::RecordVal>(zeek::compat::ToValCtorType(rtype));
     int idx = 0;
     hilti::rt::tuple_for_each(t, [&](const auto& x) {
         ::zeek::ValPtr v = nullptr;

--- a/zeek/plugin/include/zeek-compat.h
+++ b/zeek/plugin/include/zeek-compat.h
@@ -11,8 +11,11 @@
 
 #include <zeek-spicy/autogen/config.h>
 
-// TODO: Move to <zeek/zeek-config.h> once we don't need to support Zeek < 3.2 anymore.
+#if SPICY_ZEEK_VERSION_NUMBER >= 30200 // Zeek >= 3.2
+#include <zeek/zeek-config.h>
+#else
 #include "zeek-config.h"
+#endif
 
 //// Collect all the Zeek includes here that we need anywhere in the plugin.
 
@@ -190,6 +193,11 @@ inline auto ToValPtr(std::unique_ptr<T> p) {
 }
 
 template<typename T>
+inline auto ToValCtorType(T p) {
+    return ::zeek::IntrusivePtr{::zeek::NewRef{}, p};
+}
+
+template<typename T>
 inline auto Unref(const ::zeek::IntrusivePtr<T>& o) {
     // nothing to do
 }
@@ -217,7 +225,11 @@ inline auto ZeekArgs_Get(const std::vector<::zeek::TypePtr>& vl, uint64_t idx) {
 inline auto event_mgr_Enqueue(const ::zeek::EventHandlerPtr& h, ::zeek::Args vl) {
     return ::zeek::event_mgr.Enqueue(h, std::move(vl));
 }
+#if ZEEK_VERSION_NUMBER >= 40000 // Zeek >= 4.0
+inline auto event_register_Register(const std::string& x) { return ::zeek::event_registry->Register(x); }
+#else
 inline auto event_register_Register(const std::string& x) { return ::event_registry->Register(x); }
+#endif
 inline auto val_mgr_Bool(bool b) { return ::zeek::val_mgr->Bool(b); }
 inline auto val_mgr_Count(uint64_t i) { return ::zeek::val_mgr->Count(i); }
 inline auto val_mgr_Int(int64_t i) { return ::zeek::val_mgr->Int(i); }
@@ -259,6 +271,11 @@ inline auto EnumType_New(std::string& x) { return new ::EnumType(x); }
 template<typename T>
 inline auto ToValPtr(std::unique_ptr<T> p) {
     return p.release();
+}
+
+template<typename T>
+inline auto ToValCtorType(T p) {
+    return p;
 }
 
 inline auto Unref(::BroObj* o) { ::Unref(o); }

--- a/zeek/plugin/src/config.h.in
+++ b/zeek/plugin/src/config.h.in
@@ -10,6 +10,8 @@ namespace spicy::zeek::configuration {
 // can catch when this header wasn't included.
 #cmakedefine01 ZEEK_DEBUG_BUILD
 
+#define SPICY_ZEEK_VERSION_NUMBER ${ZEEK_VERSION_NUMBER}
+
 inline const int ZeekVersionNumber = ${ZEEK_VERSION_NUMBER};
 
 inline const auto CxxZeekIncludeDirectories = "${ZEEK_INCLUDE_DIRS}";


### PR DESCRIPTION
* Include paths require using <zeek/zeek-config.h>
* Val constructors that take raw pointers are gone, replaced by ones
  taking IntrusivePtr
* The global event_registry is replaced by zeek::event_registry

(There's also https://github.com/zeek/zeek/pull/1390 required to get Spicy compiling w/ current zeek/master branch)