### PR TITLE
Fix extraction of integer bits when all bits requested.

### DIFF
--- a/hilti/runtime/include/types/integer.h
+++ b/hilti/runtime/include/types/integer.h
@@ -247,7 +247,7 @@ enum class BitOrder { LSB0, MSB0, Undef };
 template<typename UINT>
 inline hilti::rt::integer::safe<UINT> bits(hilti::rt::integer::safe<UINT> v, uint64_t lower, uint64_t upper,
                                            BitOrder bo) {
-    const auto width = std::numeric_limits<UINT>::digits;
+    constexpr auto width = std::numeric_limits<UINT>::digits;
 
     if ( lower > upper )
         throw InvalidArgument("lower limit needs to be less or equal the upper limit");
@@ -268,7 +268,15 @@ inline hilti::rt::integer::safe<UINT> bits(hilti::rt::integer::safe<UINT> v, uin
     }
 
     assert(lower <= upper);
-    auto mask = ((1U << (upper - lower + 1)) - 1U) << lower;
+    const auto range = upper - lower + 1;
+
+    // If the range to extract equals the width there is no work to do.
+    //
+    // NOTE: Not returning early here would lead to a shift beyond the width below.
+    if ( range == width )
+        return v;
+
+    const auto mask = ((1U << range) - 1U) << lower;
     return (v & mask) >> lower;
 }
 

--- a/hilti/runtime/src/tests/integer.cc
+++ b/hilti/runtime/src/tests/integer.cc
@@ -166,6 +166,12 @@ TEST_CASE("bits") {
                          "upper limit needs to be less or equal the input width", const InvalidArgument&);
     CHECK_THROWS_WITH_AS(integer::bits(integer::safe<uint8_t>(0), 0, 3, integer::BitOrder::Undef),
                          "undefined bit order", const RuntimeError&);
+
+    // Extracting all bits should reproduce the input.
+    CHECK_EQ(hilti::rt::integer::bits(hilti::rt::integer::safe<uint64_t>(72623859790382848),
+                                      hilti::rt::integer::safe<std::uint64_t>{0u},
+                                      hilti::rt::integer::safe<std::uint64_t>{63u}, hilti::rt::integer::BitOrder::LSB0),
+             72623859790382848);
 }
 
 TEST_CASE("unpack") {


### PR DESCRIPTION
When calculating the extraction mask, we previously would shift an
integer beyond its width which triggers UB. With this patch we now
correctly detect such cases and directly return the input.

Closes #853.