### PR TITLE
Fix parsers for bison-3.8.1.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/parser/driver.h
+++ b/hilti/toolchain/include/compiler/detail/parser/driver.h
@@ -25,8 +25,6 @@
                                         hilti::detail::parser::location* yylloc,                                       \
                                         hilti::detail::parser::Driver* driver)
 
-#define YYSTYPE yystype_hilti
-
 #ifndef __FLEX_LEXER_H
 #define yyFlexLexer HiltiFlexLexer
 #include <FlexLexer.h>

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -27,6 +27,7 @@ namespace hilti { namespace detail { class Parser; } }
 %define api.namespace {hilti::detail::parser}
 %define api.parser.class {Parser}
 %define parse.error verbose
+%define api.value.type {yystype_hilti}
 
 %debug
 %verbose
@@ -35,7 +36,6 @@ namespace hilti { namespace detail { class Parser; } }
 %expect 120
 %expect-rr 185
 
-%union {}
 %{
 
 #include <hilti/compiler/detail/parser/scanner.h>

--- a/spicy/toolchain/include/compiler/detail/parser/driver.h
+++ b/spicy/toolchain/include/compiler/detail/parser/driver.h
@@ -28,8 +28,6 @@
                                         spicy::detail::parser::location* yylloc,                                       \
                                         spicy::detail::parser::Driver* driver)
 
-#define YYSTYPE yystype_spicy
-
 #ifndef __FLEX_LEXER_H
 #define yyFlexLexer SpicyFlexLexer
 #include <FlexLexer.h>

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -28,6 +28,7 @@ namespace spicy { namespace detail { class Parser; } }
 %define api.namespace {spicy::detail::parser}
 %define api.parser.class {Parser}
 %define parse.error verbose
+%define api.value.type {yystype_spicy}
 
 %debug
 %verbose
@@ -36,7 +37,6 @@ namespace spicy { namespace detail { class Parser; } }
 %expect 131
 %expect-rr 157
 
-%union {}
 %{
 
 #include <spicy/compiler/detail/parser/scanner.h>


### PR DESCRIPTION
With bison-3.8.1 redefining `YYSTYPE` instead of `%define
api.value.type` has been deprecated and now triggers a warning.