### PR TITLE
Avoid name collision when codegen'ing struct element initializers.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -473,7 +473,7 @@ std::string cxx::type::Struct::inlineCode() const {
         auto ctor_args = util::join(util::transform(locals_user,
                                                     [&](const auto& x) {
                                                         auto& l = std::get<declaration::Local>(x);
-                                                        return fmt("std::optional<%s> %s_", l.type, l.id);
+                                                        return fmt("std::optional<%s> %s", l.type, l.id);
                                                     }),
                                     ", ");
 
@@ -481,7 +481,7 @@ std::string cxx::type::Struct::inlineCode() const {
             util::join(util::transform(locals_user,
                                        [&](const auto& x) {
                                            auto& l = std::get<declaration::Local>(x);
-                                           return fmt("    if ( %s_ ) %s = std::move(*%s_);\n", l.id, l.id, l.id);
+                                           return fmt("    if ( %s ) this->%s = std::move(*%s);\n", l.id, l.id, l.id);
                                        }),
                        "");
 

--- a/tests/hilti/codegen/element_init.hlt
+++ b/tests/hilti/codegen/element_init.hlt
@@ -1,0 +1,12 @@
+# @TEST-EXEC: hiltic -j %INPUT
+#
+# @TEST-DOC: Tests for name collisions in codegen of struct element initializers, regression test for #942.
+
+module foo {
+
+public type X = struct {
+    bytes x;
+    uint<8> x_;
+};
+
+}


### PR DESCRIPTION
When codegen'ing a struct constructor which can initialize all fields
from passed in values we previously distinguished names of our arguments
from the user-specified fields by appending a `_` to our arguments. This
could have lead to name collisions if user code contain field names
differing only in whether they contained a final `_`.

With this patch we take a different approach in that we now explicitly
qualify access of fields with `this->`.