### PR TITLE
Split validation into two passes.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/visitors.h
+++ b/hilti/toolchain/include/compiler/detail/visitors.h
@@ -68,7 +68,9 @@ bool coerce(Node* root, Unit* unit);
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
 bool resolve(const std::shared_ptr<hilti::Context>& ctx, Node* root, Unit* unit);
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-void validate(Node* root);
+void validate_pre(Node* root);
+/** Implements the corresponding functionality for the default HILTI compiler plugin. */
+void validate_post(Node* root);
 } // namespace ast
 } // namespace detail
 } // namespace hilti

--- a/hilti/toolchain/include/compiler/plugin.h
+++ b/hilti/toolchain/include/compiler/plugin.h
@@ -163,6 +163,17 @@ struct Plugin {
     Hook<bool, std::shared_ptr<hilti::Context>, Node*, Unit*> ast_resolve;
 
     /**
+     * Hook called to validate correctness of an AST before resolving starts
+     * (to the degree it can at that time). Any errors must be reported by
+     * setting the nodes' error information.
+     *
+     * @param arg1 compiler context that's in use
+     * @param arg2 root node of AST; the hook may not modify the AST
+     * @param arg3 current unit being compiled
+     */
+    Hook<bool, std::shared_ptr<hilti::Context>, Node*, Unit*> ast_validate_pre;
+
+    /**
      * Hook called to validate correctness of an AST once fully resolved. Any
      * errors must be reported by setting the nodes' error information.
      *
@@ -170,7 +181,7 @@ struct Plugin {
      * @param arg2 root node of AST; the hook may not modify the AST
      * @param arg3 current unit being compiled
      */
-    Hook<bool, std::shared_ptr<hilti::Context>, Node*, Unit*> ast_validate;
+    Hook<bool, std::shared_ptr<hilti::Context>, Node*, Unit*> ast_validate_post;
 
     /**
      * Hook called to print an AST back as source code. The hook gets to choose

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -114,12 +114,20 @@ public:
     Result<ASTState> resolveAST(const Plugin& plugin);
 
     /**
-     * Runs a plugin's validation phase on the unit's AST.
+     * Runs a plugin's validation phase on the unit's AST before resolving.
      *
      * @param plugin plugin to execute
      * @returns true if the AST does not contain any errors
      */
-    bool validateAST(const Plugin& plugin);
+    bool validateASTPre(const Plugin& plugin);
+
+    /**
+     * Runs a plugin's validation phase on the unit's AST after resolving.
+     *
+     * @param plugin plugin to execute
+     * @returns true if the AST does not contain any errors
+     */
+    bool validateASTPost(const Plugin& plugin);
 
     /**
      * Runs a plugin's tranformation phase on the unit's AST.

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -585,6 +585,17 @@ Result<Nothing> Driver::_resolveUnitsWithPlugin(const Plugin& plugin, std::vecto
         _saveIterationAST(u, plugin, "AST before first iteration", 0);
     }
 
+    if ( ! options().skip_validation ) {
+        bool have_errors = false;
+        for ( const auto& u : units ) {
+            if ( ! u->validateASTPre(plugin) )
+                have_errors = true;
+        }
+
+        if ( have_errors || logger().errors() )
+            return result::Error("aborting after errors");
+    }
+
     int extra_rounds = 0; // set to >0 for debugging
 
     while ( true ) {
@@ -650,7 +661,7 @@ Result<Nothing> Driver::_resolveUnitsWithPlugin(const Plugin& plugin, std::vecto
     if ( ! options().skip_validation ) {
         bool have_errors = false;
         for ( const auto& u : units ) {
-            if ( ! u->validateAST(plugin) )
+            if ( ! u->validateASTPost(plugin) )
                 have_errors = true;
         }
 

--- a/hilti/toolchain/src/compiler/plugin.cc
+++ b/hilti/toolchain/src/compiler/plugin.cc
@@ -75,9 +75,15 @@ static Plugin hilti_plugin() {
         .ast_resolve = [](const std::shared_ptr<hilti::Context>& ctx, Node* m,
                           Unit* u) { return ast::resolve(ctx, m, u); },
 
-        .ast_validate =
+        .ast_validate_pre =
             [](const std::shared_ptr<hilti::Context>& ctx, Node* m, Unit* u) {
-                ast::validate(m);
+                ast::validate_pre(m);
+                return false;
+            },
+
+        .ast_validate_post =
+            [](const std::shared_ptr<hilti::Context>& ctx, Node* m, Unit* u) {
+                ast::validate_post(m);
                 return false;
             },
 

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -211,13 +211,24 @@ Result<Unit::ASTState> Unit::resolveAST(const Plugin& plugin) {
     return modified ? Modified : NotModified;
 }
 
-bool Unit::validateAST(const Plugin& plugin) {
+bool Unit::validateASTPre(const Plugin& plugin) {
     if ( ! _module )
         return true;
 
     bool modified = false; // not used
-    runHook(&modified, plugin, &*_module, _extension, &Plugin::ast_validate, fmt("validating module %s", id()),
-            context(), &*_module, this);
+    runHook(&modified, plugin, &*_module, _extension, &Plugin::ast_validate_pre,
+            fmt("validating module %s (pre)", id()), context(), &*_module, this);
+
+    return _collectErrors();
+}
+
+bool Unit::validateASTPost(const Plugin& plugin) {
+    if ( ! _module )
+        return true;
+
+    bool modified = false; // not used
+    runHook(&modified, plugin, &*_module, _extension, &Plugin::ast_validate_post,
+            fmt("validating module %s (post)", id()), context(), &*_module, this);
 
     return _collectErrors();
 }

--- a/spicy/toolchain/include/compiler/detail/visitors.h
+++ b/spicy/toolchain/include/compiler/detail/visitors.h
@@ -35,6 +35,9 @@ bool print(const hilti::Node& root, hilti::printer::Stream& out);
 bool resolve(const std::shared_ptr<hilti::Context>& ctx, hilti::Node* root, hilti::Unit* unit);
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-void validate(const std::shared_ptr<hilti::Context>& ctx, hilti::Node* root, hilti::Unit* unit);
+void validate_pre(const std::shared_ptr<hilti::Context>& ctx, hilti::Node* root, hilti::Unit* unit);
+
+/** Implements the corresponding functionality for the Spicy compiler plugin. */
+void validate_post(const std::shared_ptr<hilti::Context>& ctx, hilti::Node* root, hilti::Unit* unit);
 
 } // namespace spicy::detail::ast

