### PR TITLE
Swallow Git error messages during CMake if run from tarball.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -324,7 +324,7 @@ validate_release_tarball_task:
     - ninja -j3 -C build
   test_build_script:
     - cd /tmp/spicy-tarball/spicy-*
-    - make -C tests test-build
+    - make -C tests
 
 homebrew_catalina_task:
   skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -316,12 +316,14 @@ validate_release_tarball_task:
   unpack_script:
     - mkdir /tmp/spicy-tarball
     - tar xf spicy*.tar.gz -C /tmp/spicy-tarball
-    - cd /tmp/spicy-tarball/spicy-*
   configure_script:
+    - cd /tmp/spicy-tarball/spicy-*
     - ./configure --generator=Ninja --enable-ccache --prefix=/opt/spicy --enable-werror
   build_script:
+    - cd /tmp/spicy-tarball/spicy-*
     - ninja -j3 -C build
   test_build_script:
+    - cd /tmp/spicy-tarball/spicy-*
     - make -C tests test-build
 
 homebrew_catalina_task:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ add_custom_target(tests DEPENDS hilti-tests spicy-tests)
 # Check tags the HEAD commit corresponds to. If we cannot get the current
 # commit (e.g., no .git directory present for release tarballs), this will
 # leave SPICY_TAGS unset which is fine for users working from tarballs.
-execute_process(COMMAND git tag --points-at
+execute_process(COMMAND git tag --points-at HEAD v*
     OUTPUT_VARIABLE SPICY_TAGS
     ERROR_VARIABLE ignored)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,11 +200,14 @@ add_custom_target(check COMMAND ctest --output-on-failure -C $<CONFIG> DEPENDS t
 add_custom_target(tests DEPENDS hilti-tests spicy-tests)
 
 # Packaging.
-# Check tags the HEAD commit corresponds to.
+# Check tags the HEAD commit corresponds to. If we cannot get the current
+# commit (e.g., no .git directory present for release tarballs), this will
+# leave SPICY_TAGS unset which is fine for users working from tarballs.
 execute_process(COMMAND git tag --points-at
-    OUTPUT_VARIABLE GIT_TAGS)
+    OUTPUT_VARIABLE SPICY_TAGS
+    ERROR_VARIABLE ignored)
 
-if ( "${GIT_TAGS}" STREQUAL "" )
+if ( "${SPICY_TAGS}" STREQUAL "" )
     # If the HEAD commit does not correspond to a tag it is not a release. Hide
     # the version number in packaging artifacts so we can e.g., provide stable
     # links to the latest version.

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -387,7 +387,7 @@ TEST_CASE("memory_statistics") {
 
     const auto ru0 = resource_usage();
     REQUIRE_GE(ru0.system_time, 0);
-    REQUIRE_GT(ru0.user_time, 0);
+    REQUIRE_GE(ru0.user_time, 0);
     REQUIRE_GT(ru0.memory_heap, 0u);
     REQUIRE_EQ(ru0.num_fibers, 0u);
     REQUIRE_EQ(ru0.max_fibers, 0u);


### PR DESCRIPTION
Closes #960.