### PR TITLE
Force type information to come last in generated C++ code.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -246,6 +246,11 @@ void Unit::_generateCode(Formatter& f, bool prototypes_only) {
         }
 
         if ( ! prototypes_only || ! util::endsWith(ns, "::") ) { // skip anonymous namespace
+            if ( ns == "__hlt::type_info::" )
+                // We force this to come last later below because creating the type information needs access to all
+                // other types.
+                continue;
+
             for ( const auto& i : _constants ) {
                 if ( i.second.id.namespace_() == ns )
                     f << i.second;
@@ -270,6 +275,14 @@ void Unit::_generateCode(Formatter& f, bool prototypes_only) {
 
             if ( seperator )
                 f << separator();
+        }
+    }
+
+    // Add the contents of the type information namespace. We know that there are only constants in there.
+    if ( ! prototypes_only ) {
+        for ( const auto& i : _constants ) {
+            if ( i.second.id.namespace_() == cxx::ID("__hlt::type_info::") )
+                f << i.second;
         }
     }
 


### PR DESCRIPTION
We could run into some dependencies where the types being referred to in
the type information weren't declared yet.

No test included, as it's hard to recreate the situation; will be
tested through an upcoming change to the Zeek plugin.