### PR TITLE
Use safe integers for runtime size functions.

### DIFF
--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -11,6 +11,7 @@
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/iterator.h>
 #include <hilti/rt/result.h>
+#include <hilti/rt/types/integer.h>
 #include <hilti/rt/types/string.h>
 #include <hilti/rt/types/time.h>
 #include <hilti/rt/types/vector.h>
@@ -42,7 +43,7 @@ class Iterator {
     using difference_type = B::const_iterator::difference_type;
 
     std::weak_ptr<B*> _control;
-    typename B::size_type _index = 0;
+    typename integer::safe<std::uint64_t> _index = 0;
 
 public:
     Iterator() = default;
@@ -157,6 +158,7 @@ public:
     using Base::const_reference;
     using Base::reference;
     using Offset = uint64_t;
+    using size_type = integer::safe<uint64_t>;
 
     using Base::Base;
     using Base::data;
@@ -226,7 +228,7 @@ public:
     bool isEmpty() const { return empty(); }
 
     /** Returns the size of instance in bytes. */
-    int64_t size() const { return static_cast<int64_t>(std::string::size()); }
+    size_type size() const { return static_cast<int64_t>(std::string::size()); }
 
     /**
      * Returns the position of the first occurence of a byte.

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -506,7 +506,7 @@ struct Empty {
     auto begin() const& { return this; }
     auto end() const& { return this; }
     auto empty() const { return true; }
-    auto size() const { return 0u; }
+    auto size() const { return integer::safe<uint64_t>(0); }
 };
 
 template<typename T, typename Allocator>

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -493,7 +493,7 @@ TEST_CASE("Iterator") {
 
     SUBCASE("distance") {
         CHECK_EQ(b.end() - b.begin(), b.size());
-        CHECK_EQ(b.begin() - b.end(), -b.size());
+        CHECK_THROWS_WITH_AS(b.begin() - b.end(), "integer overflow", const RuntimeError&);
         CHECK_EQ(b.end() - b.end(), 0);
         CHECK_EQ(b.begin() - b.begin(), 0);
 

--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -73,6 +73,10 @@ TEST_CASE("match") {
 }
 
 TEST_CASE("find") {
+    SUBCASE("empty needle") {
+        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find(""_b), std::make_tuple(-1, ""_b));
+    }
+
     SUBCASE("min-matcher") {
         CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
         CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find(" abc"_b), std::make_tuple(1, "abc"_b));

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -315,7 +315,7 @@ std::tuple<int32_t, Bytes> RegExp::find(const Bytes& data) const {
     assert(_jrx() && "regexp not compiled");
 
     const auto startp = data.data();
-    const auto endp = startp + data.size();
+    const auto endp = startp + data.size().Ref();
 
     int cur_rc = 0;
     jrx_offset cur_so = -1;

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -272,7 +272,7 @@ std::tuple<bool, UnsafeConstIterator> View::_findBackward(const Bytes& needle, U
     if ( needle.size() > (i.offset() - offset()) )
         return std::make_tuple(false, UnsafeConstIterator());
 
-    i -= (needle.size() - 1); // this is safe now, get us 1st position where initial character may match
+    i -= (needle.size() - 1).Ref(); // this is safe now, get us 1st position where initial character may match
 
     auto first = *needle.begin();
 

--- a/spicy/runtime/include/sink.h
+++ b/spicy/runtime/include/sink.h
@@ -11,6 +11,7 @@
 #include <hilti/rt/exception.h>
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/types/bytes.h>
+#include <hilti/rt/types/integer.h>
 #include <hilti/rt/types/reference.h>
 #include <hilti/rt/types/stream.h>
 
@@ -226,7 +227,7 @@ public:
     /**
      * Returns the number of bytes written into the sink so far.
      */
-    uint64_t size() const { return _size; }
+    hilti::rt::integer::safe<uint64_t> size() const { return _size; }
 
     /**
      * Skips ahead in the input stream.


### PR DESCRIPTION
In fd5c53cb8ffd1a18aadb7d21b927bda801e264c8 we changed the size
functions of runtime containers to use safe integers. This patch adjusts
the remaining size functions to use safe integers as well.

We also add a test for `RegExp::find` with empty needle. While the
behavior of that function should not have changed with this patch, we
still had to adjust its implementation.