### PR TITLE
Precompile `libspicy.h`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,41 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
 string(STRIP "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BuildType}}" cflags)
 string(STRIP "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}" cxxflags)
 
+# Precompiled headers.
+
+option("HILTI_DEV_PRECOMPILE_HEADERS" "Precompile headers for developer tests" ON)
+
+if (${HILTI_DEV_PRECOMPILE_HEADERS} AND TARGET hilti-config AND TARGET spicy-config)
+    # Precompile libhilti for use in JIT during development.
+    #
+    # We only use precompiled headers during JIT, but e.g., not to during
+    # compilation of Spicy itself. This gives us the benefits of JIT without
+    # e.g., making it harder for ccache to work during development. It also
+    # allows us to punt on some trickier cleanups of header files.
+    add_custom_command(
+        COMMENT "Generating precompiled headers"
+        OUTPUT ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h
+        OUTPUT ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti_debug.h
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti_debug.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy.h
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy_debug.h
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy_debug.h.pch
+        COMMAND
+            ${CMAKE_COMMAND} -E env SPICY_CACHE=${PROJECT_BINARY_DIR}/cache/spicy
+            ${PROJECT_SOURCE_DIR}/scripts/precompile-headers.sh --bindir ${CMAKE_BINARY_DIR}/bin
+        DEPENDS
+            ${PROJECT_SOURCE_DIR}/scripts/precompile-headers.sh
+            ${CMAKE_CURRENT_SOURCE_DIR}/hilti/runtime/include/libhilti.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/spicy/runtime/include/libspicy.h
+            hilti-config
+            spicy-config)
+    add_custom_target(precompiled-headers
+        ALL
+        DEPENDS ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h)
+endif ()
+
 # Global test target
 add_custom_target(check COMMAND ctest --output-on-failure -C $<CONFIG> DEPENDS tests)
 add_custom_target(tests DEPENDS hilti-tests spicy-tests)

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -9,26 +9,3 @@ if ( HAVE_TOOLCHAIN )
 else ()
     add_custom_target(hilti-tests DEPENDS hilti-rt-tests hilti-rt-configuration-tests)
 endif ()
-
-option("HILTI_DEV_PRECOMPILE_HEADERS" "Precompile headers for developer tests" ON)
-
-if (${HILTI_DEV_PRECOMPILE_HEADERS} AND TARGET hilti-config)
-    # Precompile libhilti for use in JIT during development.
-    #
-    # We only use precompiled headers during JIT, but e.g., not to during
-    # compilation of Spicy itself. This gives us the benefits of JIT without
-    # e.g., making it harder for ccache to work during development. It also
-    # allows us to punt on some trickier cleanups of header files.
-    add_custom_command(
-        OUTPUT ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h
-        COMMAND
-            ${CMAKE_COMMAND} -E env SPICY_CACHE=${PROJECT_BINARY_DIR}/cache/spicy
-                ${PROJECT_SOURCE_DIR}/scripts/precompile-headers.sh --hilti-config $<TARGET_FILE:hilti-config>
-        DEPENDS
-            ${PROJECT_SOURCE_DIR}/scripts/precompile-headers.sh
-            ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include/libhilti.h
-            hilti-config)
-    add_custom_target(precompiled-headers
-        ALL
-        DEPENDS ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h)
-endif ()

--- a/scripts/precompile-headers.sh
+++ b/scripts/precompile-headers.sh
@@ -3,37 +3,50 @@
 set -o errexit
 set -o nounset
 
+BINDIR=$(dirname "$0")
 while [ $# -ne 0 ]; do
     case "$1" in
-        --hilti-config) HILTI_CONFIG=$2; shift 2;;
+        --bindir) BINDIR=$2; shift 2;;
     esac
 done
 
-if [ -z "${HILTI_CONFIG+x}" ]; then
-    BIN=$(dirname "$0")/
-    HILTI_CONFIG=${BIN}/hilti-config
-fi
+HILTI_CONFIG=${BINDIR}/hilti-config
+SPICY_CONFIG=${BINDIR}/spicy-config
 
