### PR TITLE
Fix unification of internal compiler arguments to not change order.

### DIFF
--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -582,6 +582,23 @@ std::vector<T>& append(std::vector<T>& v1, const std::vector<T>& v2) {
     return v1;
 }
 
+/** Remov duplicates from a vector without changing order. */
+template<typename T>
+std::vector<T> remove_duplicates(std::vector<T> v) {
+    std::set<T> seen;
+    std::vector<T> out;
+
+    for ( auto&& i : v ) {
+        if ( seen.find(i) != seen.end() )
+            continue;
+
+        seen.insert(i);
+        out.emplace_back(std::move(i));
+    }
+
+    return out;
+}
+
 /**
  * Given an associative container and an index hint, returns a new index
  * value that doesn't exist in the container yet. If the hint itself doesn't

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -384,13 +384,8 @@ Result<Nothing> Driver::initialize() {
 
     _stage = INITIALIZED;
 
-    auto uniquify = [](auto& v) {
-        std::sort(v.begin(), v.end());
-        v.erase(std::unique(v.begin(), v.end()), v.end());
-    };
-
-    uniquify(_compiler_options.cxx_include_paths);
-    uniquify(_compiler_options.library_paths);
+    util::remove_duplicates(_compiler_options.cxx_include_paths);
+    util::remove_duplicates(_compiler_options.library_paths);
 
     if ( _driver_options.logger )
         setLogger(std::move(_driver_options.logger));

--- a/hilti/toolchain/tests/util.cc
+++ b/hilti/toolchain/tests/util.cc
@@ -83,4 +83,10 @@ TEST_CASE("cacheDirectory") {
     }
 }
 
+TEST_CASE("remove_duplicates") {
+    CHECK_EQ(hilti::util::remove_duplicates(std::vector<int>{}), std::vector<int>{});
+    CHECK_EQ(hilti::util::remove_duplicates(std::vector<int>{4, 3, 2, 1}), std::vector<int>{4, 3, 2, 1});
+    CHECK_EQ(hilti::util::remove_duplicates(std::vector<int>{7, 8, 3, 8, 3, 5, 0, 7}), std::vector<int>{7, 8, 3, 5, 0});
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Closes #819.