### PR TITLE
Fix import of global constants.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -38,7 +38,7 @@ struct GlobalsVisitor : hilti::visitor::PreOrder<void, GlobalsVisitor> {
     bool include_implementation;
 
     std::vector<cxx::declaration::Global> globals;
-    std::vector<cxx::declaration::Global> constants;
+    std::vector<cxx::declaration::Constant> constants;
 
     static void addDeclarations(CodeGen* cg, const Node& module, const ID& module_id, cxx::Unit* unit,
                                 bool include_implementation) {
@@ -135,10 +135,9 @@ struct GlobalsVisitor : hilti::visitor::PreOrder<void, GlobalsVisitor> {
     }
 
     void operator()(const declaration::Constant& n, position_t p) {
-        auto x = cxx::declaration::Global{.id = {cg->unit()->cxxNamespace(), n.id()},
-                                          .type = cg->compile(n.type(), codegen::TypeUsage::Storage),
-                                          .init = cg->compile(n.value()),
-                                          .linkage = "const"};
+        auto x = cxx::declaration::Constant{.id = {cg->unit()->cxxNamespace(), n.id()},
+                                            .type = cg->compile(n.type(), codegen::TypeUsage::Storage),
+                                            .init = cg->compile(n.value())};
 
         constants.push_back(x);
     }

--- a/tests/hilti/codegen/imported-constants.hlt
+++ b/tests/hilti/codegen/imported-constants.hlt
@@ -1,0 +1,16 @@
+# @TEST-EXEC: hiltic -j %INPUT
+# @TEST-DOC: Check usage imported constants. Regression test for #1079.
+
+module B {
+
+import A;
+
+assert A::x == 64;
+
+}
+
+@TEST-START-FILE a.hlt
+module A {
+public const uint<32> x = 64;
+}
+@TEST-END-FILE


### PR DESCRIPTION
We were treating them as globals (instead of constants) and weren't
emitting them into the generated C++ code.

Closes #1079.