### PR TITLE
Add binary packaging mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,21 @@ if (NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 endif ()
 
-make_install_rpath(rpath ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_LIBDIR})
-set(CMAKE_INSTALL_RPATH "${rpath}")
+if (BINARY_PACKAGING_MODE)
+    # Binary packaging mode uses a static link which causes issues with
+    # unresolved symbols for a number of tests.
+    if (USE_SANITIZERS)
+        message(FATAL_ERROR "Sanitizers are unsupported in binary packaging mode")
+    endif ()
+
+    set(BUILD_SHARED_LIBS OFF)
+    set(CMAKE_SKIP_RPATH ON)
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH OFF)
+    set(CMAKE_MACOSX_RPATH OFF)
+else ()
+    make_install_rpath(rpath ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_LIBDIR})
+    set(CMAKE_INSTALL_RPATH "${rpath}")
+endif ()
 
 if (USE_CCACHE)
     find_program(CCACHE_PROGRAM ccache)

--- a/configure
+++ b/configure
@@ -8,6 +8,7 @@
 set -e
 
 # Defaults
+cmake_binary_packaging_mode="no"
 cmake_bison_root=""
 cmake_build_directory="build"
 cmake_build_shared_libs="yes"
@@ -50,6 +51,7 @@ usage="\
 Usage: $0 [OPTION]... [VAR=VALUE]...
 
   Build Options:
+    --binary-package                      Toggle special logic for binary packaging
     --build-dir=DIR                       Place build files in directory [default: ${cmake_build_directory}]
     --build-static-libs                   Build static libraries instead [default: shared]
     --build-toolchain={yes,no}            Build the Spicy compiler toolchain [default: ${cmake_build_toolchain}]
@@ -103,6 +105,7 @@ while [ $# -ne 0 ]; do
     esac
 
     case "$1" in
+        --binary-package)                  cmake_binary_packaging_mode="yes";;
         --build-dir=*|--builddir=*)        cmake_build_directory="${optarg}";;
         --build-static-libs)               cmake_build_shared_libs="no";;
         --build-toolchain=*)               cmake_build_toolchain="${optarg}";;
@@ -142,6 +145,7 @@ while [ $# -ne 0 ]; do
 done
 
 # Set CMake cache options.
+append_cache_entry BINARY_PACKAGING_MODE        BOOL   "${cmake_binary_packaging_mode}"
 append_cache_entry BISON_ROOT                   PATH   "${cmake_bison_root}"
 append_cache_entry BUILD_SHARED_LIBS            BOOL   "${cmake_build_shared_libs}"
 append_cache_entry BUILD_TOOLCHAIN              BOOL   "${cmake_build_toolchain}"


### PR DESCRIPTION
This patch adds a binary packaging mode which mirrors the behavior of
that flag. In this mode Spicy gets linked statically and no RPATHs are
embedded in binaries. This should make it easier to package Spicy (e.g.,
alongside Zeek) for typical distributions which tend to disallow
embedded RPATHs.

Note that we still emit linker flags with an RPATH via e.g.,
`spicy-config --ldflags-hlto`. This RPATH is however not embedded into
distributed binary artifacts.