### PR TITLE
Make spicy compile with bison 3.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/autogen-version --cm
 project(spicy VERSION "${SPICY_VERSION}" LANGUAGES ASM C CXX)
 
 set(flex_minimum_version "2.6")
-set(bison_minimum_version "3.4")
+set(bison_minimum_version "3.0")
 set(python_minimum_version "2.4")
 set(macos_minimum_version "19.0.0") # macOS 10.15.0 (Catalina)
 

--- a/ci/Dockerfile.packages
+++ b/ci/Dockerfile.packages
@@ -13,14 +13,11 @@ SHELL [ "/usr/bin/scl", "enable", "gcc-toolset-9"]
 # Use ld.gold instead.
 RUN alternatives --set ld /usr/bin/ld.gold
 
-# Need a more recent Bison than available.
-RUN cd /opt && curl -L http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz | tar xzvf - && cd /opt/bison-3.5 && ./configure && make install
-
 # Need a more recent CMake than available.
 RUN cd /usr/local && curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - && ln -s /usr/local/cmake-3.16.4-Linux-x86_64/bin/cmake /usr/local/bin
 
 # Install Zeek and package manager
-RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3 python3-GitPython python3-semantic_version \
+RUN yum install -y libpcap-devel openssl-devel zlib-devel libmaxminddb cmake-filesystem python3 python3-GitPython python3-semantic_version bison \
  && rpm -iv \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-${ZEEK_VERSION}.x86_64.rpm \
     https://download.zeek.org/binary-packages/CentOS_8/x86_64/zeek-lts-core-${ZEEK_VERSION}.x86_64.rpm \

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -163,3 +163,36 @@ function(spicy_link_executable_in_tree exec)
     spicy_link_libraries_in_tree(${exec} "${ARGN}")
     set_property(TARGET ${exec} PROPERTY ENABLE_EXPORTS true)
 endfunction ()
+
+# Wrapper around `BISON_TARGET` with Spicy-specific preprocessing.
+macro(BISON_TARGET_PP Name BisonInput BisonOutput)
+    # Name of the preprocessed Bison input.
+    string(JOIN "." BisonInputPP "${BisonOutput}" "pp")
+
+    # Preprocess the input file.
+    file(READ ${BisonInput} input)
+    if (${BISON_VERSION} VERSION_LESS "3.3.0")
+        # In versions <bison-3.3.0 `api.parser.name` was called `parser_class_name`.
+        string(REPLACE "%require \"3.3\"" "%require \"3.0\"" input "${input}")
+        string(REPLACE "api.parser.class" "parser_class_name" input "${input}")
+    endif()
+    file(WRITE ${BisonInputPP} "${input}")
+
+    # Pass preprocessed file to `BISON_TARGET`.
+    #
+    # TODO(bbannier): Since `ARGV` is a list of lists normal list manipulations like
+    # `list(REPLACE_AT ...)` do not seem to work so we create a new output list.
+    set(i 0)
+    foreach(arg ${ARGV})
+        if (i EQUAL 1)
+            list(APPEND args "${BisonInputPP}")
+        else()
+            list(APPEND args "${arg}")
+        endif()
+        MATH(EXPR i "${i}+1")
+    endforeach()
+
+    # Invoke the actual Bison processing.
+    message(WARNING "NOPE " ${args})
+    BISON_TARGET(${args})
+endmacro()

--- a/docker/Dockerfile.centos-7
+++ b/docker/Dockerfile.centos-7
@@ -16,7 +16,7 @@ RUN echo ". scl_source enable devtoolset-9" >> /etc/profile
 ENV PATH="/opt/rh/devtoolset-9/root/usr/bin:${PATH}"
 
 # Install development tools.
-RUN yum install -y ccache git make ninja-build python3 python3-pip vim doxygen diffutils m4
+RUN yum install -y ccache git make ninja-build python3 python3-pip vim doxygen diffutils m4 bison
 
 # Need a more recent CMake than available.
 WORKDIR /usr/local/cmake
@@ -26,9 +26,6 @@ ENV PATH="/usr/local/cmake/bin:${PATH}"
 # Install Spicy dependencies.
 RUN yum install -y python3-sphinx
 RUN pip3 install "btest>=0.66" sphinx-rtd-theme
-
-# Need a more recent Bison than available.
-RUN cd /opt && curl -L http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz | tar xzvf - && cd /opt/bison-3.5 && ./configure && make install
 
 # Need a more recent flex than available.
 RUN cd /opt && curl -L https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz | tar xzvf - && cd /opt/flex-2.6.4  && ./configure && make install

