### PR TITLE
Add back rule to build hilti-rt-fiber-benchmark.

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -160,3 +160,8 @@ target_compile_options(hilti-rt-configuration-tests PRIVATE $<$<CONFIG:Debug>:-O
 target_link_options(hilti-rt-configuration-tests PRIVATE $<$<CONFIG:Debug>:-O0>)
 target_link_libraries(hilti-rt-configuration-tests PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug,hilti-rt> doctest)
 add_test(NAME hilti-rt-configuration-tests COMMAND ${CMAKE_BINARY_DIR}/bin/hilti-rt-configuration-tests)
+
+add_executable(hilti-rt-fiber-benchmark src/benchmarks/fiber.cc)
+target_compile_options(hilti-rt-fiber-benchmark PRIVATE "-Wall")
+target_link_libraries(hilti-rt-fiber-benchmark PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug,hilti-rt>)
+target_link_libraries(hilti-rt-fiber-benchmark PRIVATE benchmark)


### PR DESCRIPTION
This rule was accidentially removed as part of
7c3d78dd9831c3cddc72950b0ebf56b418f59ca4.