### PR TITLE
Adjust processes used to build Docker image.

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -35,6 +35,7 @@ jobs:
         context: .
         file: ci/Dockerfile.dockerhub
         push: true
+        build_args: "SPICY_ZKG_PROCESSES=1"
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/spicy-dev:latest
           ${{ secrets.DOCKER_USERNAME }}/spicy-dev:${{ steps.version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -36,6 +36,7 @@ jobs:
         context: .
         file: ci/Dockerfile.dockerhub
         push: true
+        build_args: "SPICY_ZKG_PROCESSES=1"
         # TODO(bbannier): Automatically detect whether this is the latest
         # release and in that case also push this to `spicy:latest`.
         tags: |

--- a/ci/Dockerfile.dockerhub
+++ b/ci/Dockerfile.dockerhub
@@ -8,10 +8,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG ZEEK_LTS=1
 ARG ZEEK_VERSION=4.0.0-0
+ARG SPICY_ZKG_PROCESSES=
 
 CMD ["sh"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/spicy/bin:/opt/zeek/bin:${PATH}"
+ENV SPICY_ZKG_PROCESSES=${SPICY_ZKG_PROCESSES}
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \


### PR DESCRIPTION
Github action runners only have limited resources (currently for Linux:
2 CPUs, 7GB RAM). In the build of the spicy-plugin and spicy-analyzers
Zeek packages we previously hardcoded a certain level of parallelism,
which caused us to run into especially RAM limits when building
spicy-analyzers. With recent versions of these packages we can now
optionally externally parameterize the level of parallelism to use.

This patch adjust the Github action setup so we build these packages
with a number of processes compatible with the runners we will be faced
with.