### PR TITLE
Make only draft releases from automation [skip ci].

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,15 +28,6 @@ jobs:
       - name: Prepare archive
         run: |
           ./scripts/make-tarball.sh
-      # For now we let Github automatically create releases from tags.
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ github.ref }}
       - name: Fetch platform packages
         shell: bash
         run: |
@@ -52,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          draft: true
           files: |
             spicy*.tar.gz
             binary_artifacts/spicy*.tar.gz


### PR DESCRIPTION
While this still requires us to create public tags, marking the releases
initially as drafts removes confusion for users who might end up using a
release we ultimately might not intend to publish.