### PR TITLE
Add Debian Bullseye to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -581,6 +581,46 @@ docker_debian10_task:
     path: ./spicy*.{deb,rpm}
     type: application/gzip
 
+docker_debian11_task:
+  skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''
+
+  container:
+    dockerfile: docker/Dockerfile.debian-11
+    cpu: 4
+    memory: 12G
+
+  timeout_in: 120m
+
+  always:
+    ccache_cache:
+      folder: /tmp/ccache
+      fingerprint_script: echo $CIRRUS_TASK_NAME-$CIRRUS_OS
+
+  env:
+    CCACHE_DIR: /tmp/ccache
+    CCACHE_COMPRESS: 1
+
+  # Pull tags as well since by default Cirrus CI does not fetch them, but they
+  # are needed for `git describe` used in `scripts/autogen-version`. We also
+  # pull submodules here.
+  update_git_script:
+    - git fetch --tags
+    - git submodule update --recursive --init
+
+  configure_script:
+    - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --enable-werror
+  build_script:
+    - ninja -j4 -C build check all package
+    - cp build/spicy*.deb .
+    - dpkg --install ./spicy*.deb
+    - rm -rf build
+  test_install_script:
+    - SPICY_INSTALLATION_DIRECTORY=/opt/spicy make -C tests test-install
+
+  packages_artifacts:
+    path: ./spicy*.{deb,rpm}
+    type: application/gzip
+
 docker_ubuntu16_task:
   skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''
 

--- a/docker/Dockerfile.debian-11
+++ b/docker/Dockerfile.debian-11
@@ -14,6 +14,8 @@ RUN apt-get -q update && \
       cmake \
       file \
       flex \
+      gcc \
+      g++ \
       git \
       google-perftools \
       jq \

--- a/docker/Dockerfile.debian-11
+++ b/docker/Dockerfile.debian-11
@@ -1,0 +1,36 @@
+FROM debian:bullseye-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV CCACHE_DIR "/var/spool/ccache"
+ENV CCACHE_COMPRESS 1
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt -q update && \
+    apt install -y --no-install-recommends \
+      binutils \
+      bison \
+      ccache \
+      cmake \
+      file \
+      flex \
+      git \
+      google-perftools \
+      jq \
+      libfl-dev \
+      libgoogle-perftools-dev \
+      libkrb5-dev \
+      libmaxminddb-dev \
+      libpcap0.8-dev \
+      libssl-dev \
+      locales-all \
+      make \
+      ninja-build \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-setuptools \
+      python3-wheel \
+      swig \
+      zlib1g-dev && \
+    pip3 install --no-cache-dir "btest>=0.66" pre-commit

--- a/docker/Dockerfile.debian-11
+++ b/docker/Dockerfile.debian-11
@@ -6,8 +6,8 @@ ENV CCACHE_COMPRESS 1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt -q update && \
-    apt install -y --no-install-recommends \
+RUN apt-get -q update && \
+    apt-get install -y --no-install-recommends \
       binutils \
       bison \
       ccache \


### PR DESCRIPTION
This PR adds support for Debian Bullseye to CI.

Since Bullseye comes with GCC 10, we do not need to install the LLVM toolchain manually.

According to the [install docs](https://docs.zeek.org/projects/spicy/en/latest/installation.html), we need at least CMake 3.15. Bullseye ships with 3.18, so we can use `apt` to install all dependencies.
