### PR TITLE
Fix benchmark script for move of analyzers.

### DIFF
--- a/scripts/run-benchmarks
+++ b/scripts/run-benchmarks
@@ -22,6 +22,7 @@
 #
 #   zeek -r trace.pcap zeek/scripts/record-spicy-batch.zeek
 #
+set -e
 
 build="<no build directory>"
 work=./benchmark
@@ -45,7 +46,7 @@ check_deps() {
 }
 
 check_zeek() {
-    ${zeek} -v | grep -q debug && echo "Warning: Using debug version of Zeek"
+    ${zeek} -v | grep -q debug && echo "Warning: Using debug version of Zeek" || true
 }
 
 check_binaries() {
@@ -73,16 +74,16 @@ do_build() {
         echo Building ${p} binaries ...
 
         # Standalone binary
-        spicy-build -o ${p}-opt ${dist}/spicy/lib/protocols/http.spicy &
-        spicy-build -o ${p}-dbg -d ${dist}/spicy/lib/protocols/http.spicy &
+        spicy-build -o ${p}-opt ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy &
+        spicy-build -o ${p}-dbg -d ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy &
 
         # Standalone HLTO
-        spicyc -j -o ${p}-opt.hlto -O ${dist}/spicy/lib/protocols/http.spicy &
-        spicyc -j -o ${p}-dbg.hlto -d ${dist}/spicy/lib/protocols/http.spicy &
+        spicyc -j -o ${p}-opt.hlto -O ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy &
+        spicyc -j -o ${p}-dbg.hlto -d ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy &
 
         # Zeek HLTO
-        spicyz -o ${p}-zeek-opt.hlto -O ${dist}/spicy/lib/protocols/${p}.spicy ${dist}/zeek/plugin/lib/protocols/${p}.evt ${dist}/zeek/plugin/lib/protocols/zeek_${p}.spicy &
-        spicyz -o ${p}-zeek-dbg.hlto -d ${dist}/spicy/lib/protocols/${p}.spicy ${dist}/zeek/plugin/lib/protocols/${p}.evt ${dist}/zeek/plugin/lib/protocols/zeek_${p}.spicy &
+        spicyz -o ${p}-zeek-opt.hlto -O ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy ${dist}/zeek/plugin/lib/protocols/${p}.evt ${dist}/zeek/plugin/lib/protocols/zeek_${p}.spicy &
+        spicyz -o ${p}-zeek-dbg.hlto -d ${dist}/zeek/spicy-analyzers/analyzer/protocol/${p}/${p}.spicy ${dist}/zeek/plugin/lib/protocols/${p}.evt ${dist}/zeek/plugin/lib/protocols/zeek_${p}.spicy &
 
         wait
     done


### PR DESCRIPTION
We recently moved the analyzers from this repo to zeek/spicy-analyzers.
This broke the benchmark setup which still hardcoded the old, now
non-existing paths.

This patch adjusts the paths to now reference the new locations.

We also fix a number of other issues in the benchmark runner:

- the script now aborts on error were it previously continued with
  possibly broken state,
- all standalone binary and standalone HLTO benchmarks where
  benchmarking the HTTP parser; we now generate the correct benchmarks
  from the correct input scripts (this means that previous benchmark
  results for anything other than HTTP are not useful and cannot be
  compared to).

Closes #806.