### PR TITLE
Add syntax highlighting to docs

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
  && pip3 install "btest>=0.66" pre-commit \
  # Spicy doc dependencies.
  && apt-get install -y --no-install-recommends python3-sphinx python3-sphinx-rtd-theme doxygen \
+ && pip3 install --upgrade pygments \
  # GCC-9.
  && apt-get install -y --no-install-recommends g++ gcc \
  # Clang-9.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,15 +19,25 @@ clean:
 .PHONY: html
 html: autogen-docs sphinx
 
-.PHONY: sphinx
-sphinx:
+.PHONY: livehtml
+livehtml: autogen-docs sphinx-auto
+
+.PHONY: sphinx-setup
+sphinx-setup:
 	@rm -f "$(BUILDDIR)/doc-root" && ln -s "../doc" "$(BUILDDIR)/doc-root"
 	@  # Since Sphinx expects the Doxygen output directory, create it here to
 	@  # allow users to build without Doxygen, but still have Sphinx succeed.
 	@mkdir -p doxygen-output
+
+.PHONY: sphinx
+sphinx: sphinx-setup
 	@  # The RTD theme might be producing RemovedInSphinx30Warning
 	@PYTHONWARNINGS="ignore" PATH=$(BUILDDIR)/bin:$$PATH $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
 	@echo Built documentation in $(realpath $(DESTDIR)/html/index.html)
+
+.PHONY: sphinx-auto
+sphinx-auto: sphinx-setup
+	sphinx-autobuild --ignore "*.git/*" --ignore "*.lock" --ignore "*.pyc" --ignore "*.swp" --ignore "*.swpx" --ignore "*.swx" -b html -d "$(DESTDIR)/doctrees" "$(SOURCEDIR)" "$(DESTDIR)/html"
 
 .PHONY: autogen-docs
 autogen-docs:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,13 +9,17 @@ BUILDDIR      = $(PWD)/../build
 SOURCEDIR     = $(PWD)
 DESTDIR       = $(BUILDDIR)/html
 
+.PHONY: all
 all: html
 
+.PHONY: clean
 clean:
 	rm -rf $(DESTDIR)
 
+.PHONY: html
 html: autogen-docs sphinx
 
+.PHONY: sphinx
 sphinx:
 	@rm -f "$(BUILDDIR)/doc-root" && ln -s "../doc" "$(BUILDDIR)/doc-root"
 	@  # Since Sphinx expects the Doxygen output directory, create it here to
