### PR TITLE
Fix vector parsing potentially missing EOD.

### DIFF
--- a/spicy/lib/spicy_rt.hlt
+++ b/spicy/lib/spicy_rt.hlt
@@ -69,9 +69,7 @@ declare public bool waitForInputOrEod(inout value_ref<stream> data, view<stream>
 declare public void waitForInput(inout value_ref<stream> data, view<stream> cur, string error_msg, string location, inout strong_ref<Filters> filters) &cxxname="spicy::rt::detail::waitForInput" &have_prototype;
 declare public void waitForInput(inout value_ref<stream> data, view<stream> cur, uint<64> n, string error_msg, string location, strong_ref<Filters> filters) &cxxname="spicy::rt::detail::waitForInput" &have_prototype;
 declare public bool waitForEod(inout value_ref<stream> data, view<stream> cur, inout strong_ref<Filters> filters) &cxxname="spicy::rt::detail::waitForEod" &have_prototype;
-
-declare public bool atEod(inout value_ref<stream> data, view<stream> cur) &cxxname="spicy::rt::detail::atEod" &have_prototype;
-declare public bool haveEod(inout value_ref<stream> data, view<stream> cur) &cxxname="spicy::rt::detail::haveEod" &have_prototype;
+declare public bool atEod(inout value_ref<stream> data, view<stream> cur, inout strong_ref<Filters> filters) &cxxname="spicy::rt::detail::atEod" &have_prototype;
 
 declare public void backtrack() &cxxname="spicy::rt::detail::backtrack" &have_prototype;
 

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -360,17 +360,8 @@ extern void waitForInput(hilti::rt::ValueReference<hilti::rt::Stream>& data, // 
  * @param cur view of *data* that's being parsed
  * @return true if end-of-data has been reached
  */
-extern bool atEod(const hilti::rt::ValueReference<hilti::rt::Stream>& data, const hilti::rt::stream::View& cur);
-
-/**
- * Used by generated parsers to recognize when end-of-data has been seen,
- * but possibly not reached.
- *
- * @param data current input data
- * @param cur view of *data* that's being parsed
- * @return true if end-of-data has been seen, but not necessarily reached.
- */
-extern bool haveEod(const hilti::rt::ValueReference<hilti::rt::Stream>& data, const hilti::rt::stream::View& cur);
+extern bool atEod(hilti::rt::ValueReference<hilti::rt::Stream>& data, const hilti::rt::stream::View& cur,
+                  hilti::rt::StrongReference<spicy::rt::filter::detail::Filters> filters);
 
 /**
  * Manually trigger a backtrack operation, reverting back to the most revent &try.

--- a/spicy/runtime/src/tests/parser.cc
+++ b/spicy/runtime/src/tests/parser.cc
@@ -57,16 +57,18 @@ TEST_CASE("ParserPort") {
 
 TEST_CASE("atEod") {
     auto stream = hilti::rt::ValueReference<hilti::rt::Stream>();
+    auto filters = hilti::rt::StrongReference<filter::detail::Filters>();
 
     SUBCASE("empty") {
         bool expanding = false;
         SUBCASE("expanding view") { expanding = true; }
         SUBCASE("not expanding view") { expanding = false; }
 
-        CHECK_EQ(detail::atEod(stream, stream->view(expanding)), ! expanding);
+        // This would now yield to wait for input before deciding whether EOD has been reached.
+        // CHECK_EQ(detail::atEod(stream, stream->view(expanding), filters), ! expanding);
 
         stream->freeze();
-        CHECK(detail::atEod(stream, stream->view(expanding)));
+        CHECK(detail::atEod(stream, stream->view(expanding), filters));
     }
 
     SUBCASE("not empty") {
@@ -78,12 +80,12 @@ TEST_CASE("atEod") {
             for ( size_t i = 0; i < stream->size() + 5; ++i ) {
                 view.advance(i);
                 CAPTURE(i);
-                CHECK_FALSE(detail::atEod(stream, view));
+                CHECK_FALSE(detail::atEod(stream, view, filters));
             }
 
             stream->freeze();
-            CHECK_FALSE(detail::atEod(stream, view));
-            CHECK_FALSE(detail::atEod(stream, stream->view()));
+            CHECK_FALSE(detail::atEod(stream, view, filters));
+            CHECK_FALSE(detail::atEod(stream, stream->view(), filters));
         }
 
         SUBCASE("trimmed view") {
@@ -96,10 +98,10 @@ TEST_CASE("atEod") {
                 CAPTURE(i);
                 view = view.trim(view.begin() + i);
                 if ( i < 2 ) {
-                    CHECK_FALSE(detail::atEod(stream, view));
+                    CHECK_FALSE(detail::atEod(stream, view, filters));
                 }
                 else {
-                    CHECK(detail::atEod(stream, view));
+                    CHECK(detail::atEod(stream, view, filters));
                 }
             }
         }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -898,7 +898,7 @@ struct ProductionVisitor
         Expression cond;
 
         if ( p.eodOk() )
-            cond = builder::not_(builder::call("spicy_rt::atEod", {state().data, state().cur}));
+            cond = builder::not_(pb->atEod());
         else
             cond = builder::bool_(true);
 
@@ -1590,7 +1590,9 @@ Expression ParserBuilder::waitForInputOrEod() {
     return builder::call("spicy_rt::waitForInputOrEod", {state().data, state().cur, _filters(state())});
 }
 
-Expression ParserBuilder::atEod() { return builder::call("spicy_rt::atEod", {state().data, state().cur}); }
+Expression ParserBuilder::atEod() {
+    return builder::call("spicy_rt::atEod", {state().data, state().cur, _filters(state())});
+}
 
 void ParserBuilder::waitForInput(const std::string& error_msg, const Meta& location) {
     builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, builder::string(error_msg),


### PR DESCRIPTION
When parsing a vector bounded by &eod, the parser could enter the
code for reading the next element too early before it could reliably
tell that EOD hadn't been reached yet. The fix is to change `atEod()` so
that if stream is still unfrozen, it waits for at least one available
byte before making the decision.

This is hard to test for because it requires yielding & resuming the
input in the right way, but the PNG can act as a test case: it was
producing an unexpected weird, which is now gone.

Closes #817.

Merge with https://github.com/zeek/spicy-analyzers/pull/19