### PR TITLE
Fix code generator to emit types correctly for transitive dependencies.

### DIFF
--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -172,8 +173,13 @@ public:
      */
     Result<CxxCode> cxxCode() const;
 
-    /** Returns the list of dependencies registered for the unit so far. */
-    const auto& dependencies() { return _dependencies; }
+    /**
+     * Returns the list of dependencies registered for the unit so far.
+     *
+     * @param recursive if true, return the transitive closure of all
+     * dependent units, vs just direct dependencies of the current unit
+     */
+    std::vector<std::weak_ptr<Unit>> dependencies(bool recursive = false) const;
 
     /** Removes any dependencies registered for the unit so far. */
     void clearDependencies() { _dependencies.clear(); };
@@ -384,6 +390,9 @@ private:
 
     // Recursively destroys the module's AST.
     void _destroyModule();
+
+    // Helper for depencencies() to recurse.
+    void _recursiveDependencies(std::vector<std::weak_ptr<Unit>>* dst, std::unordered_set<const Unit*>* seen) const;
 
     // Parses a source file with the appropriate plugin.
     static Result<hilti::Module> _parse(const std::shared_ptr<Context>& context,

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -144,6 +144,7 @@
 [debug/compiler]     dependencies: Foo
 [debug/compiler]   compiling module Foo to C++
 [debug/compiler]     importing declarations from module Bar
+[debug/compiler]     importing declarations from module Foo
 [debug/compiler]     finalizing module Foo
 // Begin of Foo (from "foo.hlt")
 // Compiled by HILTI version X.X.X

--- a/tests/spicy/types/unit/transitive-imports.spicy
+++ b/tests/spicy/types/unit/transitive-imports.spicy
@@ -1,0 +1,34 @@
+# @TEST-EXEC: spicyc -d -j c.spicy d.spicy
+#
+# @TEST-DOC: Regression test for #1057 to check C++ type emission for transitive imports
+
+@TEST-START-FILE a.spicy
+module a;
+
+import spicy;
+
+%byte-order=spicy::ByteOrder::Little;
+
+public type A = unit {};
+@TEST-END-FILE
+
+@TEST-START-FILE b.spicy
+module b;
+
+import a;
+
+public type B = unit {
+    a_: a::A;
+};
+@TEST-END-FILE
+
+@TEST-START-FILE c.spicy
+module c;
+import b;
+@TEST-END-FILE
+
+@TEST-START-FILE d.spicy
+module d;
+
+import c;
+@TEST-END-FILE


### PR DESCRIPTION
Closes #1057.