### PR TITLE
Make sure container sizes are runtime integers.

### DIFF
--- a/hilti/runtime/include/types/map.h
+++ b/hilti/runtime/include/types/map.h
@@ -176,6 +176,7 @@ public:
 
     using key_type = typename M::key_type;
     using value_type = typename M::value_type;
+    using size_type = uint64_t;
 
     using iterator = typename map::Iterator<K, V>;
     using const_iterator = typename map::ConstIterator<K, V>;
@@ -257,13 +258,12 @@ public:
     auto end() const { return this->cend(); }
 
     auto begin() { return iterator(static_cast<M&>(*this).begin(), _control); }
-
     auto end() { return iterator(static_cast<M&>(*this).end(), _control); }
 
     auto cbegin() const { return const_iterator(static_cast<const M&>(*this).begin(), _control); }
-
     auto cend() const { return const_iterator(static_cast<const M&>(*this).end(), _control); }
 
+    size_type size() const { return M::size(); }
 
     /** Erases all elements from the map.
      *
@@ -291,9 +291,6 @@ public:
 
         return removed;
     }
-
-    // Methods of `std::map`.
-    using M::size;
 
     friend bool operator==(const Map& a, const Map& b) { return static_cast<const M&>(a) == static_cast<const M&>(b); }
     friend bool operator!=(const Map& a, const Map& b) { return ! (a == b); }

--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -120,7 +120,7 @@ public:
     using key_type = T;
     using value_type = T;
 
-    using size_type = typename V::size_type;
+    using size_type = uint64_t;
 
     Set() = default;
     Set(const Set&) = default;
@@ -140,8 +140,9 @@ public:
     bool contains(const T& t) const { return this->count(t); }
 
     auto begin() const { return iterator(static_cast<const V&>(*this).begin(), empty() ? nullptr : _control); }
-
     auto end() const { return iterator(static_cast<const V&>(*this).end(), empty() ? nullptr : _control); }
+
+    size_type size() const { return V::size(); }
 
     /** Removes an element from the set.
      *
@@ -171,7 +172,6 @@ public:
     // Methods of `std::set`. These methods *must not* cause any iterator invalidation.
     using V::empty;
     using V::insert;
-    using V::size;
 
     friend bool operator==(const Set& a, const Set& b) { return static_cast<const V&>(a) == static_cast<const V&>(b); }
     friend bool operator!=(const Set& a, const Set& b) { return ! (a == b); }

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -253,7 +253,7 @@ public:
 
     using V = std::vector<T, Allocator>;
 
-    using size_type = typename V::size_type;
+    using size_type = uint64_t;
     using reference = T&;
     using const_reference = const T&;
     using iterator = vector::Iterator<T, Allocator>;
@@ -465,6 +465,8 @@ public:
     auto cbegin() const { return const_iterator(0u, _control); }
     auto cend() const { return const_iterator(size(), _control); }
 
+    size_t size() const { return V::size(); }
+
     // Methods of `std::vector`.
     using typename V::value_type;
     using V::at;
@@ -475,7 +477,6 @@ public:
     using V::push_back;
     using V::reserve;
     using V::resize;
-    using V::size;
 
     friend bool operator==(const Vector& a, const Vector& b) {
         return static_cast<const V&>(a) == static_cast<const V&>(b);


### PR DESCRIPTION
For the HILTI runtime containers we previously directly forwarded the
`size` functions of the underlying stdlib containers. This could have
lead to them returning a type not expected by our runtime, e.g., on
macos these might return `unsigned long` values which our runtime e.g.,
doesn't know how to print.

This patch changes these functions so that now they return types which
we expect our runtimes to be able to work with.