### PR TITLE
Remove unneeded computations

### DIFF
--- a/hilti/toolchain/src/compiler/context.cc
+++ b/hilti/toolchain/src/compiler/context.cc
@@ -144,7 +144,7 @@ std::vector<std::weak_ptr<Unit>> Context::lookupDependenciesForUnit(const ID& id
 }
 
 void Context::dumpUnitCache(const hilti::logging::DebugStream& stream) {
-    if ( logger().isEnabled(stream) )
+    if ( ! logger().isEnabled(stream) )
         return;
 
     HILTI_DEBUG(stream, "### Unit cache");

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -1238,6 +1238,9 @@ void Driver::_dumpAST(std::shared_ptr<Unit> unit, std::ostream& stream, const Pl
 }
 
 void Driver::_dumpAST(std::shared_ptr<Unit> unit, const logging::DebugStream& stream, const std::string& prefix) {
+    if ( ! logger().isEnabled(stream) )
+        return;
+
     HILTI_DEBUG(stream, fmt("# %s: %s\n", unit->id(), prefix));
     detail::renderNode(unit->module(), stream, true);
 }


### PR DESCRIPTION
This PR removes unneeded computations around logging. While this only
speeds up the test suite by around 20% on my machine (hot ccache), it
nearly halves the time it takes to process a huge grammar (~1500 loc,
~130 units, timing excluding C++ compilation).