### PR TITLE
Fix doc links to package artifacts.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,7 @@ copyright = u'2020 by the Zeek Project'
 author = u'Zeek Project'
 
 version = subprocess.check_output("../scripts/autogen-version").decode("utf8")
-release = "1.0.0" # most recent release version
+release = "1.0.0"  # most recent release version
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,10 +58,10 @@ extlinks = {
     "pr":    ("https://github.com/zeek/spicy/pulls/%s", "#"),
 
     # Links to binary builds.
-    "package-dev-tgz": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy.tar.gz", ""),
-    "package-dev-rpm": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy.rpm", ""),
-    "package-dev-deb": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy.deb", ""),
-    "package-release-tgz": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%%s/packages/spicy-%s.tar.gz" % release, ""),
+    "package-dev-tgz": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/build/spicy-dev.tar.gz", ""),
+    "package-dev-rpm": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.rpm", ""),
+    "package-dev-deb": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.deb", ""),
+    "package-release-tgz": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%%s/packages/build/spicy-%s.tar.gz" % release, ""),
     "package-release-rpm": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%%s/packages/spicy-%s.rpm" % release, ""),
     "package-release-deb": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%%s/packages/spicy-%s.deb" % release, "")
 }


### PR DESCRIPTION
We recently renamed packages from e.g., `spicy.deb` to `spicy-dev.deb`
which wasn't reflected in the docs.

Additionally, due to the CI setup `.tar.gz` artifacts live in
`packages/build` while `.deb` and `.rpm` artifacts live in `packages/`;
we fix the links for that as well.