### PR TITLE
Bump zkg in published Docker image.

### DIFF
--- a/ci/Dockerfile.dockerhub
+++ b/ci/Dockerfile.dockerhub
@@ -23,7 +23,6 @@ RUN apt-get update \
  && if [ -n "${ZEEK_LTS}" ]; then ZEEK_LTS="-lts"; fi && export ZEEK_LTS \
  && apt-get install -y --no-install-recommends libpcap0.8 libpcap-dev libssl-dev zlib1g-dev libmaxminddb0 libmaxminddb-dev python python3 python3-pip python3-semantic-version python3-git \
  && curl -L --remote-name-all \
-    https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-core_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeekctl${ZEEK_LTS}_${ZEEK_VERSION}_amd64.deb \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-core-dev_${ZEEK_VERSION}_amd64.deb \
@@ -31,11 +30,12 @@ RUN apt-get update \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-libcaf-dev_${ZEEK_VERSION}_amd64.deb \
  && [[ ${ZEEK_VERSION} = 4.* ]] && curl -L --remote-name-all \
     https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-btest_${ZEEK_VERSION}_amd64.deb \
-    https://download.zeek.org/binary-packages/xUbuntu_20.04/amd64/zeek${ZEEK_LTS}-zkg_${ZEEK_VERSION}_amd64.deb \
  ||  pip3 install --no-cache-dir "btest>=0.66" zkg \
  && dpkg -i ./*.deb \
  && cd - \
  && rm -rf /tmp/zeek-packages \
+ # Need a newer zkg than the one currently packaged with Zeek.
+ && pip3 install --no-cache-dir "zkg>=2.12.0" \
  # Spicy build and test dependencies.
  && apt-get install -y --no-install-recommends git ninja-build ccache bison flex g++ libfl-dev python3 python3-pip zlib1g-dev jq locales-all python3-setuptools python3-wheel make \
  && apt-get clean \


### PR DESCRIPTION
In order to use packages with dependencies we require
zeek/package-manager#106 which is only available with zkg-2.12.0.