### PR TITLE
Fix potentially use-after-free in stringification of `stream::View`.

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -896,7 +896,9 @@ private:
 };
 
 inline UnsafeConstIterator::UnsafeConstIterator(const SafeConstIterator& i)
-    : _chain(i._chain.get()), _offset(i._offset), _chunk(i._chain ? i._chain->findChunk(_offset, i._chunk) : nullptr) {}
+    : _chain(i._chain.get()),
+      _offset(i._offset),
+      _chunk(i._chain ? i._chain->findChunk(_offset, i.chunk()) : nullptr) {}
 
 inline std::ostream& operator<<(std::ostream& out, const UnsafeConstIterator& x) {
     out << to_string(x);


### PR DESCRIPTION
To construct `UnsafeConstIterator`s we previously directly used a
`SafeConstIterator`'s chunk pointer which might be invalid and point to
e.g., random memory. With this patch we use the safe API to retrieve it
which either yields a valid pointer to a chunk or a `nullptr` (which we
also handle).