### PR TITLE
Fix leftovers in GH actions from master -> main rename.

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -4,8 +4,8 @@ name: Publish Docker
 on:
   push:
     branches:
-      # Since this action pushes a `latest` image it is only active for the `master` branch.
-      - master
+      # Since this action pushes a `latest` image it is only active for the `main` branch.
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -3,8 +3,6 @@
 name: Publish Docker
 on:
   push:
-    branches:
-      - master
     tags:
       # Since this action pushes just a tagged image it is only active on tags.
       - v*


### PR DESCRIPTION
We were still hardcoding `master` as our default branch in the GH action
responsible for publishing Docker images. This patch fixes that name
mismatch; we also disable to workflow for publishing tags on `main`
(this was still enabled since we didn't publish properly versioned
images before).