### PR TITLE
Build with -Werror in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,7 +171,7 @@ macos_catalina_task:
     - pip3 install "btest>=0.66" sphinx_rtd_theme
 
   configure_script:
-    - ./configure --generator=Ninja --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache
+    - ./configure --generator=Ninja --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache --enable-werror
   build_script:
     - ninja -C build all check
   test_build_script:
@@ -208,7 +208,7 @@ macos_big_sur_task:
     - pip3 install btest sphinx_rtd_theme
 
   configure_script:
-    - ./configure --generator=Ninja --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache
+    - ./configure --generator=Ninja --with-bison=/usr/local/opt/bison --with-flex=/usr/local/opt/flex --enable-ccache --enable-werror
   build_script:
     - ninja -C build all check
   test_build_script:
@@ -325,7 +325,7 @@ docker_alpine_3_12_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - LDFLAGS="-lucontext" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - LDFLAGS="-lucontext" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -365,7 +365,7 @@ docker_centos_7_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - source scl_source enable devtoolset-9 && LDFLAGS="-static-libstdc++ -static-libgcc" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - source scl_source enable devtoolset-9 && LDFLAGS="-static-libstdc++ -static-libgcc" ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - source scl_source enable devtoolset-9 && ninja -j4 -C build install
   test_script:
@@ -405,6 +405,8 @@ docker_centos_8_task:
     - git submodule update --recursive --init
 
   configure_script:
+    # TODO(bbannier): We do not enable -Werror on centos8 since it ships with
+    # flex-2.6.1 which generates code which triggers sign-compare diagnostics.
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
     - ninja -j4 -C build install
@@ -453,7 +455,7 @@ validate_release_tarball_task:
     - tar xf spicy.tar.bz2 -C /tmp/spicy-tarball
     - cd /tmp/spicy-tarball
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j3 -C build
   test_script:
@@ -509,7 +511,7 @@ docker_debian9_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -550,7 +552,7 @@ docker_debian10_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -591,6 +593,8 @@ docker_ubuntu16_task:
     - git submodule update --recursive --init
 
   configure_script:
+    # TODO(bbannier): We do not enable -Werror on ubuntu16 since there
+    # the generated flex scanners trigger null-conversion diagnostics.
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
   build_script:
     - ninja -j4 -C build install
@@ -632,7 +636,7 @@ docker_ubuntu18_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -673,7 +677,7 @@ docker_ubuntu20_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -714,7 +718,7 @@ docker_fedora32_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -755,7 +759,7 @@ docker_fedora33_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-zeek=/opt/zeek --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -857,7 +861,7 @@ freebsd11_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local --with-cxx-compiler=clang++11 --with-c-compiler=clang11
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local --with-cxx-compiler=clang++11 --with-c-compiler=clang11 --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:
@@ -896,7 +900,7 @@ freebsd12_task:
     - git submodule update --recursive --init
 
   configure_script:
