### PR TITLE
Fix a typo in container Github action filter.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
         tags: ${{ env.TEST_TAG }}
 
     - name: Login to ECR
-      if: github.event.name == 'push'
+      if: github.event_name == 'push'
       uses: docker/login-action@v1
       with:
         registry: public.ecr.aws
@@ -65,7 +65,7 @@ jobs:
         password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     - name: Login to DockerHub
-      if: github.event.name == 'push'
+      if: github.event_name == 'push'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
This patch fixes a typo in filter the login steps in the workflow
publishing container images (`github.event.name` instead of
`github.event_name`). Since the mistyped variable was undefined we
previously never performed the login.