--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -13,7 +13,7 @@ RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
 RUN yum install -y epel-release yum-utils && yum-config-manager --set-enabled powertools
 
 # Install development tools.
-RUN yum install -y ccache gdb git make ninja-build python3 python3-pip vim doxygen diffutils gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+RUN yum install -y ccache gdb git make ninja-build python3 python3-pip vim doxygen diffutils gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ bison
 ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:$PATH
 
 # Need a more recent CMake than available.
@@ -24,9 +24,6 @@ ENV PATH="/usr/local/cmake/bin:${PATH}"
 # Install Spicy dependencies.
 RUN yum install -y flex python3-sphinx
 RUN pip3 install "btest>=0.66" sphinx-rtd-theme
-
-# Need a more recent Bison than available.
-RUN cd /opt && curl -L http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz | tar xzvf - && cd /opt/bison-3.5 && ./configure && make install
 
 # Install rpmdevtools for packaging RPM files.
 RUN yum install -y rpmdevtools

--- a/docker/Dockerfile.debian-10
+++ b/docker/Dockerfile.debian-10
@@ -3,8 +3,6 @@ FROM debian:buster-slim
 ARG ZEEK_VERSION=4.0.0-0
 ARG ZEEK_LTS=1
 
-ENV BISON_VERSION "3.7.4"
-
 ENV DEBIAN_FRONTEND noninteractive
 ENV CCACHE_DIR "/var/spool/ccache"
 ENV CCACHE_COMPRESS 1
@@ -34,6 +32,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/so
     apt-get -q update && \
     apt-get install -q -y -t buster-backports --no-install-recommends \
         binutils \
+        bison \
         ccache \
         clang-${LLVM_VERSION} \
         file \
@@ -62,16 +61,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/so
   pip3 install --no-cache-dir "btest>=0.66" pre-commit && \
   # recent CMake
   mkdir -p "${CMAKE_DIR}" && \
-    curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1 && \
-  # recent Bison
-  cd /tmp && \
-    curl -sSL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz" | tar xzf - -C /tmp && \
-    cd "./bison-${BISON_VERSION}" && \
-    ./configure --prefix=/usr && \
-    make && \
-    make install && \
-    cd /tmp && \
-    rm -rf /tmp/bison*
+    curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
 
 # Install Zeek
 RUN mkdir -p /tmp/zeek-packages \

--- a/docker/Dockerfile.debian-9
+++ b/docker/Dockerfile.debian-9
@@ -4,8 +4,6 @@ FROM debian:stretch-slim
 # newer packages are published for debian-9.
 ARG ZEEK_VERSION=v3.2.2
 
-ENV BISON_VERSION "3.6.2"
-
 ENV DEBIAN_FRONTEND noninteractive
 ENV CCACHE_DIR "/var/spool/ccache"
 ENV CCACHE_COMPRESS 1
@@ -36,6 +34,7 @@ RUN sed -i "s/stretch main/stretch main contrib non-free/g" /etc/apt/sources.lis
     apt-get -q update && \
     apt-get install -q -y -t stretch-backports --no-install-recommends \
         binutils \
+        bison \
         ccache \
         clang-${LLVM_VERSION} \
         file \
@@ -65,15 +64,6 @@ RUN sed -i "s/stretch main/stretch main contrib non-free/g" /etc/apt/sources.lis
   # recent CMake
   mkdir -p "${CMAKE_DIR}" && \
     curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1 && \
-  # recent Bison
-  cd /tmp && \
-    curl -sSL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz" | tar xzf - -C /tmp && \
-    cd "./bison-${BISON_VERSION}" && \
-    ./configure --prefix=/usr && \
-    make && \
-    make install && \
-    cd /tmp && \
-    rm -rf /tmp/bison* && \
   echo "deb http://httpredir.debian.org/debian unstable main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -y --no-install-recommends install libstdc++-10-dev

--- a/docker/Dockerfile.ubuntu-16
+++ b/docker/Dockerfile.ubuntu-16
@@ -1,7 +1,6 @@
 FROM ubuntu:xenial
 
 ARG ZEEK_VERSION=v4.0.0
-ENV BISON_VERSION "3.6.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -34,14 +33,7 @@ RUN apt-get update \
 # Zeek dependencies.
  && apt-get install -y --no-install-recommends libpcap-dev libssl-dev zlib1g-dev swig python3-dev \
  # Spicy build and test dependencies.
