### PR TITLE
Show log for configure failures.

### DIFF
--- a/configure
+++ b/configure
@@ -175,8 +175,9 @@ else
 fi
 
 cd "${cmake_build_directory}"
-eval "${cmake}" > config.log 2>&1
-cat config.log
+fail=$(mktemp)
+{ eval "${cmake}" 2>&1 || echo > "$fail"; } | tee config.log &&  [ ! -s "$fail" ]
+rm "$fail"
 
 echo "# This is the command used to configure this build" > config.status
 echo "${command}" >> config.status


### PR DESCRIPTION
In 945dd34a5e49a we attempted to fix the issue of `./configure` failures
not leading to error return codes by explictly capturing the log and showing it
later. This introduced the issue that the configure log was only
shown after `./configure` finished _successfully_; on configure failure
we would correctly return an error code, but never reach the code
displaying the log.

This patch fixes this puzzling behavior so that the log is even shown
if `configure` runs into issues. For that we use the `pipefail` Bash
option.