### PR TITLE
Make sure user-visible enums are represented by `int64_t`.

### DIFF
--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -130,7 +130,7 @@ inline std::ostream& operator<<(std::ostream& out, const StackBuffer& s) {
 class Fiber {
 public:
     /** Type of fiber. */
-    enum class Type {
+    enum class Type : int64_t {
         IndividualStack, /**< Fiver using a dedicated local stack (needs more memory, but switching is fast) */
         SharedStack,     /**< Fiber sharing a global stack (needs less memory, but switching costs extra) */
 

--- a/hilti/runtime/include/types/address.h
+++ b/hilti/runtime/include/types/address.h
@@ -15,7 +15,7 @@
 
 namespace hilti::rt {
 
-enum class AddressFamily { Undef, IPv4, IPv6 };
+enum class AddressFamily : int64_t { Undef, IPv4, IPv6 };
 
 /**
  * Represents HILTI address type. This treats IPv4 and IPv6 addresses

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -29,14 +29,14 @@ class View;
 namespace bytes {
 
 /** For Bytes::Strip, which side to strip from. */
-enum class Side {
+enum class Side : int64_t {
     Left,  /**< left side */
     Right, /**< right side */
     Both   /**< left and right sides */
 };
 
 /** For Bytes::Decode, which character set to use. */
-enum class Charset { Undef, UTF8, ASCII };
+enum class Charset : int64_t { Undef, UTF8, ASCII };
 
 class Iterator {
     using B = std::string;

--- a/hilti/runtime/include/types/integer.h
+++ b/hilti/runtime/include/types/integer.h
@@ -241,7 +241,7 @@ inline uint64_t flip(uint64_t v, uint64_t n) {
 }
 
 /** Available bit orders. */
-enum class BitOrder { LSB0, MSB0, Undef };
+enum class BitOrder : int64_t { LSB0, MSB0, Undef };
 
 /** Extracts a range of bits from an integer value, shifting them to the very left before returning. */
 template<typename UINT>

--- a/hilti/runtime/include/types/port.h
+++ b/hilti/runtime/include/types/port.h
@@ -14,7 +14,7 @@
 namespace hilti::rt {
 
 /** Protocols that can be associated with a `Port`. */
-enum class Protocol { Undef = 0, TCP, UDP, ICMP };
+enum class Protocol : int64_t { Undef = 0, TCP, UDP, ICMP };
 
 /**
  * Represents HILTI's port type. A port is pair of port number and protocol.

--- a/hilti/runtime/include/types/real.h
+++ b/hilti/runtime/include/types/real.h
@@ -14,7 +14,7 @@ namespace hilti::rt {
 
 namespace real {
 /** Available formats for unpacking a binary floating point value. */
-enum class Type { Undef, IEEE754_Single, IEEE754_Double };
+enum class Type : int64_t { Undef, IEEE754_Single, IEEE754_Double };
 
 /** Unpacks a floatingpoint value from a binary representation, following the protocol for `unpack` operator. */
 extern Result<std::tuple<double, Bytes>> unpack(const Bytes& data, Type type, ByteOrder fmt);

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -58,7 +58,7 @@ using Offset = integer::safe<uint64_t>;
 using Size = integer::safe<uint64_t>;
 
 /** Direction of a search. */
-enum class Direction { Forward, Backward };
+enum class Direction : int64_t { Forward, Backward };
 
 namespace detail {
 

--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -501,7 +501,7 @@ template<typename... T>
 struct is_tuple<std::tuple<T...>> : std::true_type {};
 
 /** Available byte orders. */
-enum class ByteOrder { Little, Big, Network, Host, Undef = -1 };
+enum class ByteOrder : int64_t { Little, Big, Network, Host, Undef = -1 };
 
 /**
  * Returns the byte order of the system we're running on. The result is


### PR DESCRIPTION
In order to convert from arbitrary runtime values with
`hilti::rt::enum_::{from_int, from_uint}` we statically assert that the
enums have an underlying type `int64_t`. This is not true in general,
e.g., a port enum would previously have been represented by an `int`
(which not only does not need to be the same time, but could also have a
smaller range).

With this path we now explicitly request an underlying type `int64_t`
for enums which can be constructed by users from Spicy code.

Closes #1122.