### PR TITLE
Update test comments to reflect actual behavior [skip CI].

### DIFF
--- a/tests/spicy/types/unit/synchronize-match-length.spicy
+++ b/tests/spicy/types/unit/synchronize-match-length.spicy
@@ -1,9 +1,8 @@
-# @TEST-DOC: Checks that we always synchronize on the shortest possible match.
+# @TEST-DOC: Checks match semantics on synchronization; we prefer the longest possible match.
 
 # @TEST-EXEC: spicyc -j -d %INPUT -o test.hlto
 #
-# During normal parsing we prefer the longest possible match, but synchronize
-# on the shortest match.
+# During both normal parsing and synchronization we prefer the longest possible match.
 # @TEST-EXEC: ${SCRIPTS}/printf xABC | spicy-driver -i 1 -d test.hlto -p test::A >>output 2>&1
 # @TEST-EXEC: ${SCRIPTS}/printf ABC | spicy-driver -i 1 -d test.hlto -p test::A >>output 2>&1
 


### PR DESCRIPTION
Both during usual parsing and synchronization we prefer the longest
possible match, see #1114. The test
`spicy.types.unit.synchronize-match-length` documented the at the time
intended behavior of taking the shortest possible match instead. This
patch brings the comments in line with the actual behavior to avoid
confusion.