### PR TITLE
Fix overly generous generation of type information.

### DIFF
--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -205,6 +205,12 @@ public:
     bool requiresCompilation();
 
     /**
+     * Explicily marks the unit as requiring compilation down to C++, overiding
+     * any automatic determination.
+     */
+    void setRequiresCompilation() { _requires_compilation = true; }
+
+    /**
      * Returns true if the unit has been marked as fully resolved, so that no further AST processing is needed.
      */
     bool isResolved() { return _resolved; }
@@ -382,6 +388,7 @@ private:
     std::weak_ptr<Context> _context;                // global context
     std::optional<detail::cxx::Unit> _cxx_unit;     // compiled C++ code for this unit, once available
     bool _resolved = false;                         // state of resolving the AST
+    bool _requires_compilation = false;             // mark explicitly as requiring compilation to C++
 };
 
 } // namespace hilti

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -149,7 +149,8 @@ struct GlobalsVisitor : hilti::visitor::PreOrder<void, GlobalsVisitor> {
     void operator()(const declaration::Type& n, position_t p) {
         assert(n.typeID());
         cg->compile(n.type(), codegen::TypeUsage::Storage);
-        cg->addTypeInfoDefinition(n.type());
+        if ( include_implementation )
+            cg->addTypeInfoDefinition(n.type());
     }
 };
 

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -344,13 +344,19 @@ struct VisitorDeclaration : hilti::visitor::PreOrder<cxx::declaration::Type, Vis
         }
 
         auto id = cxx::ID(scope, sid);
+
+        // Exception instances all need an implementation of a virtual
+        // destructor to trigger generation of their vtable.
+        auto decl = cxx::declaration::Function{.result = "",
+                                               .id = cxx::ID::fromNormalized(fmt("%s::~%s", id, id.local())),
+                                               .args = {},
+                                               .linkage = "inline"};
+        auto func = cxx::Function{.declaration = std::move(decl), .body = cxx::Block()};
+        cg->unit()->add(std::move(func));
+
         return cxx::declaration::Type{.id = id,
                                       .type = fmt("HILTI_EXCEPTION_NS(%s, %s, %s)", id.local(), base_ns, base_cls),
                                       .no_using = true};
-
-        // Note: Exception instances all need an implementation of a virtual
-        // function. We do that in VisitorTypeInfo so that we ensure it's
-        // geneated only once.
     }
 };
 
@@ -807,34 +813,7 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder<cxx::Expression, Visito
                    util::join(labels, ", "));
     }
 
