### PR TITLE
Bump Zeek LTS version to 4.0.0 in some CI and Docker images.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ clang9_zeek_ubuntu_debug_task:
     dockerfile: ci/Dockerfile
     docker_arguments:
       - ZEEK_LTS:
-      - ZEEK_VERSION: 3.2.2-0
+      - ZEEK_VERSION: 4.0.0-0
     cpu: 4
     memory: 12G
 
@@ -62,7 +62,7 @@ clang10_zeek_lts_ubuntu_release_task:
     dockerfile: ci/Dockerfile
     docker_arguments:
       - ZEEK_LTS: 1
-      - ZEEK_VERSION: 3.0.11-0
+      - ZEEK_VERSION: 4.0.0-0
     cpu: 4
     memory: 8G
 
@@ -110,6 +110,7 @@ clang9_zeek_lts_ubuntu_release_static_task:
     dockerfile: ci/Dockerfile
     docker_arguments:
       - ZEEK_LTS: 1
+      # For now we keep this build at the last Zeek LTS release to also test that one somewhere.
       - ZEEK_VERSION: 3.0.11-0
     cpu: 4
     memory: 8G
@@ -225,7 +226,7 @@ no_toolchain_task:
     dockerfile: ci/Dockerfile
     docker_arguments:
       - ZEEK_LTS: 1
-      - ZEEK_VERSION: 3.0.11-0
+      - ZEEK_VERSION: 4.0.0-0
     cpu: 4
     memory: 12G
 
@@ -729,7 +730,7 @@ clang11_zeek_nightly_task:
       # We specify these only to pin a certain base image;
       # we install nightly Zeek packages in a CI step below.
       - ZEEK_LTS:
-      - ZEEK_VERSION: 3.2.2-0
+      - ZEEK_VERSION: 4.0.0-0
     cpu: 4
     memory: 8G
 

--- a/.clang-format
+++ b/.clang-format
@@ -68,7 +68,6 @@ IncludeCategories:
     Priority:        6
   - Regex:           'hilti/rt.*\.(h|hpp)>'
     Priority:        5
-    Priority:        3
   - Regex:           'clang.*\.h>'
     Priority:        10
   - Regex:           'llvm.*\.h>'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:focal
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG ZEEK_LTS=1
-ARG ZEEK_VERSION=3.0.11-0
+ARG ZEEK_VERSION=4.0.0-0
 ARG UID=1000
 ARG GID=1000
 
@@ -16,6 +16,7 @@ RUN apt-get update \
  && mkdir -p /tmp/zeek-packages \
  && cd /tmp/zeek-packages \
  && if [ -n "${ZEEK_LTS}" ]; then ZEEK_LTS="-lts"; fi && export ZEEK_LTS \
+ && apt-get install -y --no-install-recommends libpcap0.8 libpcap-dev libssl-dev zlib1g-dev libmaxminddb0 libmaxminddb-dev python python3 python3-pip python3-semantic-version python3-git \
  && curl -L --remote-name-all \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-core_${ZEEK_VERSION}_amd64.deb \
@@ -23,7 +24,10 @@ RUN apt-get update \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-core-dev_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/libbroker${ZEEK_LTS}-dev_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-libcaf-dev_${ZEEK_VERSION}_amd64.deb \
- && apt-get install -y libpcap0.8 libpcap-dev python libssl-dev zlib1g-dev libmaxminddb0 libmaxminddb-dev \
+ && [[ ${ZEEK_VERSION} = 4.* ]] && curl -L --remote-name-all \
+    https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-btest_${ZEEK_VERSION}_amd64.deb \
+    https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-zkg_${ZEEK_VERSION}_amd64.deb \
+ ||  pip3 install --no-cache-dir "btest>=0.66" zkg \
  && dpkg -i *.deb \
  && cd - \
  && rm -rf /tmp/zeek-packages \

--- a/ci/Dockerfile.dockerhub
+++ b/ci/Dockerfile.dockerhub
@@ -7,7 +7,7 @@ FROM ubuntu:focal
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG ZEEK_LTS=1
-ARG ZEEK_VERSION=3.0.11-0
+ARG ZEEK_VERSION=4.0.0-0
 
 CMD ["sh"]
 ENV DEBIAN_FRONTEND=noninteractive
@@ -55,7 +55,7 @@ RUN cd /opt/spicy/src \
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
 
 # Install Spicy Zeek plugin and analyzers.
-RUN true \
- && echo Y | zkg install spicy-plugin spicy-analyzers
+RUN echo Y | zkg install spicy-plugin \
+ && echo Y | zkg install spicy-analyzers
 
 WORKDIR /root

--- a/ci/Dockerfile.packages
+++ b/ci/Dockerfile.packages
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ARG ZEEK_VERSION=3.0.11-2.2
+ARG ZEEK_VERSION=4.0.0-3.1
 
 ENV PATH="/opt/zeek/bin:/opt/rh/gcc-toolset-9/root/bin:${PATH}"
 