-    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --with-flex=/usr/local --with-bison=/usr/local --with-zeek=/usr/local --enable-werror
   build_script:
     - ninja -j4 -C build install
   test_script:

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -334,11 +334,12 @@ TEST_CASE("toInt") {
         CHECK_EQ("100"_b.toInt(ByteOrder::Big), 3223600);
         CHECK_EQ("100"_b.toInt(ByteOrder::Network), 3223600);
         CHECK_EQ("100"_b.toInt(ByteOrder::Little), 3158065);
-        if ( systemByteOrder() == ByteOrder::Little )
+        if ( systemByteOrder() == ByteOrder::Little ) {
             CHECK_EQ("100"_b.toInt(ByteOrder::Host), 3158065);
-        else
+        }
+        else {
             CHECK_EQ("100"_b.toInt(ByteOrder::Big), 3223600);
-
+        }
 
         CHECK_THROWS_WITH_AS("1234567890"_b.toInt(ByteOrder::Big), "more than max of 8 bytes for conversion to integer",
                              const RuntimeError&);

--- a/hilti/runtime/src/tests/library.cc
+++ b/hilti/runtime/src/tests/library.cc
@@ -45,10 +45,12 @@ public:
     ~Env() {
         const auto& [k, v] = _prev;
 
-        if ( v )
+        if ( v ) {
             REQUIRE_EQ(::setenv(k.c_str(), v->c_str(), 1), 0);
-        else
+        }
+        else {
             REQUIRE_EQ(::unsetenv(k.c_str()), 0);
+        }
     }
 
 private:

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -197,7 +197,7 @@ std::vector<T> slice(const std::vector<T>& v, int begin, int end = -1) {
     if ( begin < 0 )
         begin = v.size() + begin;
 
-    if ( begin > v.size() )
+    if ( static_cast<size_t>(begin) > v.size() )
         return {};
 
     if ( end < 0 )
@@ -209,7 +209,7 @@ std::vector<T> slice(const std::vector<T>& v, int begin, int end = -1) {
     if ( end < 0 )
         end = 0;
 
-    if ( end > v.size() )
+    if ( static_cast<size_t>(end) > v.size() )
         end = v.size();
 
     return std::vector<T>(v.begin() + begin, v.begin() + end);

--- a/hilti/toolchain/src/ast/module.cc
+++ b/hilti/toolchain/src/ast/module.cc
@@ -11,7 +11,7 @@ void Module::clear() {
 
     // We fully walk the AST here in order to break any reference cycles it may
     // contain. Start at child 1 to leave ID in place.
-    for ( auto i = 1; i < childs().size(); i++ ) {
+    for ( size_t i = 1; i < childs().size(); i++ ) {
         for ( auto j : v.walk(&childs()[i]) )
             j.node = node::none;
     }

--- a/hilti/toolchain/src/compiler/visitors/apply-coercions.cc
+++ b/hilti/toolchain/src/compiler/visitors/apply-coercions.cc
@@ -20,7 +20,7 @@ struct Visitor : public visitor::PreOrder<void, Visitor> {
     bool modified = false;
 
     /** Returns a method call's i-th argument. */
-    auto methodArgument(const expression::ResolvedOperatorBase& o, int i) {
+    auto methodArgument(const expression::ResolvedOperatorBase& o, size_t i) {
         auto ops = o.op2();
 
         // If the argument list was the result of a coercion unpack its result.

--- a/spicy/runtime/src/tests/parser.cc
+++ b/spicy/runtime/src/tests/parser.cc
@@ -95,10 +95,12 @@ TEST_CASE("atEod") {
             for ( size_t i = 0; i < stream->size() + 5; ++i ) {
                 CAPTURE(i);
                 view = view.trim(view.begin() + i);
-                if ( i < 2 )
+                if ( i < 2 ) {
                     CHECK_FALSE(detail::atEod(stream, view));
-                else
+                }
+                else {
                     CHECK(detail::atEod(stream, view));
+                }
             }
         }
     }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -494,7 +494,7 @@ struct ProductionVisitor
         // Top of stack will now have the final value for the field.
         Expression stop = builder::bool_(false);
 
-        if ( const auto& c = meta.container() ) {
+        if ( meta.container() ) {
             auto elem = destination();
             popDestination();
             stop = pb->newContainerItem(*meta.container(), destination(), elem, true);

--- a/zeek/compiler/driver.cc
+++ b/zeek/compiler/driver.cc
@@ -107,7 +107,7 @@ hilti::Result<hilti::Nothing> Driver::parseOptionsPreScript(const std::string& o
                                                            [](auto o) { return hilti::util::trim(o); }),
                                     [](auto o) { return o.size(); });
 
-    auto idx = 0;
+    size_t idx = 0;
     auto argc = args.size();
     while ( idx < argc ) {
         if ( args[idx][0] != '-' ) {
@@ -152,7 +152,7 @@ hilti::Result<hilti::Nothing> Driver::parseOptionsPostScript(const std::string& 
                                                            [](auto o) { return hilti::util::trim(o); }),
                                     [](auto o) { return o.size(); });
 
-    auto idx = 0;
+    size_t idx = 0;
     auto argc = args.size();
     while ( idx < argc ) {
         if ( args[idx][0] != '-' ) {


### PR DESCRIPTION
We already have this on for CI setups using `run-ci`, but need to
specify it explicitly for platforms using the document build method via
`./configure`.