-    result_t operator()(const type::Exception& n, position_t p) {
-        if ( typeID(p.node) && ! cxxID(p.node) ) {
-            // We use this opportunity to create an empty virtual destructor
-            // that will trigger inclusion of vtable for the exception's
-            // type; see rt/exception.h. We do this only if we have a type ID
-            // as otherwise it could lead to ambiguities with naming and it
-            // can't be referred to for catching anyways then.
-
-            // ID logic follows code in VisitorDeclaration.
-            auto scope = cxx::ID{cg->unit()->cxxNamespace()};
-            auto sid = cxx::ID{*typeID(p.node)};
-
-            if ( sid.namespace_() )
-                scope = scope.namespace_();
-
-            auto id = cxx::ID(scope, sid);
-            auto decl = cxx::declaration::Function{.result = "",
-                                                   .id = cxx::ID::fromNormalized(fmt("%s::~%s", id, id.local())),
-                                                   .args = {},
-                                                   .linkage = "inline"};
-            auto func = cxx::Function{.declaration = std::move(decl), .body = cxx::Block()};
-            cg->unit()->add(std::move(func));
-        }
-
-        // Done with virtual method.
-
-        return "::hilti::rt::type_info::Exception()";
-    }
+    result_t operator()(const type::Exception& n, position_t p) { return "::hilti::rt::type_info::Exception()"; }
 
     result_t operator()(const type::Function& n) { return "::hilti::rt::type_info::Function()"; }
 

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -496,6 +496,7 @@ Result<Nothing> Driver::addInput(const hilti::rt::filesystem::path& path) {
 
         if ( auto unit = Unit::fromCache(_ctx, path) ) {
             HILTI_DEBUG(logging::debug::Driver, fmt("reusing previously cached module %s", (*unit)->id()));
+            (*unit)->setRequiresCompilation();
             _addUnit(std::move(*unit));
         }
         else {
@@ -504,6 +505,7 @@ Result<Nothing> Driver::addInput(const hilti::rt::filesystem::path& path) {
             if ( ! unit )
                 return augmentError(unit.error());
 
+            (*unit)->setRequiresCompilation();
             _addUnit(std::move(*unit));
         }
 
@@ -788,7 +790,8 @@ Result<Nothing> Driver::_resolveUnits() {
         if ( ! unit->isResolved() )
             return result::Error(fmt("module %s was not marked as resolved", unit->id()));
 
-        _hlts.push_back(unit);
+        if ( unit->requiresCompilation() )
+            _hlts.push_back(unit);
     }
 
     _stage = Stage::COMPILED;

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -307,6 +307,9 @@ bool Unit::addDependency(std::shared_ptr<Unit> unit) {
 }
 
 bool Unit::requiresCompilation() {
+    if ( _requires_compilation )
+        return true;
+
     // Visitor that goes over an AST and flags whether any node provides
     // code that needs compilation.
     struct Visitor : hilti::visitor::PreOrder<bool, Visitor> {

--- a/tests/Baseline/hilti.hiltic.print.globals/output
+++ b/tests/Baseline/hilti.hiltic.print.globals/output
@@ -6,20 +6,6 @@
 
 #include <hilti/rt/libhilti.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-} }
-
 namespace __hlt::Foo {
     struct __globals_t : hilti::rt::trait::isStruct, hilti::rt::Controllable<__globals_t> {
         std::string X{};
@@ -32,20 +18,6 @@ namespace __hlt::Foo {
     extern void __init_module();
     extern void __register_module();
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-} }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 

--- a/tests/Baseline/hilti.hiltic.print.hello-world/output
+++ b/tests/Baseline/hilti.hiltic.print.hello-world/output
@@ -6,38 +6,10 @@
 
 #include <hilti/rt/libhilti.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-} }
-
 namespace __hlt::Foo {
     extern void __init_module();
     extern void __register_module();
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-} }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 

--- a/tests/Baseline/hilti.hiltic.print.import/output
+++ b/tests/Baseline/hilti.hiltic.print.import/output
@@ -6,20 +6,6 @@
 
 #include <hilti/rt/libhilti.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-} }
-
 namespace __hlt::Bar {
     struct __globals_t : hilti::rt::trait::isStruct, hilti::rt::Controllable<__globals_t> {
         std::string bar{};
@@ -45,20 +31,6 @@ namespace __hlt::Foo {
     extern void __init_module();
     extern void __register_module();
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-} }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 
@@ -89,20 +61,6 @@ extern void __hlt::Foo::__register_module() { ::hilti::rt::detail::registerModul
 
 #include <hilti/rt/libhilti.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-} }
-
 namespace __hlt::Bar {
     struct __globals_t : hilti::rt::trait::isStruct, hilti::rt::Controllable<__globals_t> {
         std::string bar{};
@@ -128,20 +86,6 @@ namespace __hlt::Foo {
     }
 
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-} }
 
 HILTI_PRE_INIT(__hlt::Bar::__register_module)
 

--- a/tests/Baseline/hilti.hiltic.print.yield/output
+++ b/tests/Baseline/hilti.hiltic.print.yield/output
@@ -6,20 +6,6 @@
 
 #include <hilti/rt/libhilti.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-} }
-
 namespace __hlt::Foo {
     extern void __register_module();
     extern auto test(const std::string& x) -> std::string;
@@ -28,20 +14,6 @@ namespace __hlt::Foo {
 namespace hlt::Foo {
     extern auto test(const std::string& x) -> ::hilti::rt::Resumable;
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-} }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 

--- a/tests/Baseline/spicy.tools.spicyc-hello-world/test.hlt
+++ b/tests/Baseline/spicy.tools.spicyc-hello-world/test.hlt
@@ -7,74 +7,10 @@
 #include <hilti/rt/libhilti.h>
 #include <spicy/rt/libspicy.h>
 
-namespace __hlt::type_info { namespace {
-    extern const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Captures;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Charset;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Exception;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_MatchState;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Protocol;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RealType;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError;
-    extern const ::hilti::rt::TypeInfo __ti_hilti_Side;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Backtrack;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_BitOrder;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Direction;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Filters;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_FindDirection;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Forward;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_HiltiResumable;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_MIMEType;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_ParseError;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_ParsedUnit;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Parser;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_ParserPort;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_Sink;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_SinkState;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_TypeInfo;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_UnitAlreadyConnected;
-    extern const ::hilti::rt::TypeInfo __ti_spicy_rt_UnitContext;
-    extern const ::hilti::rt::TypeInfo __ti_vectorx30spicy_rt_ParserPort;
-} }
-
 namespace __hlt::Foo {
     extern void __init_module();
     extern void __register_module();
 }
-
-namespace __hlt::type_info { namespace {
-    const ::hilti::rt::TypeInfo __ti_hilti_AddressFamily = { "hilti::AddressFamily", "hilti::AddressFamily", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IPv4", 0 }, ::hilti::rt::type_info::enum_::Label{ "IPv6", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_BitOrder = { "hilti::BitOrder", "hilti::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_ByteOrder = { "hilti::ByteOrder", "hilti::ByteOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Little", 0 }, ::hilti::rt::type_info::enum_::Label{ "Big", 1 }, ::hilti::rt::type_info::enum_::Label{ "Network", 2 }, ::hilti::rt::type_info::enum_::Label{ "Host", 3 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Captures = { "hilti::Captures", "hilti::Captures", new ::hilti::rt::type_info::Vector(&::hilti::rt::type_info::bytes, ::hilti::rt::type_info::Vector::accessor<::hilti::rt::Bytes>()) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Charset = { "hilti::Charset", "hilti::Charset", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "ASCII", 0 }, ::hilti::rt::type_info::enum_::Label{ "UTF8", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Exception = { "hilti::Exception", "hilti::Exception", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_MatchState = { "hilti::MatchState", "hilti::MatchState", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_Protocol = { "hilti::Protocol", "hilti::Protocol", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "TCP", 0 }, ::hilti::rt::type_info::enum_::Label{ "UDP", 1 }, ::hilti::rt::type_info::enum_::Label{ "ICMP", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RealType = { "hilti::RealType", "hilti::RealType", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "IEEE754_Single", 0 }, ::hilti::rt::type_info::enum_::Label{ "IEEE754_Double", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_hilti_RuntimeError = { "hilti::RuntimeError", "hilti::RuntimeError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_hilti_Side = { "hilti::Side", "hilti::Side", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Left", 0 }, ::hilti::rt::type_info::enum_::Label{ "Right", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Backtrack = { "spicy_rt::Backtrack", "spicy_rt::Backtrack", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_BitOrder = { "spicy_rt::BitOrder", "spicy_rt::BitOrder", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "LSB0", 0 }, ::hilti::rt::type_info::enum_::Label{ "MSB0", 1 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Direction = { "spicy_rt::Direction", "spicy_rt::Direction", new ::hilti::rt::type_info::Enum(std::vector<::hilti::rt::type_info::enum_::Label>({::hilti::rt::type_info::enum_::Label{ "Originator", 0 }, ::hilti::rt::type_info::enum_::Label{ "Responder", 1 }, ::hilti::rt::type_info::enum_::Label{ "Both", 2 }, ::hilti::rt::type_info::enum_::Label{ "Undef", -1 }})) };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Filters = { "spicy_rt::Filters", "spicy_rt::Filters", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_FindDirection = { "spicy_rt::FindDirection", "spicy_rt::FindDirection", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Forward = { "spicy_rt::Forward", "spicy_rt::Forward", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_HiltiResumable = { "spicy_rt::HiltiResumable", "spicy_rt::HiltiResumable", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_MIMEType = { "spicy_rt::MIMEType", "spicy_rt::MIMEType", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_ParseError = { "spicy_rt::ParseError", "spicy_rt::ParseError", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_ParsedUnit = { "spicy_rt::ParsedUnit", "spicy_rt::ParsedUnit", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Parser = { "spicy_rt::Parser", "spicy_rt::Parser", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({::hilti::rt::type_info::struct_::Field{ "name", &::hilti::rt::type_info::string, offsetof(::spicy::rt::Parser, name), false }, ::hilti::rt::type_info::struct_::Field{ "parse1", &::hilti::rt::type_info::any, offsetof(::spicy::rt::Parser, parse1), false }, ::hilti::rt::type_info::struct_::Field{ "parse2", &::hilti::rt::type_info::any, offsetof(::spicy::rt::Parser, parse2), false }, ::hilti::rt::type_info::struct_::Field{ "parse3", &::hilti::rt::type_info::any, offsetof(::spicy::rt::Parser, parse3), false }, ::hilti::rt::type_info::struct_::Field{ "context_new", &::hilti::rt::type_info::any, offsetof(::spicy::rt::Parser, context_new), false }, ::hilti::rt::type_info::struct_::Field{ "type_info", &type_info::__ti_spicy_rt_TypeInfo, offsetof(::spicy::rt::Parser, type_info), false }, ::hilti::rt::type_info::struct_::Field{ "description", &::hilti::rt::type_info::string, offsetof(::spicy::rt::Parser, description), false }, ::hilti::rt::type_info::struct_::Field{ "mime_types", &::hilti::rt::type_info::any, offsetof(::spicy::rt::Parser, mime_types), false }, ::hilti::rt::type_info::struct_::Field{ "ports", &type_info::__ti_vectorx30spicy_rt_ParserPort, offsetof(::spicy::rt::Parser, ports), false }})) };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_ParserPort = { "spicy_rt::ParserPort", "spicy_rt::ParserPort", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_Sink = { "spicy_rt::Sink", "spicy_rt::Sink", new ::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({})) };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_SinkState = { "spicy_rt::SinkState", "spicy_rt::SinkState", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_TypeInfo = { "spicy_rt::TypeInfo", "spicy_rt::TypeInfo", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_UnitAlreadyConnected = { "spicy_rt::UnitAlreadyConnected", "spicy_rt::UnitAlreadyConnected", new ::hilti::rt::type_info::Exception() };
-    const ::hilti::rt::TypeInfo __ti_spicy_rt_UnitContext = { "spicy_rt::UnitContext", "spicy_rt::UnitContext", new ::hilti::rt::type_info::Library() };
-    const ::hilti::rt::TypeInfo __ti_vectorx30spicy_rt_ParserPort = { {}, "vector<spicy_rt::ParserPort>", new ::hilti::rt::type_info::Vector(&type_info::__ti_spicy_rt_ParserPort, ::hilti::rt::type_info::Vector::accessor<::spicy::rt::ParserPort>()) };
-} }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)
 


### PR DESCRIPTION
We recently started including type information for all types that a
module included. That doesn't harm functionally, but increased code
size and compilation time. This patch reverts that to the old behavior.

Doing so required one additional fix for exceptions, which had
generation of their destructor tied to the generation of type
information; which now doesn't work anymore, but also seems unnecessary
in the first place.

Addresses #1009.