### PR TITLE
Add assertion to ensure that code cannot be reached.

### DIFF
--- a/hilti/toolchain/include/ast/operator.h
+++ b/hilti/toolchain/include/ast/operator.h
@@ -14,6 +14,7 @@
 #include <hilti/ast/types/type.h>
 #include <hilti/base/logger.h>
 #include <hilti/base/type_erase.h>
+#include <hilti/base/util.h>
 #include <hilti/base/visitor-types.h>
 
 namespace hilti {
@@ -333,6 +334,8 @@ constexpr auto isCommutative(Kind k) {
         case Kind::Unpack:
         case Kind::Unset: return false;
     };
+
+    util::cannot_be_reached();
 }
 
 namespace detail {


### PR DESCRIPTION
Some compilers diagnose the function changed here as having a missing
return. Since we switch over all possible values we should never return
without a value, though.

This patch adds a runtime assertion that we do not return without a
value.