@@ -20,12 +20,14 @@ RUN cd /opt && curl -L http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz | tar xzvf 
 RUN cd /usr/local && curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - && ln -s /usr/local/cmake-3.16.4-Linux-x86_64/bin/cmake /usr/local/bin
 
 # Install Zeek and package manager
-RUN yum install -y libpcap-devel openssl-devel zlib-devel python3 \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3 python3-GitPython python3-semantic_version \
  && rpm -iv \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeekctl-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
-    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-btest-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-zkg-${ZEEK_VERSION}.x86_64.rpm
 RUN pip3 install zkg && zkg autoconfig

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ARG ZEEK_VERSION=3.0.11-2.2
+ARG ZEEK_VERSION=4.0.0-3.1
 
 WORKDIR /root
 
@@ -37,13 +37,15 @@ RUN cd /opt && curl -L https://github.com/westes/flex/files/981163/flex-2.6.4.ta
 RUN yum install -y rpmdevtools
 
 # Install Zeek.
-RUN yum install -y libpcap-devel openssl-devel zlib-devel \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb \
  && rpm -iv \
     https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeekctl-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_7/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
-    https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm
+    https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-zkg-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_7/x86_64/zeek-lts-btest-${ZEEK_VERSION}.x86_64.rpm
 
 WORKDIR /root

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ARG ZEEK_VERSION=3.0.11-2.2
+ARG ZEEK_VERSION=4.0.0-3.1
 
 WORKDIR /root
 
@@ -35,13 +35,15 @@ RUN yum install -y rpmdevtools
 RUN yum install -y libpcap-devel openssl-devel python3-devel swig zlib-devel
 
 # Install Zeek.
-RUN yum install -y libpcap-devel openssl-devel zlib-devel \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3-GitPython python3-semantic_version \
  && rpm -iv \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeekctl-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
-    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-zkg-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-btest-${ZEEK_VERSION}.x86_64.rpm
 
 WORKDIR /root

--- a/docker/Dockerfile.debian-10
+++ b/docker/Dockerfile.debian-10
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG ZEEK_VERSION=3.0.11-0
+ARG ZEEK_VERSION=4.0.0-0
 ARG ZEEK_LTS=1
 
 ENV BISON_VERSION "3.7.4"
@@ -85,9 +85,11 @@ RUN mkdir -p /tmp/zeek-packages \
    https://download.zeek.org/binary-packages/Debian_10/amd64/zeek${ZEEK_LTS}-core_${ZEEK_VERSION}_amd64.deb \
    https://download.zeek.org/binary-packages/Debian_10/amd64/zeek${ZEEK_LTS}-libcaf-dev_${ZEEK_VERSION}_amd64.deb \
    https://download.zeek.org/binary-packages/Debian_10/amd64/zeek${ZEEK_LTS}_${ZEEK_VERSION}_amd64.deb \
+   https://download.zeek.org/binary-packages/Debian_10/amd64/zeek${ZEEK_LTS}-btest_${ZEEK_VERSION}_amd64.deb \
+   https://download.zeek.org/binary-packages/Debian_10/amd64/zeek${ZEEK_LTS}-zkg_${ZEEK_VERSION}_amd64.deb \
    https://download.zeek.org/binary-packages/Debian_10/amd64/zeekctl${ZEEK_LTS}-dbgsym_${ZEEK_VERSION}_amd64.deb \
    https://download.zeek.org/binary-packages/Debian_10/amd64/zeekctl${ZEEK_LTS}_${ZEEK_VERSION}_amd64.deb  \
- && apt-get install -y libpcap-dev python2 \
+ && apt-get install -y libpcap-dev python python3-semantic-version python3-git \
  && dpkg -i *.deb \
  && cd - \
  && rm -rf /tmp/zeek-packages

--- a/docker/Dockerfile.debian-9
+++ b/docker/Dockerfile.debian-9
@@ -1,5 +1,7 @@
 FROM debian:stretch-slim
 
+# TODO(bbannier): We need to keep this at an older Zeek version as currently no
+# newer packages are published for debian-9.
 ARG ZEEK_VERSION=v3.2.2
 
 ENV BISON_VERSION "3.6.2"

--- a/docker/Dockerfile.fedora-32
+++ b/docker/Dockerfile.fedora-32
@@ -1,13 +1,13 @@
 FROM fedora:32
 
-ARG ZEEK_VERSION=3.0.11-2.1
+ARG ZEEK_VERSION=4.0.0-3.1
 
 RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LC_ALL="C"' >> /etc/locale.conf \
  && echo 'LANG="C"' >> /etc/locale.conf
 
 # Install Zeek.
-RUN yum install -y libpcap-devel openssl-devel zlib-devel \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3-GitPython python3-semantic_version \
  && rpm -iv \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \
