### PR TITLE
Fix potentially use-after-free in stringification of `stream::View`.

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -896,9 +896,7 @@ private:
 };
 
 inline UnsafeConstIterator::UnsafeConstIterator(const SafeConstIterator& i)
-    : _chain(i._chain.get()),
-      _offset(i._offset),
-      _chunk(i._chain ? i._chain->findChunk(_offset, i.chunk()) : nullptr) {}
+    : _chain(i.chain()), _offset(i.offset()), _chunk(i.chain() ? i.chain()->findChunk(_offset, i.chunk()) : nullptr) {}
 
 inline std::ostream& operator<<(std::ostream& out, const UnsafeConstIterator& x) {
     out << to_string(x);


### PR DESCRIPTION
This is a fixup commit for dbc4c6e0d8e where we missed a couple
potential use-after-frees.