### PR TITLE
Fix strftime unit test: increase portability of localtime_r() usage

### DIFF
--- a/hilti/runtime/src/util.cc
+++ b/hilti/runtime/src/util.cc
@@ -420,6 +420,11 @@ std::string hilti::rt::strftime(const std::string& format, const hilti::rt::Time
     constexpr size_t size = 128;
     char mbstr[size];
 
+    // localtime() is required to call tzset() internally, whereas
+    // localtime_r() may or may not do so -- to be portable we have to
+    // call it ourselves:
+    ::tzset();
+
     auto localtime = ::localtime_r(&seconds, &tm);
     if ( ! localtime )
         throw InvalidArgument(hilti::rt::fmt("cannot convert timestamp to local time: %s", std::strerror(errno)));


### PR DESCRIPTION
The HILTI unit tests fail on my system:
```
$ cd build
$ ctest
Test project /home/christian/devel/zeek/spicy/build
    Start 1: hilti-rt-tests
1/5 Test #1: hilti-rt-tests ...................***Failed    0.13 sec
    Start 2: hilti-rt-configuration-tests
2/5 Test #2: hilti-rt-configuration-tests .....   Passed    0.01 sec
    Start 3: hilti-toolchain-tests
3/5 Test #3: hilti-toolchain-tests ............   Passed    0.03 sec
    Start 4: spicy-rt-tests
4/5 Test #4: spicy-rt-tests ...................   Passed    0.01 sec
    Start 5: spicy-toolchain-tests
5/5 Test #5: spicy-toolchain-tests ............   Passed    0.02 sec

80% tests passed, 1 tests failed out of 5

Total Test time (real) =   0.20 sec

The following tests FAILED:
          1 - hilti-rt-tests (Failed)
Errors while running CTest
```
This is due to:
```
$ ./bin/hilti-rt-tests
[doctest] doctest version is "2.4.0"
[doctest] run with "--help" for options
===============================================================================
/home/christian/devel/zeek/spicy/hilti/runtime/src/tests/util.cc:586:
TEST SUITE: util
TEST CASE:  strftime

/home/christian/devel/zeek/spicy/hilti/runtime/src/tests/util.cc:590: ERROR: CHECK_EQ( strftime("%A %c", Time()), "Thursday Thu Jan  1 00:00:00 1970" ) is NOT correct!
  values: CHECK_EQ( Wednesday Wed Dec 31 16:00:00 1969, Thursday Thu Jan  1 00:00:00 1970 )

===============================================================================
[doctest] test cases:    332 |    331 passed |      1 failed |      0 skipped
[doctest] assertions:   2904 |   2903 passed |      1 failed |
[doctest] Status: FAILURE!
```
So the timezone adjustment to UTC done in the unit test wasn't actually working. I tracked this down to a subtle difference in the use of `localtime()` vs `localtime_r()` — the former is required to honor the `TZ` environment variable, but the latter may not do so, and portability suggests calling `tzset()` yourself:

> According to POSIX.1-2001, localtime() is required to behave as though tzset(3) was called, while localtime_r() does not have this requirement.  For portable code, tzset(3) should be called before localtime_r().

On my systems (Linux), `tzset` is declared thread-safe. It might a good idea to check whether that is true on all platforms, since I'm seeing old (decade-plus) threads where apparently it once wasn't...

This also broke installation of the spicy-runtime Zeek package for me, btw.