--- a/spicy/toolchain/src/compiler/plugin.cc
+++ b/spicy/toolchain/src/compiler/plugin.cc
@@ -46,9 +46,15 @@ static hilti::Plugin spicy_plugin() {
         .ast_resolve = [](const std::shared_ptr<hilti::Context>& ctx, Node* m,
                           hilti::Unit* u) { return ast::resolve(ctx, m, u); },
 
-        .ast_validate =
+        .ast_validate_pre =
             [](const std::shared_ptr<hilti::Context>& ctx, Node* m, hilti::Unit* u) {
-                ast::validate(ctx, m, u);
+                ast::validate_pre(ctx, m, u);
+                return false;
+            },
+
+        .ast_validate_post =
+            [](const std::shared_ptr<hilti::Context>& ctx, Node* m, hilti::Unit* u) {
+                ast::validate_post(ctx, m, u);
                 return false;
             },
 

--- a/tests/Baseline/hilti.ast.basic-module/output
+++ b/tests/Baseline/hilti.ast.basic-module/output
@@ -2,6 +2,7 @@
 [debug/compiler] parsing file "<...>/basic-module.hlt" as HILTI code
 [debug/compiler] registering ".hlt" AST for module Foo ("<...>//basic-module.hlt")
 [debug/compiler] resolving units with plugin HILTI: Foo
+[debug/compiler]   [HILTI] validating module Foo (pre)
 [debug/compiler]   processing ASTs, round 0
 [debug/compiler]     resetting nodes for module Foo
 [debug/compiler]     [HILTI] building scopes for module Foo
@@ -40,7 +41,7 @@
 [debug/ast-final]             - node::None (basic-module.hlt:5:13-7:15) [@n:XXX]
 [debug/ast-final]         - node::None (basic-module.hlt:5:13-7:15) [@n:XXX]
 [debug/ast-final]         - node::None (basic-module.hlt:5:13-7:15) [@n:XXX]
-[debug/compiler]   [HILTI] validating module Foo
+[debug/compiler]   [HILTI] validating module Foo (post)
 [debug/compiler]   finalized module Foo
 [debug/compiler]   compiling module Foo to C++
 [debug/compiler]     finalizing module Foo

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -2,6 +2,7 @@
 [debug/compiler] parsing file "foo.hlt" as HILTI code
 [debug/compiler] registering ".hlt" AST for module Foo ("<...>//foo.hlt")
 [debug/compiler] resolving units with plugin HILTI: Foo
+[debug/compiler]   [HILTI] validating module Foo (pre)
 [debug/compiler]   processing ASTs, round 0
 [debug/compiler]     resetting nodes for module Foo
 [debug/compiler]     [HILTI] building scopes for module Foo
@@ -135,8 +136,8 @@
 [debug/ast-final]             - node::None (foo.hlt:6:1) [@n:XXX]
 [debug/ast-final]         - node::None (foo.hlt:6:1) [@n:XXX]
 [debug/ast-final]         - node::None (foo.hlt:6:1) [@n:XXX]
-[debug/compiler]   [HILTI] validating module Foo
-[debug/compiler]   [HILTI] validating module Bar
+[debug/compiler]   [HILTI] validating module Foo (post)
+[debug/compiler]   [HILTI] validating module Bar (post)
 [debug/compiler]   finalized module Foo
 [debug/compiler]     dependencies: Bar
 [debug/compiler]   finalized module Bar

--- a/tests/Baseline/hilti.ast.types/output
+++ b/tests/Baseline/hilti.ast.types/output
@@ -2,6 +2,7 @@
 [debug/compiler] parsing file "<...>/types.hlt" as HILTI code
 [debug/compiler] registering ".hlt" AST for module Foo ("<...>//types.hlt")
 [debug/compiler] resolving units with plugin HILTI: Foo
+[debug/compiler]   [HILTI] validating module Foo (pre)
 [debug/compiler]   processing ASTs, round 0
 [debug/compiler]     resetting nodes for module Foo
 [debug/compiler]     [HILTI] building scopes for module Foo
@@ -42,7 +43,7 @@
 [debug/ast-final]           - expression::Ctor (types.hlt:8:17) (const) (resolved) [@e:XXX]
 [debug/ast-final]             - ctor::UnsignedInteger <value="2" width="64"> (types.hlt:8:17) [@c:XXX]
 [debug/ast-final]               - type::UnsignedInteger <width="64"> (types.hlt:8:17) (const) (resolved) [@t:XXX]
-[debug/compiler]   [HILTI] validating module Foo
+[debug/compiler]   [HILTI] validating module Foo (post)
 [debug/compiler]   finalized module Foo
 module Foo {
 


### PR DESCRIPTION
One validation pass runs before AST resolving, one afterwards. The first
can be used for any checks that don't need any further worn on that AST
so that they can abort processing quickly.

Right now, the pre-resolver validators are empty no-ops, nothing has
moved over yet.

Addresses #1013.