### PR TITLE
Make compiler plugin initialization explicit.

### DIFF
--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCES
     src/compiler/cxx/linker.cc
     src/compiler/cxx/unit.cc
     src/compiler/driver.cc
+    src/compiler/init.cc
     src/compiler/jit.cc
     src/compiler/optimizer.cc
     src/compiler/parser/driver.cc

--- a/hilti/toolchain/bin/hiltic.cc
+++ b/hilti/toolchain/bin/hiltic.cc
@@ -1,8 +1,10 @@
 // Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
 
+#include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
 int main(int argc, char** argv) {
+    hilti::init();
     hilti::Driver driver("hiltic", hilti::util::currentExecutable());
 
     if ( auto rc = driver.parseOptions(argc, argv); ! rc ) {

--- a/hilti/toolchain/include/compiler/init.h
+++ b/hilti/toolchain/include/compiler/init.h
@@ -1,0 +1,8 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+namespace hilti {
+/** Perform global initializations for compiling HILTI source files. */
+void init();
+} // namespace hilti

--- a/hilti/toolchain/include/compiler/plugin.h
+++ b/hilti/toolchain/include/compiler/plugin.h
@@ -287,21 +287,10 @@ private:
     std::vector<Plugin> _plugins;
 };
 
-namespace plugin {
-/**
- * Helper class to register a plugin at startup. To add a plugin, create a
- * global `Register` instance to register it.
- */
-class Register {
-public:
-    /**
-     * Registers a plugin with the global `registry()`.
-     *
-     * @param p plugin to register
-     */
-    Register(const Plugin& p) { registry().register_(p); }
-};
+namespace detail {
 
-} // namespace plugin
+Plugin create_hilti_plugin();
+
+} // namespace detail
 
 } // namespace hilti

--- a/hilti/toolchain/src/compiler/init.cc
+++ b/hilti/toolchain/src/compiler/init.cc
@@ -1,0 +1,16 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+
+#include "compiler/init.h"
+
+#include <hilti/compiler/plugin.h>
+
+void hilti::init() {
+    static bool initialized = false;
+
+    if ( initialized )
+        return;
+
+    plugin::registry().register_(detail::create_hilti_plugin());
+
+    initialized = true;
+}

--- a/hilti/toolchain/src/compiler/parser/driver.cc
+++ b/hilti/toolchain/src/compiler/parser/driver.cc
@@ -6,6 +6,7 @@
 #include <hilti/base/logger.h>
 #include <hilti/compiler/detail/parser/driver.h>
 #include <hilti/compiler/detail/parser/scanner.h>
+#include <hilti/compiler/plugin.h>
 #include <hilti/global.h>
 
 /** We compile with a source property to find this. */

--- a/hilti/toolchain/src/compiler/plugin.cc
+++ b/hilti/toolchain/src/compiler/plugin.cc
@@ -1,9 +1,10 @@
 // Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
 
+#include "hilti/compiler/plugin.h"
+
 #include <hilti/autogen/config.h>
 #include <hilti/compiler/context.h>
 #include <hilti/compiler/detail/visitors.h>
-#include <hilti/compiler/plugin.h>
 
 using namespace hilti;
 using namespace hilti::detail;
@@ -43,7 +44,7 @@ void PluginRegistry::register_(const Plugin& p) {
 }
 
 // Always-on default plugin with HILTI functionality.
