### PR TITLE
Adjust removal of symlinks on install for `DESTDIR`.

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -95,8 +95,8 @@ install(TARGETS hilti-rt hilti-rt-debug ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBD
 
 install_headers(include hilti/rt)
 install_headers(${PROJECT_BINARY_DIR}/include/hilti/rt hilti/rt)
-install(CODE "file(REMOVE_RECURSE ${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/rt/hilti)"
-)# Get rid of symlink
+install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/rt/hilti)"
+)# Get rid of symlink.
 
 # Install the 3rdparty headers that we need individually.
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/ArticleEnumClass-v2

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -186,7 +186,8 @@ install(TARGETS hilti-config RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install_headers(include hilti)
 install_headers(${PROJECT_BINARY_DIR}/include/hilti hilti)
-install(CODE "file(REMOVE ${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/hilti)") # Get rid of symlink
+install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/hilti)"
+)# Get rid of symlink.
 
 ##### Tests
 

--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -64,8 +64,8 @@ install(TARGETS spicy-rt spicy-rt-debug ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBD
 
 install_headers(include spicy/rt)
 install_headers(${PROJECT_BINARY_DIR}/include/spicy/rt spicy/rt)
-install(CODE "file(REMOVE_RECURSE ${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/rt/spicy)"
-)# Get rid of symlink
+install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/rt/spicy)"
+)# Get rid of symlink.
 
 ##### Tests
 

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -172,7 +172,8 @@ install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build DESTINATION ${CMA
 
 install_headers(include spicy)
 install_headers(${PROJECT_BINARY_DIR}/include/spicy spicy)
-install(CODE "file(REMOVE ${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/spicy)") # Get rid of symlink
+install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/spicy)"
+)# Get rid of symlink.
 
 ## Tests
 


### PR DESCRIPTION
We previously did not take `DESTDIR` installs into account when removing
symlinks in the installation directory, so we never actually removed
symlinks for `DESTDIR` installs.

Closes #1201.