### PR TITLE
Provide mktime() library function.

### DIFF
--- a/doc/autogen/spicy-functions.spicy
+++ b/doc/autogen/spicy-functions.spicy
@@ -45,6 +45,19 @@ Finalizes a base64 stream used for decoding or encoding.
 
 Returns the current wall clock time.
 
+.. _spicy_mktime:
+
+.. rubric:: ``function spicy::mktime(y: uint64, m: uint64, d: uint64, H: uint64, M: uint64, S: uint64) : time``
+
+Constructs a time value from a tuple of broken-out elements specifying local time.
+
+- *y*: year (1970-...)
+- *m*: month (1-12)
+- *d*: day (1-31)
+- *H*: hour (0-23)
+- *M*: minute (0-59)
+- *S*: second (0-59)
+
 .. _spicy_bytes_to_hexstring:
 
 .. rubric:: ``function spicy::bytes_to_hexstring(value: bytes) : string``

--- a/hilti/lib/hilti.hlt
+++ b/hilti/lib/hilti.hlt
@@ -22,6 +22,7 @@ declare public void debugIndent(string dbg_stream) &cxxname="hilti::rt::debug::i
 declare public void debugDedent(string dbg_stream) &cxxname="hilti::rt::debug::dedent" &have_prototype;
 
 declare public time current_time() &cxxname="hilti::rt::time::current_time" &have_prototype;
+declare public time mktime(uint<64> y, uint<64> m, uint<64> d, uint<64> H, uint<64> M, uint<64> S) &cxxname="hilti::rt::time::mktime" &have_prototype;
 
 declare public void abort() &cxxname="hilti::rt::abort_with_backtrace" &have_prototype;
 

--- a/hilti/runtime/include/types/time.h
+++ b/hilti/runtime/include/types/time.h
@@ -97,6 +97,7 @@ private:
 
 namespace time {
 extern Time current_time();
+extern Time mktime(uint64_t y, uint64_t m, uint64_t d, uint64_t H, uint64_t M, uint64_t S);
 } // namespace time
 
 namespace detail::adl {

--- a/hilti/runtime/src/tests/time.cc
+++ b/hilti/runtime/src/tests/time.cc
@@ -24,6 +24,16 @@ TEST_CASE("current_time") {
     CHECK_GE(end + 1, current_time.seconds());
 }
 
+TEST_CASE("mktime") {
+    setenv("TZ", "", 1);
+    tzset();
+    const auto t = time::mktime(2021, 4, 1, 1, 2, 3);
+    CHECK_EQ(t, Time(1617238923, Time::SecondTag{}));
+
+    CHECK_THROWS_AS(time::mktime(42, 4, 1, 1, 2, 3), const InvalidValue&);
+    CHECK_THROWS_AS(time::mktime(2021, 4, 1, 1, 2, 100), const InvalidValue&);
+}
+
 TEST_SUITE_BEGIN("Time");
 
 TEST_CASE("comparisions") {

--- a/hilti/runtime/src/types/time.cc
+++ b/hilti/runtime/src/types/time.cc
@@ -18,6 +18,27 @@ Time time::current_time() {
     return Time(t, Time::SecondTag());
 }
 
+Time time::mktime(uint64_t y, uint64_t m, uint64_t d, uint64_t H, uint64_t M, uint64_t S) {
+    if ( y < 1970 || (m < 1 || m > 12) || (d < 1 || d > 31) || H > 23 || M > 59 || S > 59 )
+        throw InvalidValue("value out of range");
+
+    struct tm t;
+    t.tm_sec = S;
+    t.tm_min = M;
+    t.tm_hour = H;
+    t.tm_mday = d;
+    t.tm_mon = m - 1;
+    t.tm_year = y - 1900;
+    t.tm_isdst = -1;
+
+    time_t teatime = mktime(&t);
+
+    if ( teatime < 0 )
+        throw InvalidValue("cannot create time value");
+
+    return Time(teatime, Time::SecondTag());
+}
+
 Time::operator std::string() const {
     if ( _nsecs == 0 )
         return "<not set>";

--- a/spicy/lib/spicy.spicy
+++ b/spicy/lib/spicy.spicy
@@ -84,6 +84,16 @@ public function base64_finish(inout stream_: Base64Stream) : bytes &cxxname="spi
 ## Returns the current wall clock time.
 public function current_time() : time &cxxname="hilti::rt::time::current_time" &have_prototype;
 
+## Constructs a time value from a tuple of broken-out elements specifying local time.
+##
+## - *y*: year (1970-...)
+## - *m*: month (1-12)
+## - *d*: day (1-31)
+## - *H*: hour (0-23)
+## - *M*: minute (0-59)
+## - *S*: second (0-59)
+public function mktime(y: uint64, m: uint64, d: uint64, H: uint64, M: uint64, S: uint64) : time &cxxname="hilti::rt::time::mktime" &have_prototype;
+
 ## Returns a bytes value rendered as a hex string.
 public function bytes_to_hexstring(value: bytes) : string &cxxname="spicy::rt::bytes_to_hexstring" &have_prototype;
 

--- a/tests/hilti/types/time/functions.hlt
+++ b/tests/hilti/types/time/functions.hlt
@@ -1,4 +1,4 @@
-# @TEST-EXEC: ${HILTIC} -j %INPUT >output
+# @TEST-EXEC: TZ=C ${HILTIC} -j %INPUT >output
 # @TEST-EXEC: btest-diff output
 
 module Test {
@@ -7,4 +7,8 @@ import hilti;
 
 global t = hilti::current_time();
 assert t > time(1564617600) && t < time(1893456000);
+
+t = hilti::mktime(2021, 4, 1, 1, 2, 3);
+assert t == time(1617238923);
+
 }


### PR DESCRIPTION
This allows creating a `time` value from individual compenents, similar
to mktime(3). Providing to both HILTI and Spicy code.