### PR TITLE
Improve docs for vector &until parsing

### DIFF
--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -1098,11 +1098,13 @@ loop. To that end, vectors support the following attributes:
     common to use it with vectors.)
 
 ``&until=EXPR``
-    Parses elements until one with the value ``EXPR`` is encountered.
-    ``EXPR`` must be of the same type as the vector's elements. Once
-    the specified element is encountered, vector parsing stops
-    *without* including the matching one into the field's vector
-    value.
+    Vector elements are parsed in a loop with ``EXPR`` being evaluated after
+    each parsed-element and before adding the element to the vector.  If
+    ``EXPR`` is a boolean expression, parsing stops when ``EXPR`` evaluates to
+    true.  If ``EXPR`` is of the same type as the vector's elements, parsing
+    stops when one is found with a value equal to ``EXPR``.  In either case,
+    once the condition is satisfied, parsing stops *without* adding the element
+    that was just parsed to the vector.
 
 ``&until-including=EXPR``
     Similar to ``&until``, but does include the final element ``EXPR``


### PR DESCRIPTION
Explicitly mention that boolean expressions are allowed.

(i.e. what would help in relation to #771)