### PR TITLE
Fix YAML comment in docker-latest GH workflow [skip ci].

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -35,8 +35,8 @@ jobs:
         context: .
         file: ci/Dockerfile.dockerhub
         push: true
+        # TODO(bbannier): Create `spicy:latest` from tagged in release to docker-tags.yml.
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/spicy-dev:latest
           ${{ secrets.DOCKER_USERNAME }}/spicy-dev:${{ steps.version.outputs.RELEASE_VERSION }}
-          # TODO(bbannier): Move this to docker-tags.yml after the release.
           ${{ secrets.DOCKER_USERNAME }}/spicy:latest


### PR DESCRIPTION
The comment was not valid in its previous place which allowed only
tags. This patch moves it to a proper place.

This is a fixup commit for 843e9e0073006b5c8eee5568e5a9d69fcd834250.