### PR TITLE
Do not artificially suppress uses of `(u)int8` in some cases.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/coercions.cc
+++ b/hilti/toolchain/src/compiler/codegen/coercions.cc
@@ -125,10 +125,10 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
             return fmt("static_cast<bool>(%s)", expr);
 
         if ( auto t = dst.tryAs<type::SignedInteger>() )
-            return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", std::max(16, t->width()), expr);
+            return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", t->width(), expr);
 
         if ( auto t = dst.tryAs<type::UnsignedInteger>() )
-            return fmt("::hilti::rt::integer::safe<uint%d_t>(%s)", std::max(16, t->width()), expr);
+            return fmt("::hilti::rt::integer::safe<uint%d_t>(%s)", t->width(), expr);
 
         logger().internalError(fmt("codegen: unexpected type coercion from signed integer to %s", dst.typename_()));
     }
@@ -177,10 +177,10 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
             return fmt("static_cast<bool>(%s)", expr);
 
         if ( auto t = dst.tryAs<type::SignedInteger>() )
-            return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", std::max(16, t->width()), expr);
+            return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", t->width(), expr);
 
         if ( auto t = dst.tryAs<type::UnsignedInteger>() )
-            return fmt("::hilti::rt::integer::safe<uint%d_t>(%s)", std::max(16, t->width()), expr);
+            return fmt("::hilti::rt::integer::safe<uint%d_t>(%s)", t->width(), expr);
 
         logger().internalError(fmt("codegen: unexpected type coercion from unsigned integer to %s", dst.typename_()));
     }


### PR DESCRIPTION
We previously would uses at least `(u)int16`, even though the the user
explicitly requested `(u)int8`. This could e.g., lead to surprising
behavior when interacting with function overloading. This patch removes
the special handling and we now use the requested type

Closes #1174.