### PR TITLE
Use signed integers for numbers which can potentially be negative.

### DIFF
--- a/hilti/toolchain/include/base/timing.h
+++ b/hilti/toolchain/include/base/timing.h
@@ -121,7 +121,7 @@ protected:
 
     Duration _time_used = Duration(0);
     uint64_t _num_completed = 0;
-    uint64_t _level = 0;
+    int64_t _level = 0;
     std::string _name;
 
 private:

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -193,7 +193,7 @@ extern std::pair<std::string, std::string> rsplit1(std::string s, const std::str
  * @param end one beyond last index; if negative, counts from end Python-style
  */
 template<typename T>
-std::vector<T> slice(const std::vector<T>& v, unsigned int begin, unsigned int end = -1) {
+std::vector<T> slice(const std::vector<T>& v, int begin, int end = -1) {
     if ( begin < 0 )
         begin = v.size() + begin;
 


### PR DESCRIPTION
Closes #657.