### PR TITLE
Fixes for noop build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,13 +209,13 @@ if (${HILTI_DEV_PRECOMPILE_HEADERS} AND TARGET hilti-config AND TARGET spicy-con
     add_custom_command(
         COMMENT "Generating precompiled headers"
         OUTPUT ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h
-        OUTPUT ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti.h.gch
                ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti_debug.h
-               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti_debug.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libhilti_debug.h.gch
                ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy.h
-               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy.h.gch
                ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy_debug.h
-               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy_debug.h.pch
+               ${PROJECT_BINARY_DIR}/cache/spicy/precompiled_libspicy_debug.h.gch
         COMMAND
             ${CMAKE_COMMAND} -E env SPICY_CACHE=${PROJECT_BINARY_DIR}/cache/spicy
             ${PROJECT_SOURCE_DIR}/scripts/precompile-headers.sh --bindir ${CMAKE_BINARY_DIR}/bin

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -150,10 +150,11 @@ spicy_link_executable_in_tree(spicy-batch-extract PRIVATE)
 
 add_subdirectory(bin/spicy-dump)
 
-add_custom_target(spicy-build ALL)
-add_custom_command(TARGET spicy-build
-                   POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/bin/spicy-build
-                                                               ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+add_custom_target(spicy-build ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build)
+add_custom_command(
+    POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                       ${CMAKE_CURRENT_SOURCE_DIR}/bin/spicy-build ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build)
 
 ## Installation
 


### PR DESCRIPTION
We currently always execute some commands, even if we just completed a
build. This PR addresses that.