### PR TITLE
Fix matching of multiple regexps to prefer shortest match.

### DIFF
--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -70,6 +70,11 @@ TEST_CASE("match") {
         CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("abbbcdef"_b), 1);
         CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("012abbbc345"_b), 0);
     }
+
+    SUBCASE("prefers shorted match") {
+        CHECK_EQ(RegExp(std::vector<std::string>{"A{#1}", "ABC{#2}"}).match("ABC"_b), 1);
+        CHECK_EQ(RegExp(std::vector<std::string>{"ABC{#1}", "A{#2}"}).match("ABC"_b), 2);
+    }
 }
 
 TEST_CASE("find") {


### PR DESCRIPTION
If multiple regexps match at the same left-most offset, justrx would
previously prefer the longest instead of the shortest match. These are
not the expected and documented semantics for Spicy.

This patch bumps justrx to a version which has the expected semantics.

Closes #1114.