### PR TITLE
Remove freebsd11, add freebsd13.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -785,13 +785,18 @@ docker_opensuse15_2_task:
     path: ./spicy*.{deb,rpm}
     type: application/gzip
 
-freebsd11_task:
+freebsd13_task:
   freebsd_instance:
-    image_family: freebsd-11-4
+    image_family: freebsd-13-0
     cpu: 8
     memory: 8GB
 
   prepare_script: ./ci/prepare_freebsd.sh
+
+  # Not required for now since the way we perform symbol demangling seems to be
+  # broken on freebsd13 at the moment, see #1171.
+  allow_failures: true
+  skip_notification: true
 
   timeout_in: 120m
 


### PR DESCRIPTION
Freebsd11 is EOL and it seems upstream package servers became
unavailable. This makes it impossible to install required packages. This
patch adds support for freebsd13 instead. Since it seems that support the
the way we perform symbol demangling is currently broken in freebsd13
(see e.g., https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=222563)
the step is not required.

This patch is the first, but not last piece of work to get #1171 fixed.