- && apt-get install -y --no-install-recommends git ninja-build ccache flex libfl-dev python3 python3-pip zlib1g-dev locales-all python3-setuptools python3-wheel make llvm-11-dev clang-11 libclang-11-dev libc++-11-dev \
- && curl -sSL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz" | tar xzf - -C /tmp \
- && cd "/tmp/bison-${BISON_VERSION}" \
- && ./configure --prefix=/usr \
- && make \
- && make install \
- && cd /tmp \
- && rm -rf /tmp/bison* \
+ && apt-get install -y --no-install-recommends git ninja-build ccache flex libfl-dev python3 python3-pip zlib1g-dev locales-all python3-setuptools python3-wheel make llvm-11-dev clang-11 libclang-11-dev libc++-11-dev bison \
  && pip3 install "btest>=0.66" pre-commit \
  # Spicy doc dependencies.
  && apt-get install -y --no-install-recommends python3-sphinx python3-sphinx-rtd-theme doxygen \

--- a/docker/Dockerfile.ubuntu-18
+++ b/docker/Dockerfile.ubuntu-18
@@ -1,7 +1,6 @@
 FROM ubuntu:bionic
 
 ARG ZEEK_VERSION=4.0.0-0
-ENV BISON_VERSION "3.6.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -36,14 +35,7 @@ RUN apt-get update \
  && cd - \
  && rm -rf /tmp/zeek-packages \
  # Spicy build and test dependencies.
- && apt-get install -y --no-install-recommends git ninja-build ccache g++ llvm-9-dev clang-9 libclang-9-dev flex libfl-dev python3 python3-pip zlib1g-dev jq locales-all python3-setuptools python3-wheel make \
- && curl -sSL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz" | tar xzf - -C /tmp \
- && cd "/tmp/bison-${BISON_VERSION}" \
- && ./configure --prefix=/usr \
- && make \
- && make install \
- && cd /tmp \
- && rm -rf /tmp/bison* \
+ && apt-get install -y --no-install-recommends git ninja-build ccache g++ llvm-9-dev clang-9 libclang-9-dev flex libfl-dev python3 python3-pip zlib1g-dev jq locales-all python3-setuptools python3-wheel make bison \
  && pip3 install "btest>=0.66" pre-commit \
  # Spicy doc dependencies.
  && apt-get install -y --no-install-recommends python3-sphinx python3-sphinx-rtd-theme doxygen \

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -9,7 +9,7 @@ file(MAKE_DIRECTORY  "${CMAKE_BINARY_DIR}/bin" "${CMAKE_BINARY_DIR}/lib")
 
 FLEX_TARGET(scanner_hilti src/compiler/parser/scanner.ll ${AUTOGEN_CC}/__scanner.cc
             DEFINES_FILE ${AUTOGEN_CC}/__scanner.h)
-BISON_TARGET(parser_hilti src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc
+BISON_TARGET_PP(parser_hilti src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc
             DEFINES_FILE ${AUTOGEN_CC}/__parser.h
 )
 

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -1,7 +1,11 @@
 /* Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details. */
 
+/* This grammar is written against the bison-3.3 API. If an older Bison version
+ * was detected we perform preprocessing to support versions down to at least
+ * bison-3.0, see the CMake macro `BISON_TARGET_PP`. */
+%require "3.3"
+
 %skeleton "lalr1.cc"                          /*  -*- C++ -*- */
-%require "3.4"
 %defines
 
 %{

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -11,7 +11,7 @@ set(AUTOGEN_H_HILTI  "${CMAKE_BINARY_DIR}/include/hilti/autogen")
 
 FLEX_TARGET(scanner_spicy src/compiler/parser/scanner.ll ${AUTOGEN_CC}/__scanner.cc
             DEFINES_FILE ${AUTOGEN_CC}/__scanner.h)
-BISON_TARGET(parser_spicy src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc
+BISON_TARGET_PP(parser_spicy src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc
             DEFINES_FILE ${AUTOGEN_CC}/__parser.h
 )
 

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -1,7 +1,11 @@
 /* Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details. */
 
+/* This grammar is written against the bison-3.3 API. If an older Bison version
+ * was detected we perform preprocessing to support versions down to at least
+ * bison-3.0, see the CMake macro `BISON_TARGET_PP`. */
+%require "3.3"
+
 %skeleton "lalr1.cc"                          /*  -*- C++ -*- */
-%require "3.4"
 %defines
 
 %{


### PR DESCRIPTION
This also allows compiling under OpenSUSE Leap 15.2, which only ships with bison 3.0.4.

Relates to GH-882