### PR TITLE
Fix `?.` operator to work with constant structs.

### DIFF
--- a/hilti/toolchain/include/ast/operators/struct.h
+++ b/hilti/toolchain/include/ast/operators/struct.h
@@ -164,7 +164,7 @@ BEGIN_OPERATOR_CUSTOM(struct_, HasMember)
     bool isLhs() const { return false; }
 
     std::vector<Operand> operands() const {
-        return {{.type = type::Struct(type::Wildcard()), .doc = "struct"},
+        return {{.type = type::constant(type::Struct(type::Wildcard())), .doc = "struct"},
                 {.type = type::Member(type::Wildcard()), .doc = "<field>"}};
     }
 


### PR DESCRIPTION
It would require a non-const struct, for no reason.