### PR TITLE
Fix missing normalization of enum label IDs.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -152,7 +152,7 @@ struct Visitor : hilti::visitor::PreOrder<std::string, Visitor> {
 
         if ( auto c = n.declaration().tryAs<declaration::Constant>() ) {
             if ( c->value().type().isA<type::Enum>() )
-                return cg->compile(c->value()); // This constructs the right ID.
+                return cxx::ID(cg->compile(c->value()));
 
             return cxx::ID(cg->options().cxx_namespace_intern, cxx::ID(n.id()));
         }


### PR DESCRIPTION
They weren't turned into proper C++ codegen IDs, meaning they weren't
normalized.

(Skipping test.)

Closes #872.