### PR TITLE
Replace uses of deprecated `result_of` with `invoke_result`.

### DIFF
--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -330,7 +330,7 @@ constexpr auto transform_result_value(const C&) {
 /** Applies a function to each element of container. */
 template<typename C, typename F>
 auto transform(const C& x, F f) {
-    using Y = typename std::result_of_t<F(typename C::value_type&)>;
+    using Y = typename std::invoke_result_t<F, typename C::value_type&>;
 
     auto y = detail::transform_result_value<C, Y>(x);
     std::transform(std::begin(x), std::end(x), std::inserter(y, std::end(y)), f);

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -890,7 +890,7 @@ auto filter(const hilti::node::Set<X>& x, F f) {
  */
 template<typename X, typename F>
 auto transform(const hilti::node::Range<X>& x, F f) {
-    using Y = typename std::result_of<F(X&)>::type;
+    using Y = typename std::invoke_result_t<F, X&>;
     std::vector<Y> y;
     y.reserve(x.size());
     for ( const auto& i : x )
@@ -905,7 +905,7 @@ auto transform(const hilti::node::Range<X>& x, F f) {
  */
 template<typename X, typename F>
 auto transform(const hilti::node::Set<X>& x, F f) {
-    using Y = typename std::result_of<F(X&)>::type;
+    using Y = typename std::invoke_result_t<F, X&>;
     std::vector<Y> y;
     y.reserve(x.size());
     for ( const auto& i : x )

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -86,7 +86,7 @@ using hilti::rt::transform; // NOLINT(misc-unused-using-decls)
 /** Applies a function to each element of a set, returning a vector with the results. */
 template<typename X, typename F>
 auto transform_to_vector(const std::set<X>& x, F f) {
-    using Y = typename std::result_of<F(X&)>::type;
+    using Y = typename std::invoke_result_t<F, X&>;
     std::vector<Y> y;
     y.reserve(x.size());
     for ( const auto& i : x )


### PR DESCRIPTION
With C++17 `std::result_of` was deprecated in favor of
`std::invoke_result`. This patch removes uses of the deprecated
template.

Closes #1190.