### PR TITLE
Hardcode DockerHub org we publish images for in GH workflow.

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -37,5 +37,5 @@ jobs:
         push: true
         build-args: "SPICY_ZKG_PROCESSES=1"
         tags: |
-          ${{ secrets.DOCKER_USERNAME }}/spicy-dev:latest
-          ${{ secrets.DOCKER_USERNAME }}/spicy-dev:${{ steps.version.outputs.RELEASE_VERSION }}
+          zeekurity/spicy-dev:latest
+          zeekurity/spicy-dev:${{ steps.version.outputs.RELEASE_VERSION }}

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -40,4 +40,4 @@ jobs:
         # TODO(bbannier): Automatically detect whether this is the latest
         # release and in that case also push this to `spicy:latest`.
         tags: |
-          ${{ secrets.DOCKER_USERNAME }}/spicy:${{ steps.version.outputs.RELEASE_VERSION }}
+          zeekurity/spicy:${{ steps.version.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
The DockerHub org we publish to previously matched the user we used to
log in to DockerHub, so we could avoid hardcoding the full org name.
Since we now use a bot account to publish to DockerHub this is not
true anymore and we need to specify the org explicitly.

This patch hardcodes the org name as `zeekurity` into Github workflows
publishing images to DockerHub.