### PR TITLE
Prevent exception if cache directory is not readable.

### DIFF
--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <system_error>
 
 #include <hilti/rt/autogen/version.h>
 
@@ -26,7 +27,8 @@ std::optional<hilti::rt::filesystem::path> precompiled_libhilti(const Configurat
     if ( auto&& cache = util::cacheDirectory(configuration) ) {
         const rt::filesystem::path file_name = rt::fmt("precompiled_libhilti%s.h.pch", (debug ? "_debug" : ""));
 
-        if ( auto pch = (*cache) / file_name; rt::filesystem::exists(pch) )
+        std::error_code ec;
+        if ( auto pch = (*cache) / file_name; rt::filesystem::exists(pch, ec) )
             return pch.replace_extension();
     }
 

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
 
+#include <system_error>
+
 #include <hilti/rt/filesystem.h>
 
 #include <hilti/autogen/config.h>
@@ -26,7 +28,8 @@ std::optional<hilti::rt::filesystem::path> precompiled_libspicy(const hilti::Con
         const hilti::rt::filesystem::path file_name =
             hilti::rt::fmt("precompiled_libspicy%s.h.gch", (debug ? "_debug" : ""));
 
-        if ( auto pch = (*cache) / file_name; hilti::rt::filesystem::exists(pch) )
+        std::error_code ec;
+        if ( auto pch = (*cache) / file_name; hilti::rt::filesystem::exists(pch, ec) )
             return pch.replace_extension();
     }
 


### PR DESCRIPTION
If the cache directory is not readable for the user we cannot check
whether a precompiled header exists. Instead of propagating the
exception from `filesystem::exists` up to the user instead ignore such
paths which effectively means that no precompiled header will be found.