-if [ ! -x "${HILTI_CONFIG}" ]; then
-    echo "cannot determine path 'hilti-config'"
-    exit 1
-fi
-
-for flag in $(${HILTI_CONFIG} --cxxflags); do
-    if ! echo "${flag}" | grep -q '^-I'; then
-        continue
-    fi
-    dir=${flag#??}
-    if [ -e "${dir}"/hilti/rt/libhilti.h ]; then
-        LIBHILTI=${dir}/hilti/rt/libhilti.h
+for config in "${HILTI_CONFIG}" "${SPICY_CONFIG}"; do
+    if [ ! -x "${config}" ]; then
+        echo "${config} is not an executable file"
+        exit 1
     fi
 done
 
-if [ -z "${LIBHILTI+x}" ]; then
-    echo "Error: could not determine location of libhilti.h"
-    exit 1
-fi
+# Helper function to from a given Spicy `*-config` executable determine the location of a header.
+search_header() {
+    config=$1
+    header=$2;
 
+    for flag in $(${config} --cxxflags); do
+        if ! echo "${flag}" | grep -q '^-I'; then
+            continue
+        fi
+        dir=${flag#??}
+        if [ -e "${dir}/${header}" ]; then
+            location=${dir}/${header}
+        fi
+    done
+
+    if [ -z "${location+x}" ]; then
+        echo "Error: could not determine location of ${header}"
+        exit 1
+    fi
+
+    echo "${location}"
+}
+
+LIBHILTI=$(search_header "${HILTI_CONFIG}" hilti/rt/libhilti.h)
+LIBSPICY=$(search_header "${SPICY_CONFIG}" spicy/rt/libspicy.h)
+
+# Extract version from `hilti-config`. It should be identical to the one from `spicy-config`.
 VERSION=$(${HILTI_CONFIG} --version | cut -d ' ' -f1)
 
 # The cache is read from the environment variable `SPICY_CACHE`
@@ -43,10 +56,16 @@ CACHE=${SPICY_CACHE:-$HOME/.cache/spicy/${VERSION}}
 rm -rf "${CACHE}"
 mkdir -p "${CACHE}"
 
-# NOTE: The compiler invocation here should be kept in sync
-# with what we do in `hilti/runtime/CMakeLists.txt`.
+# NOTE: The compiler invocations here should be kept in sync
+# with what we do in `CMakeLists.txt`.
 cp "${LIBHILTI}" "${CACHE}/precompiled_libhilti_debug.h"
 $("${HILTI_CONFIG}" --cxx --cxxflags --debug) -x c++-header "${LIBHILTI}" -o "${CACHE}/precompiled_libhilti_debug.h.pch"
 
 cp "${LIBHILTI}" "${CACHE}/precompiled_libhilti.h"
 $("${HILTI_CONFIG}" --cxx --cxxflags) -x c++-header "${LIBHILTI}" -o "${CACHE}/precompiled_libhilti.h.pch"
+
+cp "${LIBSPICY}" "${CACHE}/precompiled_libspicy_debug.h"
+$("${SPICY_CONFIG}" --cxx --cxxflags --debug) -x c++-header "${LIBSPICY}" -o "${CACHE}/precompiled_libspicy_debug.h.pch"
+
+cp "${LIBSPICY}" "${CACHE}/precompiled_libspicy.h"
+$("${SPICY_CONFIG}" --cxx --cxxflags) -x c++-header "${LIBSPICY}" -o "${CACHE}/precompiled_libspicy.h.pch"

--- a/spicy/runtime/include/libspicy.h
+++ b/spicy/runtime/include/libspicy.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <hilti/rt/libhilti.h>
+
 #include <spicy/rt/autogen/config.h>
 #include <spicy/rt/base64.h>
 #include <spicy/rt/debug.h>

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -12,6 +12,40 @@ using namespace spicy;
 const auto flatten = hilti::util::flattenParts;
 const auto prefix = hilti::util::prefixParts;
 
+namespace {
+std::optional<hilti::rt::filesystem::path> precompiled_libspicy(const hilti::Configuration& config, bool debug) {
+    // We disable use of precompiled headers for sanitizers builds since the
+    // sanitizer flags are not exposed on the config level.
+    //
+    // TODO(bbannier): Allow using of precompiled headers for sanitizer builds.
+#ifdef HILTI_HAVE_SANITIZER
+    return {};
+#endif
+
+    if ( const auto& cache = hilti::util::cacheDirectory(config) ) {
+        const hilti::rt::filesystem::path file_name =
+            hilti::rt::fmt("precompiled_libspicy%s.h.gch", (debug ? "_debug" : ""));
+
+        if ( auto pch = (*cache) / file_name; hilti::rt::filesystem::exists(pch) )
+            return pch.replace_extension();
+    }
+
+    return {};
+}
+
+// Helper function to ensure exactly one precompile header is used.
+void set_precompiled_header(const hilti::Configuration& config, bool debug, std::vector<std::string>& cxxflags) {
+    auto header = precompiled_libspicy(config, debug);
+    if ( ! header )
+        return;
+
+    for ( auto& flag : cxxflags )
+        if ( flag.find("precompiled_libhilti") != std::string::npos )
+            flag = hilti::rt::fmt("-include%s", header->c_str());
+}
+
+} // namespace
+
 template<class T>
 inline auto join(const std::vector<T>& v1, const std::vector<T>& v2) {
     std::vector<T> n;
@@ -33,8 +67,12 @@ void Configuration::extendHiltiConfiguration() {
     spcy.init(hlt.uses_build_directory);
 
     hlt.hilti_library_paths = join(spcy.spicy_library_paths, hlt.hilti_library_paths);
+
     hlt.runtime_cxx_flags_debug = join(spcy.runtime_cxx_flags_debug, hlt.runtime_cxx_flags_debug);
     hlt.runtime_cxx_flags_release = join(spcy.runtime_cxx_flags_release, hlt.runtime_cxx_flags_release);
+    set_precompiled_header(hlt, true, hlt.runtime_cxx_flags_debug);
+    set_precompiled_header(hlt, false, hlt.runtime_cxx_flags_release);
+
     hlt.runtime_cxx_include_paths = join(spcy.runtime_cxx_include_paths, hlt.runtime_cxx_include_paths);
     hlt.runtime_cxx_library_paths = join(spcy.runtime_cxx_library_paths, hlt.runtime_cxx_library_paths);
     hlt.runtime_ld_flags_debug = join(spcy.runtime_ld_flags_debug, hlt.runtime_ld_flags_debug);
@@ -67,20 +105,24 @@ void Configuration::init(bool use_build_directory) {
     spicy_library_paths = hilti::util::transform(library_paths, [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_include_paths =
-        hilti::util::transform(hilti::util::split(prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)),
-                        [](auto s) { return hilti::rt::filesystem::path(s); });
+        hilti::util::transform(hilti::util::split(
+                                   prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                               [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_library_paths =
-        hilti::util::transform(hilti::util::split(prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)),
-                        [](auto s) { return hilti::rt::filesystem::path(s); });
+        hilti::util::transform(hilti::util::split(
+                                   prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                               [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_include_paths =
-        hilti::util::transform(hilti::util::split(prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
-                        [](auto s) { return hilti::rt::filesystem::path(s); });
+        hilti::util::transform(hilti::util::split(
+                                   prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                               [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_library_paths =
-        hilti::util::transform(hilti::util::split(prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
-                        [](auto s) { return hilti::rt::filesystem::path(s); });
+        hilti::util::transform(hilti::util::split(
+                                   prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                               [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_flags_debug = flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
                                        prefix("${SPICY_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});


### PR DESCRIPTION
Since only a single precompiled header can be explicitly added we need
to add this header to Spicy's `CXXFLAGS` differently in that it replaces
any precompiled header for `libhilti.h` we inherited from the HILTI
config.

We also include `libhilti.h` in `libspicy.h` now so we still get the
precompilation benefits for that part as well.