@@ -15,6 +15,8 @@ RUN yum install -y libpcap-devel openssl-devel zlib-devel \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-btest-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/Fedora_32/x86_64/zeek-lts-zkg-${ZEEK_VERSION}.x86_64.rpm \
 # Install Spicy build dependencies
  && yum install -y ccache git ninja-build flex bison gcc-c++ findutils diffutils python3-pip which \
  && pip3 install "btest>=0.66" \

--- a/docker/Dockerfile.fedora-33
+++ b/docker/Dockerfile.fedora-33
@@ -1,6 +1,6 @@
 FROM fedora:33
 
-ARG ZEEK_VERSION=3.0.11-2.1
+ARG ZEEK_VERSION=4.0.0-3.1
 
 ENV PATH="/opt/zeek/bin:${PATH}"
 
@@ -9,7 +9,7 @@ RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LANG="C"' >> /etc/locale.conf
 
 # Install Zeek.
-RUN yum install -y libpcap-devel openssl-devel zlib-devel \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3-GitPython python3-semantic_version \
  && rpm -iv \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \
@@ -17,6 +17,8 @@ RUN yum install -y libpcap-devel openssl-devel zlib-devel \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/libbroker-lts-devel-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-libcaf-devel-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-btest-${ZEEK_VERSION}.x86_64.rpm \
+    https://download.zeek.org/binary-packages/Fedora_33/x86_64/zeek-lts-zkg-${ZEEK_VERSION}.x86_64.rpm \
 # Install Spicy build dependencies
  && yum install -y ccache git ninja-build cmake flex bison gcc-c++ findutils diffutils python3-pip which \
  && pip3 install "btest>=0.66" \

--- a/docker/Dockerfile.ubuntu-16
+++ b/docker/Dockerfile.ubuntu-16
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-ARG ZEEK_VERSION=v3.0.11
+ARG ZEEK_VERSION=v4.0.0
 ENV BISON_VERSION "3.6.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/Dockerfile.ubuntu-18
+++ b/docker/Dockerfile.ubuntu-18
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-ARG ZEEK_VERSION=3.0.11-0
+ARG ZEEK_VERSION=4.0.0-0
 ENV BISON_VERSION "3.6.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -20,6 +20,7 @@ ENV CC=clang-9
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
  # Zeek.
+ && apt-get install -y --no-install-recommends libpcap0.8 libpcap-dev libssl-dev zlib1g-dev libmaxminddb0 libmaxminddb-dev python python3 python3-pip python3-semantic-version python3-git \
  && mkdir -p /tmp/zeek-packages \
  && cd /tmp/zeek-packages \
  && curl -L --remote-name-all \
@@ -29,7 +30,8 @@ RUN apt-get update \
     https://download.zeek.org/binary-packages/xUbuntu_18.04/amd64/zeek-lts-core-dev_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_18.04/amd64/libbroker-lts-dev_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_18.04/amd64/zeek-lts-libcaf-dev_${ZEEK_VERSION}_amd64.deb \
- && apt-get install -y libpcap0.8 libpcap-dev python libssl-dev zlib1g-dev \
+    https://download.zeek.org/binary-packages/xUbuntu_18.04/amd64/zeek-lts-btest_${ZEEK_VERSION}_amd64.deb \
+    https://download.zeek.org/binary-packages/xUbuntu_18.04/amd64/zeek-lts-zkg_${ZEEK_VERSION}_amd64.deb \
  && dpkg -i *.deb \
  && cd - \
  && rm -rf /tmp/zeek-packages \

--- a/docker/Dockerfile.ubuntu-20
+++ b/docker/Dockerfile.ubuntu-20
@@ -6,7 +6,7 @@ ENV IMAGE_VERSION=1
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG ZEEK_LTS=1
-ARG ZEEK_VERSION=3.0.11-0
+ARG ZEEK_VERSION=4.0.0-0
 
 CMD ["sh"]
 ENV DEBIAN_FRONTEND=noninteractive

--- a/hilti/toolchain/include/ast/types/struct.h
+++ b/hilti/toolchain/include/ast/types/struct.h
@@ -33,7 +33,8 @@ public:
         : NodeBase(nodes(std::move(id), std::move(ft), node::none, std::move(attrs), node::none), std::move(m)),
           _cc(cc) {}
     Field(ID id, hilti::Function inline_func, std::optional<AttributeSet> attrs = {}, Meta m = Meta())
-        : NodeBase(nodes(std::move(id), node::none, node::none, std::move(attrs), inline_func), std::move(m)),
+        : NodeBase(nodes(std::move(id), node::none, node::none, std::move(attrs), std::move(inline_func)),
+                   std::move(m)),
           _cc(inline_func.callingConvention()) {}
 
     const auto& id() const { return child<ID>(0); }


### PR DESCRIPTION
We still keep at least a single setup with zeek-3.0.0 so we also have
some coverage there.

Closes #827.