### PR TITLE
More fixes for building on ARM64.

### DIFF
--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -249,7 +249,7 @@ std::pair<char*, char*> detail::StackBuffer::activeRegion() const {
     // The direction in which the stack grows is platform-specific. It's
     // probably gong to be growing downwards pretty much everywhere, but to be
     // safe we whitelist platforms that we have confirmed to do so.
-#if __x86_64__ || __arm64__
+#if __x86_64__ || __arm64__ || __aarch64__
     auto lower = reinterpret_cast<char*>(_fiber->regs.sp);
     auto upper = reinterpret_cast<char*>(_fiber->regs.sp) + fiber_stack_used_size(_fiber);
 #else
@@ -268,7 +268,7 @@ size_t detail::StackBuffer::liveRemainingSize() const {
     assert(::fiber_is_executing(_fiber)); // must be live
 
     // Whitelist architectures where we know how to do this.
-#if __x86_64__ || (__APPLE__ && __arm64__)
+#if __x86_64__ || __arm64__ || __aarch64__
     // See
     // https://stackoverflow.com/questions/20059673/print-out-value-of-stack-pointer
     // for discussion of how to get stack pointer.


### PR DESCRIPTION
In 89d3295f1363d8d07eda5c711740b18f31483d88 we adjusted some
preprocessor code to enable building on arm64. That patch missed an
update of another instance to the same conditional which we fix with
this patch.

Some ARM64 platforms do not seem to reliably set the `__arm64__` define,
but instead `__aarch64__`. We now allow that as an alternative.