@@ -25,15 +29,16 @@ sphinx:
 	@PYTHONWARNINGS="ignore" PATH=$(BUILDDIR)/bin:$$PATH $(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(DESTDIR)" $(SPHINXOPTS) $(O)
 	@echo Built documentation in $(realpath $(DESTDIR)/html/index.html)
 
+.PHONY: autogen-docs
 autogen-docs:
 	@echo Auto-generating reference documentation ...
 	(cd $(BUILDDIR)/.. && ./doc/scripts/autogen-docs)
 
+.PHONY: doxygen
 doxygen:
 	mkdir -p ../build/html/html/doxygen
 	doxygen
 
+.PHONY: check
 check:
 	@$(SPHINXBUILD) -q -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
-
-.PHONY: autogen-docs check doxygen

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,7 +14,7 @@ all: html
 clean:
 	rm -rf $(DESTDIR)
 
-html: Makefile autogen-docs sphinx
+html: autogen-docs sphinx
 
 sphinx:
 	@rm -f "$(BUILDDIR)/doc-root" && ln -s "../doc" "$(BUILDDIR)/doc-root"
@@ -36,4 +36,4 @@ doxygen:
 check:
 	@$(SPHINXBUILD) -q -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
 
-.PHONY: Makefile autogen-docs check doxygen
+.PHONY: autogen-docs check doxygen

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,8 @@ needs_sphinx = '1.8'
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.extlinks',
-    'spicy'
+    'spicy',
+    'spicy-pygments'
 ]
 
 exclude_patterns = [u'_build', 'autogen', 'Thumbs.db',

--- a/doc/examples/frontpage.spicy
+++ b/doc/examples/frontpage.spicy
@@ -1,4 +1,4 @@
-# cat http-request.spicy
+# http-request.spicy
 
 module HTTP;
 
@@ -21,6 +21,3 @@ type Version = unit {
     :       /HTTP\//;
     number: /[0-9]+\.[0-9]+/;
 };
-
-# echo "GET /index.html HTTP/1.0" | spicy-driver http-request.spicy
-[$method=b"GET", $uri=b"/index.html", $version=[$number=b"1.0"]]

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -16,6 +16,7 @@ Here's a simple "Hello, world!" in Spicy:
 
 .. literalinclude:: examples/hello.spicy
    :lines: 4-
+   :language: spicy
 
 Assuming that's stored in ``hello.spicy``, you can compile and execute
 the code with Spicy's standalone compiler ``spicyc``::
@@ -80,6 +81,7 @@ Here's an example of a Spicy script for parsing HTTP request lines:
 .. literalinclude:: examples/my-http.spicy
    :lines: 4-
    :caption: my-http.spicy
+   :language: spicy
 
 In this example, you can see a number of things that are typical for
 Spicy code:
@@ -255,6 +257,7 @@ We do both of these by creating an additional control file for Zeek:
 .. literalinclude:: examples/my-http.evt
     :caption: my-http.evt
     :linenos:
+    :language: spicy-evt
 
 The first block (lines 1-3) tells Zeek that we have a new protocol
 analyzer to provide. The analyzer's Zeek-side name is
@@ -284,6 +287,7 @@ information we are parsing. Let's use this:
 
 .. literalinclude:: examples/my-http.zeek
     :caption: my-http.zeek
+    :language: zeek
 
 You see an Zeek event handler for the event that we just defined,
 having the expected signature of four parameters matching the types of
@@ -348,6 +352,7 @@ specific parser. Here's a small C++ program that parses input with our
 
 .. literalinclude:: examples/my-http.cc
     :caption: my-http.cc
+    :language: c++
 
 .. code::
 

--- a/doc/host-applications.rst
+++ b/doc/host-applications.rst
@@ -45,6 +45,7 @@ C++ application.
 .. literalinclude:: examples/my-http.spicy
    :lines: 4-
    :caption: my-http.spicy
+   :language: spicy
 
 First, we'll use :ref:`spicyc` to generate a C++ parser from the Spicy
 source code::
@@ -109,6 +110,7 @@ Let's start by using ``parse1()``:
 .. literalinclude:: examples/my-http-host-parse1.cc
    :caption: my-http-host.cc
    :lines: 10-34
+   :language: c++
 
 This code first instantiates a stream from data giving on the command
 line. It freezes the stream to indicate that no further data will
@@ -132,9 +134,10 @@ If we want that, we can use ``parse2()`` instead and provide it with a
 ``struct`` to fill in:
 
 .. literalinclude:: examples/my-http-host-parse2.cc
-   :caption: my-http-host.spicy
+   :caption: my-http-host.cc
    :lines: 10-44
    :emphasize-lines: 19-28
+   :language: c++
 
 ::
 
@@ -156,6 +159,7 @@ and (2) implement a Spicy hook that calls it:
    :caption: my-http.spicy
    :start-after: doc-start-callback-spicy
    :end-before: doc-end-callback-spicy
+   :language: spicy
 
 The ``&cxxname`` attribute for ``got_request_line`` indicates to Spicy
 that this is a function implemented externally inside custom C++ code,
@@ -166,6 +170,7 @@ function:
    :caption: my-http-callback.cc
    :start-after: doc-start-callback-cc
    :end-before: doc-end-callback-cc
+   :language: c++
 
 Finally, we compile it altogether:
 
@@ -229,6 +234,7 @@ prints out our one available parser:
 .. literalinclude:: examples/my-http-host-driver.cc
    :caption: my-http-host.cc
    :lines:   9-13,31-42,57-63
+   :language: c++
 
 ::
 
@@ -243,6 +249,7 @@ instantiate it from C++, and then feed it data:
 
 .. literalinclude:: examples/my-http-host-driver.cc
    :lines:   44-53
+   :language: c++
 
 ::
 
@@ -261,6 +268,7 @@ generically over HILTI types like this unit:
 
 .. literalinclude:: examples/my-http-host-driver.cc
    :lines: 15-29
+   :language: c++
 
 Adding ``print(unit->value()`` after the call to ``processInput()``
 then gives us this output:
@@ -288,6 +296,7 @@ taking the file to load from the command line:
     :caption: my-driver
     :lines: 31-69
     :emphasize-lines: 5-8
+    :language: c++
 
 ::
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ Spicy --- Generating Parsers for Protocols & Files
 ==================================================
 
 .. literalinclude:: examples/frontpage.spicy
-    :language: text
+    :language: spicy
 
 Overview
     Spicy is a C++ parser generator that makes it easy to create

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,11 @@ Spicy --- Generating Parsers for Protocols & Files
 .. literalinclude:: examples/frontpage.spicy
     :language: spicy
 
+::
+
+    # echo "GET /index.html HTTP/1.0" | spicy-driver http-request.spicy
+    [$method=b"GET", $uri=b"/index.html", $version=[$number=b"1.0"]]
+
 Overview
     Spicy is a C++ parser generator that makes it easy to create
     robust parsers for network protocols, file formats, and more.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -241,6 +241,7 @@ To build Spicy, you will need:
     - For building the documentation:
 
         * `Sphinx <https://www.sphinx-doc.org/en/master>`_  >= 1.8
+        * `Pygments <https://pygments.org/>`_  >= 2.5
         * `Read the Docs Sphinx Theme <https://sphinx-rtd-theme.readthedocs.io/en/stable/>`_  (``pip install sphinx_rtd_theme``)
 
 In the following we record how to get these dependencies in place on

--- a/doc/programming/language/modules.rst
+++ b/doc/programming/language/modules.rst
@@ -51,7 +51,9 @@ X.Y.Z;`` searches the module ``NAME`` (i.e., ``NAME.spicy``) inside a
 sub-directory ``X/Y/Z`` along the search path.
 
 Once Spicy code  has imported a module, it can access identifiers by
-prefixing them with the module's namespace::
+prefixing them with the module's namespace:
+
+.. spicy-code::
 
     import MyModule;
 

--- a/doc/programming/language/variables.rst
+++ b/doc/programming/language/variables.rst
@@ -20,13 +20,17 @@ As a shortcut, you can skip ``: TYPE`` if the global comes with a
 default.Spicy then just applies the expression's type to the global.
 
 We define global constants in a similar way, just replacing ``global``
-with ``const``::
+with ``const``:
+
+.. spicy-code::
 
     const x: uint32 = 42;
     const foo = "Foo";
 
 Inside a function, local variables use the same syntax once more, just
-prefixed with ``local`` this time::
+prefixed with ``local`` this time:
+
+.. spicy-code::
 
     function f() {
         local x: bytes;

--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -17,7 +17,9 @@ or records in other languages: It defines an ordered set of fields,
 each with a name and a type, that during runtime will store
 corresponding values. Units can be instantiated, fields can be
 assigned values, and these values can then be retrieved. Here's about
-the most basic Spicy unit one can define::
+the most basic Spicy unit one can define:
+
+.. spicy-code::
 
     type Foo = unit {
         version: uint32;
@@ -443,7 +445,9 @@ type; we discuss these the :ref:`corresponding section <sinks>`.
 There are three locations where hooks can be implemented:
 
 - Inside a unit, ``on <hook name> { ... }`` implements the hook of the
-  given name::
+  given name:
+
+  .. spicy-code::
 
     type Foo = unit {
         x: uint32;
@@ -456,7 +460,9 @@ There are three locations where hooks can be implemented:
     }
 
 - Field and container hooks may be directly attached to their field,
-  skipping the ``on ...`` part::
+  skipping the ``on ...`` part:
+
+  .. spicy-code::
 
     type Foo = unit {
         x: uint32 { ... }
@@ -465,7 +471,9 @@ There are three locations where hooks can be implemented:
 
 - At the global module level, one can add hooks to any available unit
   type through ``on <unit type>::<hook name> { ... }``. With the
-  definition of ``Foo`` above, this implements hooks externally::
+  definition of ``Foo`` above, this implements hooks externally:
+
+  .. spicy-code::
 
       on Foo::%init { ... }
       on Foo::x { ... }
@@ -479,7 +487,9 @@ There are three locations where hooks can be implemented:
 If multiple implementations are provided for the same hook, by default
 it remains undefined in which order they will execute. If a particular
 order is desired, you can specify priorities for your hook
-implementations::
+implementations:
+
+.. spicy-code::
 
       on Foo::v priority=5 { ... }
       on Foo::v priority=-5 { ... }
@@ -607,7 +617,9 @@ to be declared as ``inout`` (e.g., ``Bar(inout s: string)``).
 .. note::
 
     A common use-case for unit parameters is passing the ``self`` of a
-    higher-level unit down into a subunit::
+    higher-level unit down into a subunit:
+
+    .. spicy-code::
 
         type Foo = unit {
             ...
@@ -631,7 +643,9 @@ Unit types support the following type attributes:
 
 ``&size=N``
     Limits the unit's input to ``N`` bytes, which it must fully
-    consume. Example::
+    consume. Example:
+
+    .. spicy-code::
 
         type Foo = unit {
             a: int8;
@@ -889,7 +903,9 @@ expected to match at the current position of the input stream. The
 field's type becomes ``bytes``, and it will store the matching data.
 
 Inside hooks for fields with regular expressions, you can access
-capture groups through ``$1``, ``$2``, ``$3``, etc. For example::
+capture groups through ``$1``, ``$2``, ``$3``, etc. For example:
+
+.. spicy-code::
 
     x : /(a.c)(de*f)(h.j)/ {
         print $1, $2, $3;
@@ -1146,13 +1162,15 @@ explicit branch and one driving by look-ahead:
 
 .. rubric:: Branch by expression
 
-The most basic form of switching by expression looks like this::
+The most basic form of switching by expression looks like this:
+
+.. spicy-code::
 
     switch ( EXPR ) {
         VALUE_1 -> FIELD_1;
         VALUE_2 -> FIELD_2;
         ...
-        VALUE_N -> FIELD_N``
+        VALUE_N -> FIELD_N;
     };
 
 This evaluates ``EXPR`` at the time parsing reaches the ``switch``. If

--- a/doc/scripts/spicy-pygments.py
+++ b/doc/scripts/spicy-pygments.py
@@ -1,0 +1,270 @@
+from pygments.lexer import RegexLexer, bygroups, include, words, bygroups
+from pygments.token import *
+from sphinx.highlighting import lexers
+
+
+def setup(app):
+    lexers['spicy'] = SpicyLexer()
+    lexers['spicy-evt'] = SpicyEvtLexer()
+
+
+class SpicyLexer(RegexLexer):
+    """
+    For `Spicy <https://github.com/zeek/spicy>`_ grammars.
+    """
+    name = 'Spicy'
+    aliases = ['spicy']
+    filenames = ['*.spicy']
+
+    _hex = r'[0-9a-fA-F]'
+    _float = r'((\d*\.?\d+)|(\d+\.?\d*))([eE][-+]?\d+)?'
+    _h = r'[A-Za-z0-9][-A-Za-z0-9]*'
+    _id = r'[a-zA-Z_][a-zA-Z_0-9]*'
+
+    tokens = {
+        'root': [
+            include('whitespace'),
+            include('comments'),
+            include('attributes'),
+            include('hooks'),
+            include('properties'),
+            include('types'),
+            include('modules'),
+            include('keywords'),
+            include('literals'),
+            include('operators'),
+            include('punctuation'),
+            include('function-call'),
+            include('identifiers'),
+        ],
+
+        'whitespace': [
+            (r'\n', Text),
+            (r'\s+', Text),
+            (r'\\\n', Text),
+        ],
+
+        'comments': [
+            (r'#.*$', Comment),
+        ],
+
+        'attributes': [
+            (words(('bit-order', 'byte-order', 'chunked', 'convert', 'count',
+                    'cxxname', 'default', 'eod', 'internal', 'ipv4', 'ipv6',
+                    'length', 'no-emit', 'nosub', 'on-heap', 'optional',
+                    'originator', 'parse-at', 'parse-from', 'priority',
+                    'requires', 'responder', 'size', 'static', 'synchronize',
+                    'transient', 'try', 'type', 'until', 'until-including',
+                    'while', 'have_prototype'),
+                prefix=r'&', suffix=r'\b'),
+             Keyword.Pseudo),
+        ],
+
+        'hooks': [
+            (fr'(on)(\s+)(({_id}::)+%?{_id}(\.{_id})*)',
+                bygroups(Keyword, Text, Name.Function)),
+            (fr'(on)(\s+)(%?{_id}(\.{_id})*)',
+                bygroups(Keyword, Text, Name.Function)),
+        ],
+
+        'properties': [
+            # Like an ID, but allow hyphenation ('-')
+            (r'%[a-zA-Z_][a-zA-Z_0-9-]*', Name.Attribute),
+        ],
+
+        'types': [
+            (words(('any', 'addr', 'bitfield', 'bool', 'bytes',
+                    '__library_type', 'iterator', 'const_iterator', 'int8',
+                    'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32',
+                    'uint64', 'enum', 'interval', 'interval_ns', 'list', 'map',
+                    'optional', 'port', 'real', 'regexp', 'set', 'sink',
+                    'stream', 'view', 'string', 'time', 'time_ns', 'tuple',
+                    'unit', 'vector', 'void', 'function', 'struct'
+                    ),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword.Type),
+
+            (fr'\b(type)(\s+)((?:{_id})(?:::(?:{_id}))*)\b',
+                bygroups(Keyword, Text, Name.Class)),
+        ],
+
+        'modules': [
+            (fr'\b(import)(\s+)({_id})(\s+)(from)(\s+)(\S+)\b',
+                bygroups(Keyword.Namespace, Text, Name.Namespace, Text,
+                         Keyword.Namespace, Text, Name.Namespace)),
+
+            (fr'\b(module|import)(\s+)({_id})\b',
+                bygroups(Keyword.Namespace, Text, Name.Namespace)),
+        ],
+
+        'keywords': [
+            (words(('global', 'const', 'local', 'var',
+                    'public', 'private',
+                    'inout'
+                    ),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword.Declaration),
+
+
+            (words(('print',
+                    'add', 'delete', 'stop', 'unset',
+                    'assert', 'assert-exception',
+                    'new', 'cast', 'begin', 'end',
+                    'type', 'attribute',
+                    'on', 'priority',
+                    'if', 'else',
+                    'switch', 'case', 'default',
+                    'try', 'catch',
+                    'break', 'return', 'continue',
+                    'while', 'for', 'foreach',
+                    'module', 'import', 'export', 'from'
+                    ),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword),
+        ],
+
+        'literals': [
+            (r'b?"', String, 'string'),
+
+            # Not the greatest match for patterns, but generally helps
+            # disambiguate between start of a pattern and just a division
+            # operator.
+            (r'/(?=.*/)', String.Regex, 'regex'),
+
+            (r'\b(True|False|None|Null)\b', Keyword.Constant),
+
+            # Port
+            (r'\b\d{1,5}/(udp|tcp)\b', Number),
+
+            # IPv4 Address
+            (r'\b(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\b', Number),
+
+            # IPv6 Address (not 100% correct: that takes more effort)
+            (r'\[([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?((25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2}))?\]', Number),
+
+            # Numeric
+            (fr'\b0[xX]{_hex}+\b', Number.Hex),
+            (r'\b{_float}\b', Number.Float),
+            (r'\b(\d+)\b', Number.Integer),
+        ],
+
+        'operators': [
+            (r'[$][$]', Name.Builtin.Pseudo), # just-parsed-element
+            (r'[$]\d+', Name.Builtin.Pseudo), # capture-group
+            (r'\b(in)\b', Operator.Word),
+            (r'[-+*=&|<>.]{2}', Operator),
+            (r'[-+*/=!><]=', Operator),
+            (r'[?][.]', Operator),
+            (r'[.][?]', Operator),
+            (r'[-][>]', Operator),
+            (r'[!][<>]', Operator),
+            (r'[!%*/+<=>~|&^-]', Operator),
+            # Technically, colons are often used for punctuation/sepration.
+            # E.g. field name/type separation.
+            (r'[?:]', Operator),
+        ],
+
+        'punctuation': [
+            (r'[{}()\[\],;:.]', Punctuation),
+        ],
+
+        'function-call': [
+            (fr'\b((?:{_id})(?:::(?:{_id}))*)(?=\s*\()', Name.Function),
+        ],
+
+        'identifiers': [
+            (r'\b(self)\b', Name.Builtin.Pseudo),
+            (r'([a-zA-Z_]\w*)(::)', bygroups(Name, Punctuation)),
+            (r'[a-zA-Z_]\w*', Name),
+        ],
+
+        'string': [
+            (r'\\.', String.Escape),
+            (r'%-?[0-9]*(\.[0-9]+)?[DTdxsefg]', String.Escape),
+            (r'"', String, '#pop'),
+            (r'.', String),
+        ],
+
+        'regex': [
+            (r'\\.', String.Escape),
+            (r'/', String.Regex, '#pop'),
+            (r'.', String.Regex),
+        ],
+    }
+
+
+class SpicyEvtLexer(RegexLexer):
+    """
+    For `Spicy <https://github.com/zeek/spicy>`_ Zeek interface definitions.
+    """
+    name = 'SpicyEvt'
+    aliases = ['spicy-evt']
+    filenames = ['*.evt']
+
+    _id = r'[a-zA-Z_][a-zA-Z_0-9]*'
+
+    tokens = {
+        'root': [
+            include('whitespace'),
+            include('comments'),
+            include('directives'),
+            include('hooks'),
+            include('modules'),
+            include('keywords'),
+            include('literals'),
+            include('operators'),
+            include('punctuation'),
+            include('function-call'),
+            include('identifiers'),
+        ],
+
+        'whitespace': SpicyLexer.tokens['whitespace'],
+        'comments': SpicyLexer.tokens['comments'],
+        'directives': [(r'(@(if|else|endif))\b', Comment.Preproc)],
+        'hooks': SpicyLexer.tokens['hooks'],
+        'modules': SpicyLexer.tokens['modules'],
+
+        'keywords': [
+            (fr'\b(analyzer|with|replaces)(\s+)({_id}(::{_id})*)',
+                bygroups(Keyword, Text, Name.Class)),
+
+            (words(('protocol', 'packet', 'file'),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword.Type),
+
+            (words(('port', 'event',
+                    'parse', 'over',
+                    'mime-type'),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword),
+
+            (words(('cast'),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword),
+
+            (words(('if', 'else',
+                    'switch', 'case', 'default',
+                    'try', 'catch',
+                    'break', 'return', 'continue',
+                    'while', 'for', 'foreach',
+                    ),
+                prefix=r'\b', suffix=r'\b'),
+             Keyword),
+        ],
+
+        'literals': SpicyLexer.tokens['literals'],
+        'operators': SpicyLexer.tokens['operators'],
+        'punctuation': SpicyLexer.tokens['punctuation'],
+        'function-call': SpicyLexer.tokens['function-call'],
+
+        'identifiers': [
+            (r'\b(ZEEK_VERSION)\b', Name.Builtin),
+            (r'\b(self)\b', Name.Builtin.Pseudo),
+            (r'[$](conn|file|is_orig)', Name.Builtin.Pseudo),
+            (r'([a-zA-Z_]\w*)(::)', bygroups(Name, Punctuation)),
+            (r'[a-zA-Z_]\w*', Name),
+        ],
+
+        'string': SpicyLexer.tokens['string'],
+        'regex': SpicyLexer.tokens['regex'],
+    }

--- a/doc/scripts/spicy.py
+++ b/doc/scripts/spicy.py
@@ -242,7 +242,7 @@ class SpicyCode(CodeBlock):
             file = None
 
         args = list(args)
-        args[1] = ["text"]
+        args[1] = self.arguments = ['spicy']
         args[2]['lines'] = "2-"
         super(CodeBlock, self).__init__(*args, **kwargs)
         if file:
@@ -265,6 +265,7 @@ class SpicyCode(CodeBlock):
 
     def run(self):
         literal = CodeBlock.run(self)
+        language = literal[0]['language']
 
         if not self.file:
             return literal
@@ -302,6 +303,7 @@ class SpicyCode(CodeBlock):
 
         ntext = ntext.strip()
         literal[0] = nodes.literal_block(ntext, ntext)
+        literal[0]['language'] = language
 
         return literal
 

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -582,6 +582,7 @@ following complete grammar for TFTP, including the packet formats in
 comments as well:
 
 .. literalinclude:: examples/tftp.spicy
+    :language: spicy
 
 Zeek Integration
 ================
@@ -603,7 +604,7 @@ comes with a tool :ref:`spicyz <spicyz>` for that. The following
 command line produces a binary object file ``tftp.hlto`` containing
 the executable analyzer code:
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy
 
@@ -612,13 +613,13 @@ Below, we will prepare an additional interface definition file
 will need to give that to ``spicyz`` as well, and our full
 compilation command hence becomes:
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy tftp.evt
 
 When starting Zeek, we add ``tftp.hlto`` to its command line:
 
-.. spicy-code::
+.. code::
 
     # zeek -r tftp_rrq.pcap tftp.hlto
 
@@ -638,6 +639,7 @@ following into ``tftp.evt``, the analyzer definition file:
 
 .. literalinclude:: examples/tftp.evt
     :lines: 3-5
+    :language: spicy-evt
 
 The first line provides our analyzer with a Zeek-side name
 (``spicy::TFTP``) and also tells Zeek that we are adding an
@@ -653,7 +655,7 @@ will not generate any events yet, but we can at least see the output of
 the ``on %done { print self; }`` hook that still remains part of the
 grammar from earlier:
 
-.. spicy-code::
+.. code::
 
     # zeek -r tftp_rrq.pcap tftp.hlto Spicy::enable_print=T
     [$opcode=Opcode::RRQ, $rrq=[$filename=b"rfc1350.txt", $mode=b"octet"], $wrq=(not set), $data=(not set), $ack=(not set), $error=(not set)]
@@ -684,6 +686,7 @@ by adding this definition to ``tftp.evt``:
 
 .. literalinclude:: examples/tftp-single-request.evt
     :lines: 5-7
+    :language: spicy-evt
 
 The first line makes our Spicy TFTP grammar available to the rest of
 the file. The line ``on ...`` defines one event: Every time a
@@ -698,10 +701,11 @@ Now we need a Zeek event handler for our new event. Let's put this
 into ``tftp.zeek``:
 
 .. literalinclude:: examples/tftp-single-request.zeek
+    :language: zeek
 
 Running Zeek then gives us:
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -711,6 +715,7 @@ Let's extend the event signature a bit by passing further arguments:
 
 .. literalinclude:: examples/tftp-single-request-more-args.evt
     :lines: 5-7
+    :language: spicy-evt
 
 This shows how each parameter gets specified as a Spicy expression:
 ``self`` refers to the instance currently being parsed (``self``), and
@@ -720,8 +725,9 @@ will be true if the event has been triggered by originator-side
 traffic. On the Zeek side, our event now has the following signature:
 
 .. literalinclude:: examples/tftp-single-request-more-args.zeek
+    :language: zeek
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -735,14 +741,16 @@ generation through an additional ``if`` condition:
 
 .. literalinclude:: examples/tftp.evt
     :lines: 9-10
+    :language: spicy-evt
 
 This now defines two separate events, each being generated only for
 the corresponding value of ``is_read``. Let's try it with a new
 ``tftp.zeek``:
 
 .. literalinclude:: examples/tftp-two-requests.zeek
+    :language: zeek
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -761,8 +769,9 @@ because this is Zeek-specific logic:
 
 .. literalinclude:: examples/zeek_tftp.spicy
     :lines: 3-
+    :language: spicy
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy zeek_tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -781,6 +790,7 @@ file:
 
 .. literalinclude:: examples/tftp.evt
     :lines: 3-
+    :language: spicy-evt
 
 
 Detour: Zeek vs. TFTP
@@ -792,7 +802,7 @@ pcap file contains multiple different types of packets. The reason
 becomes clear once we look more closely at the UDP ports that are in
 use:
 
-.. spicy-code::
+.. code::
 
     # tcpdump -ttnr tftp_rrq.pcap
     1367411051.972852 IP 192.168.0.253.50618 > 192.168.0.10.69:  20 RRQ "rfc1350.txtoctet" [tftp]
@@ -811,7 +821,7 @@ one at all due to its lack of the well-known port (neither does
 ``tcpdump``!). Zeek's connection log confirms this by showing two
 separate entries:
 
-.. spicy-code::
+.. code::
 
     # cat conn.log
     1367411051.972852  CH3xFz3U1nYI1Dp1Dk  192.168.0.253  50618  192.168.0.10  69  udp  spicy_tftp  -  -  -  S0  -  -  0  D  1  48  0  0  -
@@ -824,8 +834,9 @@ function to designate a specific analyzer for an anticipated future
 connection. We can call that function when we see the initial request:
 
 .. literalinclude:: examples/tftp-schedule-analyzer.zeek
+    :language: zeek
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy zeek_tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -854,7 +865,7 @@ desired. We have created such :download:`a script for TFTP
 generates. Once we add that to the Zeek command line, we will see a
 new ``tftp.log``:
 
-.. spicy-code::
+.. code::
 
     # spicyz -o tftp.hlto tftp.spicy zeek_tftp.spicy tftp.evt
     # zeek -r tftp_rrq.pcap tftp.hlto tftp.zeek
@@ -867,7 +878,7 @@ adding a corresponding entry to the ``service`` field inside the
 Zeek-side connection record. With that, we are now seeing this in
 ``conn.log``:
 
-.. spicy-code::
+.. code::
 
     1367411051.972852  ChbSfq3QWKuNirt9Uh  192.168.0.253  50618  192.168.0.10  69  udp  spicy_tftp  -  -  -  S0  -  -0  D  1  48  0  0  -
     1367411052.077243  CowFQj20FHHduhHSYk  192.168.0.10  3445  192.168.0.253  50618  udp  spicy_tftp_data  0.181558  24795  196  SF  --  0  Dd  49  26167  49  1568  -

--- a/doc/zeek.rst
+++ b/doc/zeek.rst
@@ -183,7 +183,9 @@ properties are supported:
         Here, ``SMTP`` is the name you would write into ``replaces`` to
         disable the built-in SMTP analyzer.
 
-As a full example, here's what a new HTTP analyzer could look like::
+As a full example, here's what a new HTTP analyzer could look like:
+
+.. code-block:: spicy-evt
 
     protocol analyzer spicy::HTTP over TCP:
         parse originator with HTTP::Requests,
@@ -227,7 +229,9 @@ for more. You will need to use the
 <https://docs.zeek.org/en/master/scripts/base/bif/packet_analysis.bif.zeek.html#id-PacketAnalyzer::try_register_packet_analyzer_by_name>`_
 for registering Spicy analyzers (not `register_packet_analyzer`), with
 the name of the new Spicy analyzer being ``ANALYZER_NAME``. `zeek -NN`
-shows the names of existing analyzers. For example::
+shows the names of existing analyzers. For example:
+
+.. code-block:: zeek
 
     event zeek_init()
         {
@@ -278,7 +282,9 @@ File analyzers support the following properties:
             HTTP's ``Content-Type`` header). If in doubt, examine
             ``files.log`` for what it records as a file's type.
 
-As a full example, here's what a new GIF analyzer could look like::
+As a full example, here's what a new GIF analyzer could look like:
+
+.. code-block:: spicy-evt
 
     file analyzer spicy::GIF:
         parse with GIF::Image,
@@ -556,7 +562,7 @@ behavior, similar to what the :ref:`spicy-driver` provides as
 command-line arguments:
 
 .. literalinclude:: /../zeek/plugin/scripts/base/spicy/main.zeek
-    :language: bro
+    :language: zeek
     :start-after: doc-start
     :end-before:  doc-end
 


### PR DESCRIPTION
* Add a `livehtml` target which uses `sphinx-autobuild` for convenience
* Add Pygments syntax highlighters for `.spicy` and `.evt` files
* Use syntax highlighting for spicy/spicy-evt/zeek/c++ languages in the docs