### PR TITLE
Allow changing `DESTDIR` between configure and install time.

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -95,7 +95,7 @@ install(TARGETS hilti-rt hilti-rt-debug ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBD
 
 install_headers(include hilti/rt)
 install_headers(${PROJECT_BINARY_DIR}/include/hilti/rt hilti/rt)
-install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/rt/hilti)"
+install(CODE "file(REMOVE \"\$ENV\{DESTDIR\}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/rt/hilti\")"
 )# Get rid of symlink.
 
 # Install the 3rdparty headers that we need individually.

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -186,7 +186,7 @@ install(TARGETS hilti-config RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install_headers(include hilti)
 install_headers(${PROJECT_BINARY_DIR}/include/hilti hilti)
-install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/hilti)"
+install(CODE "file(REMOVE \"\$ENV\{DESTDIR\}${CMAKE_INSTALL_FULL_INCLUDEDIR}/hilti/hilti\")"
 )# Get rid of symlink.
 
 ##### Tests

--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -64,7 +64,7 @@ install(TARGETS spicy-rt spicy-rt-debug ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBD
 
 install_headers(include spicy/rt)
 install_headers(${PROJECT_BINARY_DIR}/include/spicy/rt spicy/rt)
-install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/rt/spicy)"
+install(CODE "file(REMOVE \"\$ENV\{DESTDIR\}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/rt/spicy\")"
 )# Get rid of symlink.
 
 ##### Tests

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -172,7 +172,7 @@ install(PROGRAMS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build DESTINATION ${CMA
 
 install_headers(include spicy)
 install_headers(${PROJECT_BINARY_DIR}/include/spicy spicy)
-install(CODE "file(REMOVE $ENV{DESTDIR}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/spicy)"
+install(CODE "file(REMOVE \"\$ENV\{DESTDIR\}${CMAKE_INSTALL_FULL_INCLUDEDIR}/spicy/spicy\")"
 )# Get rid of symlink.
 
 ## Tests


### PR DESCRIPTION
We previously would back to value of `DESTDIR` in at configure time.
This made it impossible to change its value at install time so that
e.g., typical uses like

    make DESTDIR=<dest> install

did not perform like expected, i.e., symlinks which were supposed to be
removed at install time did not get removed due to incorrect paths. With
this patch we now evaluate the value of `DESTDIR` at install time
instead.