### PR TITLE
Use safe integer for runtime container sizes.

### DIFF
--- a/hilti/runtime/include/types/map.h
+++ b/hilti/runtime/include/types/map.h
@@ -22,6 +22,7 @@
 
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/iterator.h>
+#include <hilti/rt/safe-int.h>
 #include <hilti/rt/util.h>
 
 namespace hilti::rt {
@@ -176,7 +177,7 @@ public:
 
     using key_type = typename M::key_type;
     using value_type = typename M::value_type;
-    using size_type = uint64_t;
+    using size_type = integer::safe<uint64_t>;
 
     using iterator = typename map::Iterator<K, V>;
     using const_iterator = typename map::ConstIterator<K, V>;

--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -20,6 +20,7 @@
 
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/iterator.h>
+#include <hilti/rt/safe-int.h>
 #include <hilti/rt/types/set_fwd.h>
 #include <hilti/rt/types/vector_fwd.h>
 #include <hilti/rt/util.h>
@@ -120,7 +121,7 @@ public:
     using key_type = T;
     using value_type = T;
 
-    using size_type = uint64_t;
+    using size_type = integer::safe<uint64_t>;
 
     Set() = default;
     Set(const Set&) = default;

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -31,6 +31,7 @@
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/fmt.h>
 #include <hilti/rt/iterator.h>
+#include <hilti/rt/safe-int.h>
 #include <hilti/rt/types/vector_fwd.h>
 #include <hilti/rt/util.h>
 
@@ -253,7 +254,7 @@ public:
 
     using V = std::vector<T, Allocator>;
 
-    using size_type = uint64_t;
+    using size_type = integer::safe<uint64_t>;
     using reference = T&;
     using const_reference = const T&;
     using iterator = vector::Iterator<T, Allocator>;
@@ -465,7 +466,7 @@ public:
     auto cbegin() const { return const_iterator(0u, _control); }
     auto cend() const { return const_iterator(size(), _control); }
 
-    size_t size() const { return V::size(); }
+    size_type size() const { return V::size(); }
 
     // Methods of `std::vector`.
     using typename V::value_type;

--- a/hilti/runtime/src/tests/map.cc
+++ b/hilti/runtime/src/tests/map.cc
@@ -41,7 +41,7 @@ TEST_CASE("subscript") {
         CHECK_THROWS_WITH_AS(m[99], "key is unset", const IndexError&);
         // Proxy objects only invalidate iterators if an element was actually inserted.
         m = Map<int, int>{{1, 11}};
-        REQUIRE(m.size());
+        REQUIRE_EQ(m.size(), 1u);
         auto begin = m.begin();
         REQUIRE_EQ(begin->first, 1);
         REQUIRE_EQ(begin->second, 11);
@@ -148,7 +148,7 @@ TEST_CASE("Iterator") {
 TEST_CASE("index_assign") {
     // Modifying an existing element does not invalidate iterators.
     auto m = Map<int, int>{{1, 11}};
-    REQUIRE(m.size());
+    REQUIRE_EQ(m.size(), 1u);
     auto begin = m.begin();
     REQUIRE_EQ(begin->first, 1);
     REQUIRE_EQ(begin->second, 11);

--- a/hilti/runtime/src/tests/set.cc
+++ b/hilti/runtime/src/tests/set.cc
@@ -62,7 +62,7 @@ TEST_CASE("erase") {
     REQUIRE_EQ(*it1, 1);
     REQUIRE_EQ(*it2, 2);
 
-    REQUIRE(s.erase(1));
+    REQUIRE_EQ(s.erase(1), 1u);
 
     // In contrast to a `std::set`, removing elements from a `Set` invalidates
     // _all iterators_, not just iterators to the removed element.


### PR DESCRIPTION
When generating code we directly expose the size function of runtime
containers in generated code. We previously would use naked `uint64_t`
or `size_t` which aren't really types e.g., generated code handles well;
instead it in general expects integer types to be some `integer::safe`.

This patch changes the runtime container size functions to return safe
integer values.

Closes #988.