### PR TITLE
Fix syntax for Spicy `struct` declaration.

### DIFF
--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -450,7 +450,7 @@ are mutable.
 
 .. rubric:: Type
 
-- ``struct { TYPE_1: IDENTIFIER_1; ...; TYPE_N: IDENTIFIER_N }``
+- ``struct { IDENTIFIER_1: TYPE_1; ...; IDENTIFIER_N: TYPE_N;  }``
 
 .. rubric:: Constants
 

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -35,7 +35,7 @@ namespace spicy { namespace detail { class Parser; } }
 
 %glr-parser
 %expect 131
-%expect-rr 157
+%expect-rr 156
 
 %{
 
@@ -633,7 +633,7 @@ struct_type   : STRUCT '{' struct_fields '}'     { $$ = hilti::type::Struct(std:
 struct_fields : struct_fields struct_field       { $$ = std::move($1); $$.push_back($2); }
               | /* empty */                      { $$ = std::vector<Declaration>{}; }
 
-struct_field  : type local_id opt_attributes ';' { $$ = hilti::declaration::Field(std::move($2), std::move($1), std::move($3), __loc__); }
+struct_field  : local_id ':' type opt_attributes ';' { $$ = hilti::declaration::Field(std::move($1), std::move($3), std::move($4), __loc__); }
 
 enum_type     : ENUM '{' enum_labels '}'         { $$ = hilti::type::Enum(std::move($3), __loc__); }
 

--- a/tests/spicy/types/enum/type.spicy
+++ b/tests/spicy/types/enum/type.spicy
@@ -14,9 +14,9 @@ type Y = enum {
 };
 
 type Z = struct {
-    X x1;
-    X x2 &optional;
-    Y y1 &optional &default=Y::B1;
+    x1: X;
+    x2: X &optional;
+    y1: Y &optional &default=Y::B1;
 };
 
 global x: X = X::A1;

--- a/tests/spicy/types/map/ops.spicy
+++ b/tests/spicy/types/map/ops.spicy
@@ -19,7 +19,7 @@ assert map<uint64, int64>(i: j) == map(1: -1);
 assert map(i: j) == map<uint64, int64>(1: -1);
 
 type S = struct {
-    int8 i;
+    i: int8;
 };
 global s: S;
 s.i = 42;

--- a/tests/spicy/types/struct/basic.spicy
+++ b/tests/spicy/types/struct/basic.spicy
@@ -6,8 +6,8 @@
 module test;
 
 type Foo = struct {
-    int32 x;
-    real y;
+    x: int32;
+    y: real;
 };
 
 # NOTE: We perform these tests at local scope as a workaround for #1035.

--- a/tests/spicy/types/struct/parse-fail.spicy
+++ b/tests/spicy/types/struct/parse-fail.spicy
@@ -6,7 +6,7 @@
 module test;
 
 type Foo = struct {
-    uint32 x;
+    x: uint32;
 };
 
 type Bar = unit {


### PR DESCRIPTION
We previously supported declaring `struct` types in Spicy with HILTI
syntax, i.e., fields were declared like

    TYPE IDENTIFIER [ATTRIBUTES];

This syntax does not fit Spicy well so this patch adjusts the syntax for
`struct` field declarations to be

    IDENTIFIER: TYPE [ATTRIBUTES];

We also update the recently added documentation for `struct` types.

Closes #1068.