-static Plugin hilti_plugin() {
+Plugin hilti::detail::create_hilti_plugin() {
     return Plugin{
         .component = "HILTI",
         .order = 10,
@@ -90,5 +91,3 @@ static Plugin hilti_plugin() {
         .ast_transform = {},
     };
 }
-
-static plugin::Register _(hilti_plugin());

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOURCES_COMPILER
     src/compiler/codegen/productions/while.cc
     src/compiler/codegen/unit-builder.cc
     src/compiler/driver.cc
+    src/compiler/init.cc
     src/compiler/parser/driver.cc
     src/compiler/plugin.cc
     src/compiler/visitors/normalizer.cc

--- a/spicy/toolchain/bin/spicy-doc.cc
+++ b/spicy/toolchain/bin/spicy-doc.cc
@@ -3,8 +3,10 @@
 #include <hilti/rt/json.h>
 
 #include <hilti/ast/detail/operator-registry.h>
+#include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
+#include <spicy/compiler/init.h>
 #include <spicy/spicy.h>
 
 using nlohmann::json;
@@ -117,6 +119,9 @@ static json operandToJSON(const hilti::operator_::Operand& o) {
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char** argv) {
+    hilti::init();
+    spicy::init();
+
     json all_operators;
 
     // Helper function adding one operator to all_operators.

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -9,8 +9,10 @@
 
 #include <spicy/rt/libspicy.h>
 
+#include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
+#include <spicy/compiler/init.h>
 #include <spicy/spicy.h>
 
 using spicy::rt::fmt;
@@ -232,6 +234,9 @@ void SpicyDriver::parseOptions(int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
+    hilti::init();
+    spicy::init();
+
     SpicyDriver driver;
 
     driver.parseOptions(argc, argv);

--- a/spicy/toolchain/bin/spicy-dump/main.cc
+++ b/spicy/toolchain/bin/spicy-dump/main.cc
@@ -10,8 +10,10 @@
 
 #include <spicy/rt/libspicy.h>
 
+#include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
+#include <spicy/compiler/init.h>
 #include <spicy/spicy.h>
 
 #include "options.h"
@@ -220,6 +222,9 @@ void SpicyDump::parseOptions(int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
+    hilti::init();
+    spicy::init();
+
     SpicyDump driver;
 
     driver.parseOptions(argc, argv);

--- a/spicy/toolchain/bin/spicyc.cc
+++ b/spicy/toolchain/bin/spicyc.cc
@@ -2,8 +2,10 @@
 
 #include <spicy/rt/libspicy.h>
 
+#include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
+#include <spicy/compiler/init.h>
 #include <spicy/spicy.h>
 
 class Spicyc : public spicy::Driver {
@@ -17,6 +19,9 @@ public:
 };
 
 int main(int argc, char** argv) {
+    hilti::init();
+    spicy::init();
+
     Spicyc driver;
 
     if ( auto rc = driver.parseOptions(argc, argv); ! rc ) {

--- a/spicy/toolchain/include/compiler/init.h
+++ b/spicy/toolchain/include/compiler/init.h
@@ -1,0 +1,8 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+namespace spicy {
+/** Perform global initializations for compiling Spicy source files. */
+void init();
+} // namespace spicy

--- a/spicy/toolchain/include/compiler/plugin.h
+++ b/spicy/toolchain/include/compiler/plugin.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <hilti/compiler/plugin.h>
+
+namespace spicy::detail {
+
+hilti::Plugin create_spicy_plugin();
+
+} // namespace spicy::detail

--- a/spicy/toolchain/src/compiler/init.cc
+++ b/spicy/toolchain/src/compiler/init.cc
@@ -1,0 +1,18 @@
+// Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
+
+#include "compiler/init.h"
+
+#include <hilti/compiler/plugin.h>
+
+#include <spicy/compiler/plugin.h>
+
+void spicy::init() {
+    static bool initialized = false;
+
+    if ( initialized )
+        return;
+
+    hilti::plugin::registry().register_(detail::create_spicy_plugin());
+
+    initialized = true;
+}

--- a/spicy/toolchain/src/compiler/plugin.cc
+++ b/spicy/toolchain/src/compiler/plugin.cc
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
 
+#include "compiler/plugin.h"
+
 #include <hilti/compiler/plugin.h>
 #include <hilti/compiler/printer.h>
 
@@ -13,7 +15,7 @@
 using namespace spicy;
 using namespace spicy::detail;
 
-static hilti::Plugin spicy_plugin() {
+hilti::Plugin spicy::detail::create_spicy_plugin() {
     return hilti::Plugin{
         .component = "Spicy",
         .order = 5, // before HILTI
@@ -65,5 +67,3 @@ static hilti::Plugin spicy_plugin() {
         },
     };
 }
-
-static hilti::plugin::Register _(spicy_plugin());


### PR DESCRIPTION
Support for working with Spicy and HILTI source files is handled by
plugins. We previously registered these plugins via hidden static
variables. This had issues if Spicy is linked statically and the hidden
registration variable was not linked into the final output (in that case
not registration would happen).

In order to better control the language registration this patch
introduces dedicated functions `hilti::init` and `spicy::init` which
currently only register support for HILTI and Spicy source files,
respectively. We also adjust our executables to invoke these functions
now.

Closes #1164.