### PR TITLE
Emit linker glue type definitions for vector fields.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -7,6 +7,7 @@
 #include <hilti/ast/id.h>
 #include <hilti/ast/module.h>
 #include <hilti/ast/scope-lookup.h>
+#include <hilti/ast/type.h>
 #include <hilti/ast/types/struct.h>
 #include <hilti/base/logger.h>
 #include <hilti/base/util.h>
@@ -288,6 +289,9 @@ struct Visitor : hilti::visitor::PreOrder<void, Visitor> {
 
             for ( const auto& p : ft.parameters() ) {
                 auto type = p.type();
+
+                if ( type::isIterable(type) )
+                    type = type.elementType();
 
                 while ( type::isReferenceType(type) )
                     type = type.dereferencedType();

--- a/tests/spicy/types/unit/vector-field-link-glue.spicy
+++ b/tests/spicy/types/unit/vector-field-link-glue.spicy
@@ -1,0 +1,14 @@
+# @TEST-EXEC: spicyc -l %INPUT -o foo.cc
+# @TEST-EXEC: $(spicy-config --cxx --cxxflags --debug) -c foo.cc
+#
+# @TEST-DOC: Checks that we emit type defs in the linker glue for vector fields.
+
+# This is a regression test for #966.
+
+module foo;
+
+public type A = unit {
+    bs: B[1] {}
+};
+
+type B = unit {};


### PR DESCRIPTION
Closes #966.