### PR TITLE
Incremental performance tweaks for JIT

### DIFF
--- a/hilti/toolchain/include/ast/operator.api
+++ b/hilti/toolchain/include/ast/operator.api
@@ -62,7 +62,7 @@ class Operator(trait::isOperator) {
      *
      * @return
      */
-    std::vector<hilti::operator_::Operand> operands() const;
+    const std::vector<hilti::operator_::Operand>& operands() const;
 
     /**
      * Creates an expression representing this operator instantied with a

--- a/hilti/toolchain/include/ast/operators/address.h
+++ b/hilti/toolchain/include/ast/operators/address.h
@@ -12,14 +12,15 @@ STANDARD_OPERATOR_2(address, Equal, type::Bool(), type::Address(), type::Address
 STANDARD_OPERATOR_2(address, Unequal, type::Bool(), type::Address(), type::Address(), "Compares two address values.")
 
 BEGIN_METHOD(address, Family)
-    auto signature() const {
-        return Signature{.self = type::Address(),
-                         .result = builder::typeByID("hilti::AddressFamily"),
-                         .id = "family",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Address(),
+                                           .result = builder::typeByID("hilti::AddressFamily"),
+                                           .id = "family",
+                                           .args = {},
+                                           .doc = R"(
 Returns the protocol family of the address, which can be IPv4 or IPv6.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/bytes.h
+++ b/hilti/toolchain/include/ast/operators/bytes.h
@@ -86,12 +86,12 @@ STANDARD_OPERATOR_2x(bytes, SumAssignUInt8, SumAssign, type::Bytes(), type::Byte
                      "Appends a single byte to the data.");
 
 BEGIN_METHOD(bytes, Find)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Tuple({type::Bool(), type::bytes::Iterator()}),
-                         .id = "find",
-                         .args = {{"needle", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Tuple({type::Bool(), type::bytes::Iterator()}),
+                                           .id = "find",
+                                           .args = {{"needle", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Searches *needle* in the value's content. Returns a tuple of a boolean and an
 iterator. If *needle* was found, the boolean will be true and the iterator will
 point to its first occurrence. If *needle* was not found, the boolean will be
@@ -100,273 +100,297 @@ it is guaranteed to not contain even a partial match of *needle*. Note that for 
 simple yes/no result, you should use the ``in`` operator instead of this method,
 as it's more efficient.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, LowerCase)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "lower",
-                         .args = {{"charset", type::Enum(type::Wildcard()), false,
-                                   builder::id("hilti::Charset::UTF8")}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Bytes(),
+                      .id = "lower",
+                      .args = {{"charset", type::Enum(type::Wildcard()), false, builder::id("hilti::Charset::UTF8")}},
+                      .doc = R"(
 Returns a lower-case version of the bytes value, assuming it is encoded in character set *charset*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, UpperCase)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "upper",
-                         .args = {{"charset", type::Enum(type::Wildcard()), false,
-                                   builder::id("hilti::Charset::UTF8")}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Bytes(),
+                      .id = "upper",
+                      .args = {{"charset", type::Enum(type::Wildcard()), false, builder::id("hilti::Charset::UTF8")}},
+                      .doc = R"(
 Returns an upper-case version of the bytes value, assuming it is encoded in character set *charset*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, At)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::bytes::Iterator(),
-                         .id = "at",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::bytes::Iterator(),
+                                           .id = "at",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Returns an iterator representing the offset *i* inside the bytes value.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Split)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Vector(type::Bytes()),
-                         .id = "split",
-                         .args = {{"sep", type::constant(type::Bytes()), true}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Vector(type::Bytes()),
+                                           .id = "split",
+                                           .args = {{"sep", type::constant(type::Bytes()), true}},
+                                           .doc = R"(
 Splits the bytes value at each occurrence of *sep* and returns a vector
 containing the individual pieces, with all separators removed. If the separator
 is not found, the returned vector will have the whole bytes value as its single
 element. If the separator is not given, or empty, the split will take place at
 sequences of white spaces.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Split1)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Tuple({type::Bytes(), type::Bytes()}),
-                         .id = "split1",
-                         .args = {{"sep", type::constant(type::Bytes()), true}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Tuple({type::Bytes(), type::Bytes()}),
+                                           .id = "split1",
+                                           .args = {{"sep", type::constant(type::Bytes()), true}},
+                                           .doc = R"(
 Splits the bytes value at the first occurrence of *sep* and returns the two parts
 as a 2-tuple, with the separator removed. If the separator is not found, the
 returned tuple will have the whole bytes value as its first element and an empty value
 as its second element. If the separator is not given, or empty, the split will
 take place at the first sequence of white spaces.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, StartsWith)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bool(),
-                         .id = "starts_with",
-                         .args = {{"b", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Bool(),
+                                           .id = "starts_with",
+                                           .args = {{"b", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Returns true if the bytes value starts with *b*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Strip)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "strip",
-                         .args = {{"side", type::constant(type::Library("::hilti::rt::bytes::Side")), true},
-                                  {"set", type::constant(type::Bytes()), true}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Bytes(),
+                      .id = "strip",
+                      .args = {{"side", type::constant(type::Library("::hilti::rt::bytes::Side")), true},
+                               {"set", type::constant(type::Bytes()), true}},
+                      .doc = R"(
 Removes leading and/or trailing sequences of all characters in *set* from the bytes
 value. If *set* is not given, removes all white spaces. If *side* is given,
 it indicates which side of the value should be stripped; ``Side::Both`` is the
 default if not given.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, SubIterators)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "sub",
-                         .args = {{"begin", type::bytes::Iterator()}, {"end", type::bytes::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Bytes(),
+                      .id = "sub",
+                      .args = {{"begin", type::bytes::Iterator()}, {"end", type::bytes::Iterator()}},
+                      .doc = R"(
 Returns the subsequence from *begin* to (but not including) *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, SubIterator)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "sub",
-                         .args = {{"end", type::bytes::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Bytes(),
+                                           .id = "sub",
+                                           .args = {{"end", type::bytes::Iterator()}},
+                                           .doc = R"(
 Returns the subsequence from the value's beginning to (but not including) *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, SubOffsets)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "sub",
-                         .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Bytes(),
+                      .id = "sub",
+                      .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
+                      .doc = R"(
 Returns the subsequence from offset *begin* to (but not including) offset *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Join)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Bytes(),
-                         .id = "join",
-                         .args = {{"parts", type::Vector(type::Wildcard())}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Bytes(),
+                                           .id = "join",
+                                           .args = {{"parts", type::Vector(type::Wildcard())}},
+                                           .doc =
+                                               R"(
 Returns the concatenation of all elements in the *parts* list rendered as
 printable strings. The portions will be separated by the bytes value to
 which this method is invoked as a member.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToIntAscii)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::SignedInteger(64),
-                         .id = "to_int",
-                         .args = {{"base", type::UnsignedInteger(64), true}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::SignedInteger(64),
+                                           .id = "to_int",
+                                           .args = {{"base", type::UnsignedInteger(64), true}},
+                                           .doc =
+                                               R"(
 Interprets the data as representing an ASCII-encoded number and converts that
 into a signed integer, using a base of *base*. *base* must be between 2 and 36.
 If *base* is not given, the default is 10.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToUIntAscii)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::UnsignedInteger(64),
-                         .id = "to_uint",
-                         .args = {{"base", type::UnsignedInteger(64), true}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::UnsignedInteger(64),
+                                           .id = "to_uint",
+                                           .args = {{"base", type::UnsignedInteger(64), true}},
+                                           .doc =
+                                               R"(
 Interprets the data as representing an ASCII-encoded number and converts that
 into an unsigned integer, using a base of *base*. *base* must be between 2 and
 36. If *base* is not given, the default is 10.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToIntBinary)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::SignedInteger(64),
-                         .id = "to_int",
-                         .args = {{"byte_order", type::Enum(type::Wildcard())}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::SignedInteger(64),
+                                           .id = "to_int",
+                                           .args = {{"byte_order", type::Enum(type::Wildcard())}},
+                                           .doc =
+                                               R"(
 Interprets the ``bytes`` as representing an binary number encoded with the given
 byte order, and converts it into signed integer.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToUIntBinary)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::UnsignedInteger(64),
-                         .id = "to_uint",
-                         .args = {{"byte_order", type::Enum(type::Wildcard())}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::UnsignedInteger(64),
+                                           .id = "to_uint",
+                                           .args = {{"byte_order", type::Enum(type::Wildcard())}},
+                                           .doc =
+                                               R"(
 Interprets the ``bytes`` as representing an binary number encoded with the given
 byte order, and converts it into an unsigned integer.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToTimeAscii)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Time(),
-                         .id = "to_time",
-                         .args = {{"base", type::UnsignedInteger(64), true}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Time(),
+                                           .id = "to_time",
+                                           .args = {{"base", type::UnsignedInteger(64), true}},
+                                           .doc =
+                                               R"(
 Interprets the ``bytes`` as representing a number of seconds since the epoch in
 the form of an ASCII-encoded number, and converts it into a time value using a
 base of *base*. If *base* is not given, the default is 10.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, ToTimeBinary)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Time(),
-                         .id = "to_time",
-                         .args = {{"byte_order", type::Enum(type::Wildcard())}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Bytes()),
+                                           .result = type::Time(),
+                                           .id = "to_time",
+                                           .args = {{"byte_order", type::Enum(type::Wildcard())}},
+                                           .doc =
+                                               R"(
 Interprets the ``bytes`` as representing as number of seconds since the epoch in
 the form of an binary number encoded with the given byte order, and converts it
 into a time value.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Decode)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::String(),
-                         .id = "decode",
-                         .args = {{"charset", type::Enum(type::Wildcard()), false,
-                                   builder::id("hilti::Charset::UTF8")}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::String(),
+                      .id = "decode",
+                      .args = {{"charset", type::Enum(type::Wildcard()), false, builder::id("hilti::Charset::UTF8")}},
+                      .doc =
+                          R"(
 Interprets the ``bytes`` as representing an binary string encoded with the given
 character set, and converts it into a UTF8 string.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(bytes, Match)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Bytes()),
-                         .result = type::Result(type::Bytes()),
-                         .id = "match",
-                         .args = {{"regex", type::RegExp()}, {"group", type::UnsignedInteger(64), true}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Bytes()),
+                      .result = type::Result(type::Bytes()),
+                      .id = "match",
+                      .args = {{"regex", type::RegExp()}, {"group", type::UnsignedInteger(64), true}},
+                      .doc =
+                          R"(
 Matches the ``bytes`` object against the regular expression *regex*. Returns
 the matching part or, if *group* is given, then the corresponding subgroup. The
 expression is considered anchored to the beginning of the data.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/common.h
+++ b/hilti/toolchain/include/ast/operators/common.h
@@ -50,7 +50,7 @@ private:                                                                        
 
 /** Ends definition of a method call operator. */
 #define END_OPERATOR                                                                                                   \
-    std::vector<hilti::operator_::Operand> operands() const { return signature().args; }                               \
+    const std::vector<hilti::operator_::Operand>& operands() const { return signature().args; }                        \
                                                                                                                        \
     std::string doc() const { return signature().doc; }                                                                \
                                                                                                                        \
@@ -103,13 +103,14 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_1(ns, op, result_, ty_op1, doc_)                                                             \
     BEGIN_OPERATOR(ns, op)                                                                                             \
-        auto signature() const {                                                                                       \
-            return hilti::operator_::Signature{.result = result_,                                                      \
-                                               .args =                                                                 \
-                                                   {                                                                   \
-                                                       {"op", ty_op1},                                                 \
-                                                   },                                                                  \
-                                               .doc = doc_};                                                           \
+        const auto& signature() const {                                                                                \
+            static hilti::operator_::Signature _signature = {.result = result_,                                        \
+                                                             .args =                                                   \
+                                                                 {                                                     \
+                                                                     {"op", ty_op1},                                   \
+                                                                 },                                                    \
+                                                             .doc = doc_};                                             \
+            return _signature;                                                                                         \
         }                                                                                                              \
     END_OPERATOR
 
@@ -118,13 +119,14 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_1x(ns, cls, op, result_, ty_op1, doc_)                                                       \
     __BEGIN_OPERATOR_CUSTOM(ns, op, cls)                                                                               \
-    auto signature() const {                                                                                           \
-        return hilti::operator_::Signature{.result = result_,                                                          \
-                                           .args =                                                                     \
-                                               {                                                                       \
-                                                   {"op", ty_op1},                                                     \
-                                               },                                                                      \
-                                           .doc = doc_};                                                               \
+    const auto& signature() const {                                                                                    \
+        static hilti::operator_::Signature _signature = {.result = result_,                                            \
+                                                         .args =                                                       \
+                                                             {                                                         \
+                                                                 {"op", ty_op1},                                       \
+                                                             },                                                        \
+                                                         .doc = doc_};                                                 \
+        return _signature;                                                                                             \
     }                                                                                                                  \
     END_OPERATOR
 
@@ -133,10 +135,11 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_2(ns, op, result_, ty_op1, ty_op2, doc_)                                                     \
     BEGIN_OPERATOR(ns, op)                                                                                             \
-        auto signature() const {                                                                                       \
-            return hilti::operator_::Signature{.result = result_,                                                      \
-                                               .args = {{"op0", ty_op1}, {"op1", ty_op2}},                             \
-                                               .doc = doc_};                                                           \
+        const auto& signature() const {                                                                                \
+            static hilti::operator_::Signature _signature = {.result = result_,                                        \
+                                                             .args = {{"op0", ty_op1}, {"op1", ty_op2}},               \
+                                                             .doc = doc_};                                             \
+            return _signature;                                                                                         \
         }                                                                                                              \
     END_OPERATOR
 
@@ -145,10 +148,11 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_2x(ns, cls, op, result_, ty_op1, ty_op2, doc_)                                               \
     __BEGIN_OPERATOR_CUSTOM(ns, op, cls)                                                                               \
-    auto signature() const {                                                                                           \
-        return hilti::operator_::Signature{.result = result_,                                                          \
-                                           .args = {{"op0", ty_op1}, {"op1", ty_op2}},                                 \
-                                           .doc = doc_};                                                               \
+    const auto& signature() const {                                                                                    \
+        static hilti::operator_::Signature _signature = {.result = result_,                                            \
+                                                         .args = {{"op0", ty_op1}, {"op1", ty_op2}},                   \
+                                                         .doc = doc_};                                                 \
+        return _signature;                                                                                             \
     }                                                                                                                  \
     END_OPERATOR
 
@@ -157,11 +161,12 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_2x_low_prio(ns, cls, op, result_, ty_op1, ty_op2, doc_)                                      \
     __BEGIN_OPERATOR_CUSTOM(ns, op, cls)                                                                               \
-    auto signature() const {                                                                                           \
-        return hilti::operator_::Signature{.priority = operator_::Priority::Low,                                       \
-                                           .result = result_,                                                          \
-                                           .args = {{"op0", ty_op1}, {"op1", ty_op2}},                                 \
-                                           .doc = doc_};                                                               \
+    const auto& signature() const {                                                                                    \
+        static hilti::operator_::Signature _signature = {.priority = operator_::Priority::Low,                         \
+                                                         .result = result_,                                            \
+                                                         .args = {{"op0", ty_op1}, {"op1", ty_op2}},                   \
+                                                         .doc = doc_};                                                 \
+        return _signature;                                                                                             \
     }                                                                                                                  \
     END_OPERATOR
 
@@ -170,11 +175,12 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_2x_lhs(ns, cls, op, result_, ty_op1, ty_op2, doc_)                                           \
     __BEGIN_OPERATOR_CUSTOM(ns, op, cls)                                                                               \
-    auto signature() const {                                                                                           \
-        return hilti::operator_::Signature{.lhs = true,                                                                \
-                                           .result = result_,                                                          \
-                                           .args = {{"op0", ty_op1}, {"op1", ty_op2}},                                 \
-                                           .doc = doc_};                                                               \
+    const auto& signature() const {                                                                                    \
+        static hilti::operator_::Signature _signature = {.lhs = true,                                                  \
+                                                         .result = result_,                                            \
+                                                         .args = {{"op0", ty_op1}, {"op1", ty_op2}},                   \
+                                                         .doc = doc_};                                                 \
+        return _signature;                                                                                             \
     }                                                                                                                  \
     END_OPERATOR
 
@@ -183,10 +189,10 @@ private:                                                                        
  */
 #define STANDARD_OPERATOR_3(ns, op, result_, ty_op1, ty_op2, ty_op3, doc_)                                             \
     BEGIN_OPERATOR(ns, op)                                                                                             \
-        auto signature() const {                                                                                       \
-            return hilti::operator_::Signature{.result = result_,                                                      \
-                                               .args = {{"op0", ty_op1}, {"op1", ty_op2}, {"op2", ty_op3}},            \
-                                               .doc = doc_};                                                           \
+        const auto& signature() const {                                                                                \
+            static hilti::operator_::Signature _signature =                                                            \
+                {.result = result_, .args = {{"op0", ty_op1}, {"op1", ty_op2}, {"op2", ty_op3}}, .doc = doc_};         \
+            return _signature;                                                                                         \
         }                                                                                                              \
     END_OPERATOR
 
@@ -210,10 +216,11 @@ private:                                                                        
 
 /** Internal helper macro. */
 #define __END_METHOD                                                                                                   \
-    std::vector<hilti::operator_::Operand> operands() const {                                                          \
-        return {{{}, signature().self},                                                                                \
-                {{}, hilti::type::Member(signature().id)},                                                             \
-                {{}, hilti::type::OperandList(signature().args)}};                                                     \
+    const std::vector<hilti::operator_::Operand>& operands() const {                                                   \
+        static std::vector<hilti::operator_::Operand> _operands = {{{}, signature().self},                             \
+                                                                   {{}, hilti::type::Member(signature().id)},          \
+                                                                   {{}, hilti::type::OperandList(signature().args)}};  \
+        return _operands;                                                                                              \
     }                                                                                                                  \
                                                                                                                        \
     std::string doc() const { return signature().doc; }
@@ -250,8 +257,10 @@ private:                                                                        
 #define BEGIN_CTOR(ns, cls) __BEGIN_OPERATOR_CUSTOM(ns, Call, cls)
 
 #define END_CTOR                                                                                                       \
-    std::vector<hilti::operator_::Operand> operands() const {                                                          \
-        return {{{}, hilti::type::Type_(ctorType())}, {{}, hilti::type::OperandList(signature().args)}};               \
+    const std::vector<hilti::operator_::Operand>& operands() const {                                                   \
+        static std::vector<hilti::operator_::Operand> _operands = {{{}, hilti::type::Type_(ctorType())},               \
+                                                                   {{}, hilti::type::OperandList(signature().args)}};  \
+        return _operands;                                                                                              \
     }                                                                                                                  \
                                                                                                                        \
     std::string doc() const { return signature().doc; }                                                                \

--- a/hilti/toolchain/include/ast/operators/enum.h
+++ b/hilti/toolchain/include/ast/operators/enum.h
@@ -27,37 +27,40 @@ STANDARD_OPERATOR_2x(
 BEGIN_CTOR(enum_, CtorSigned)
     auto ctorType() const { return type::Enum(type::Wildcard()); }
 
-    auto signature() const {
-        return Signature{.args = {{"value", type::SignedInteger(type::Wildcard())}}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.args = {{"value", type::SignedInteger(type::Wildcard())}}, .doc = R"(
 Instantiates an enum instance initialized from a signed integer value. The value does
 *not* need to correspond to any of the type's enumerator labels.
 )"};
+        return _signature;
     }
 END_CTOR
 
 BEGIN_CTOR(enum_, CtorUnsigned)
     auto ctorType() const { return type::Enum(type::Wildcard()); }
 
-    auto signature() const {
-        return Signature{.args = {{"value", type::UnsignedInteger(type::Wildcard())}}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.args = {{"value", type::UnsignedInteger(type::Wildcard())}}, .doc = R"(
 Instantiates an enum instance initialized from an unsigned integer
 value. The value does *not* need to correspond to any of the type's
 enumerator labels. It must not be larger than the maximum that a
 *signed* 64-bit integer value can represent.
 )"};
+        return _signature;
     }
 END_CTOR
 
 BEGIN_METHOD(enum_, HasLabel)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Enum(type::Wildcard())),
-                         .result = type::Bool(),
-                         .id = "has_label",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Enum(type::Wildcard())),
+                                           .result = type::Bool(),
+                                           .id = "has_label",
+                                           .args = {},
+                                           .doc = R"(
 Returns *true* if the value of *op1* corresponds to a known enum label (other
 than ``Undef``), as defined by it's type.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/error.h
+++ b/hilti/toolchain/include/ast/operators/error.h
@@ -8,12 +8,13 @@
 namespace hilti::operator_ { // NOLINT(modernize-concat-nested-namespaces)
 
 BEGIN_METHOD(error, Description)
-    auto signature() const {
-        return Signature{.self = type::Error(),
-                         .result = type::String(),
-                         .id = "description",
-                         .args = {},
-                         .doc = "Retrieves the textual description associated with the error."};
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Error(),
+                                           .result = type::String(),
+                                           .id = "description",
+                                           .args = {},
+                                           .doc = "Retrieves the textual description associated with the error."};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/exception.h
+++ b/hilti/toolchain/include/ast/operators/exception.h
@@ -10,22 +10,24 @@ namespace hilti::operator_ {
 BEGIN_CTOR(exception, Ctor)
     auto ctorType() const { return type::Exception(type::Wildcard()); }
 
-    auto signature() const {
-        return Signature{.args = {{"msg", type::String()}}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.args = {{"msg", type::String()}}, .doc = R"(
 Instantiates an instance of the exception type carrying the error message *msg*.
 )"};
+        return _signature;
     }
 END_CTOR
 
 BEGIN_METHOD(exception, Description)
-    auto signature() const {
-        return Signature{.self = type::Exception(type::Wildcard()),
-                         .result = type::String(),
-                         .id = "description",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Exception(type::Wildcard()),
+                                           .result = type::String(),
+                                           .id = "description",
+                                           .args = {},
+                                           .doc = R"(
 Returns the textual message associated with an exception object.
 )"};
+        return _signature;
     }
 END_METHOD
 } // namespace hilti::operator_

--- a/hilti/toolchain/include/ast/operators/function.h
+++ b/hilti/toolchain/include/ast/operators/function.h
@@ -31,7 +31,7 @@ public:
         }
 
         static operator_::Kind kind() { return operator_::Kind::Call; }
-        std::vector<operator_::Operand> operands() const { return _operands; }
+        const std::vector<operator_::Operand>& operands() const { return _operands; }
         Type result(const hilti::node::Range<Expression>& /* ops */) const { return _result; }
         bool isLhs() const { return false; }
         auto priority() const { return hilti::operator_::Priority::Normal; }

--- a/hilti/toolchain/include/ast/operators/generic.h
+++ b/hilti/toolchain/include/ast/operators/generic.h
@@ -29,8 +29,10 @@ BEGIN_OPERATOR_CUSTOM(generic, Unpack)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {Operand{{}, type::Type_(type::Wildcard())}, Operand{{}, type::Tuple(type::Wildcard())}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {Operand{{}, type::Type_(type::Wildcard())},
+                                                 Operand{{}, type::Tuple(type::Wildcard())}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -54,10 +56,11 @@ BEGIN_OPERATOR_CUSTOM(generic, Begin)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {
             Operand{{}, type::Any(), false, {}, "<container>"},
         };
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -79,10 +82,11 @@ BEGIN_OPERATOR_CUSTOM(generic, End)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {
             {{}, type::Any(), false, {}, "<container>"},
         };
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -109,11 +113,12 @@ BEGIN_OPERATOR_CUSTOM(generic, New)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {
             {"t", type::Any()},
             {{}, type::Tuple(type::Wildcard())},
         };
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -152,7 +157,10 @@ public:
         Operator() = default;
 
         static operator_::Kind kind() { return operator_::Kind::Cast; }
-        std::vector<operator_::Operand> operands() const { return {}; } // Won't participate in overload resolution
+        const std::vector<operator_::Operand>& operands() const {
+            static std::vector<Operand> _operands = {}; // Won't participate in overload resolution
+            return _operands;
+        }
         Type result(const hilti::node::Range<Expression>& ops) const {
             return ops[1].as<expression::Type_>().typeValue();
         }

--- a/hilti/toolchain/include/ast/operators/interval.h
+++ b/hilti/toolchain/include/ast/operators/interval.h
@@ -28,22 +28,25 @@ STANDARD_OPERATOR_2x(interval, MultipleReal, Multiple, type::Interval(), type::I
                      "Multiplies the interval with the given factor.");
 
 BEGIN_METHOD(interval, Seconds)
-    auto signature() const {
-        return Signature{.self = type::Interval(), .result = type::Real(), .id = "seconds", .args = {}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Interval(), .result = type::Real(), .id = "seconds", .args = {}, .doc = R"(
 Returns the interval as a real value representing seconds.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(interval, Nanoseconds)
-    auto signature() const {
-        return Signature{.self = type::Interval(),
-                         .result = type::SignedInteger(64),
-                         .id = "nanoseconds",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Interval(),
+                                           .result = type::SignedInteger(64),
+                                           .id = "nanoseconds",
+                                           .args = {},
+                                           .doc = R"(
 Returns the interval as an integer value representing nanoseconds.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/map.h
+++ b/hilti/toolchain/include/ast/operators/map.h
@@ -74,27 +74,26 @@ STANDARD_OPERATOR_3(map, IndexAssign, type::void_, type::Map(type::Wildcard()), 
                     "Updates the map value for a given key. If the key does not exist a new element is inserted.");
 
 BEGIN_METHOD(map, Get)
-    auto signature() const {
-        return Signature{.self = type::Map(type::Wildcard()),
-                         .result = operator_::elementType(0),
-                         .id = "get",
-                         .args = {{"key", type::Any()}, {"default", type::Any(), true}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Map(type::Wildcard()),
+                                           .result = operator_::elementType(0),
+                                           .id = "get",
+                                           .args = {{"key", type::Any()}, {"default", type::Any(), true}},
+                                           .doc = R"(
 Returns the map's element for the given key. If the key does not exist, returns
 the default value if provided; otherwise throws a runtime error.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(map, Clear)
-    auto signature() const {
-        return Signature{.self = type::Map(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "clear",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Map(type::Wildcard()), .result = type::void_, .id = "clear", .args = {}, .doc = R"(
 Removes all elements from the map.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/network.h
+++ b/hilti/toolchain/include/ast/operators/network.h
@@ -15,34 +15,35 @@ STANDARD_OPERATOR_2(network, In, type::Bool(), type::Address(), type::Network(),
                     "Returns true if the address is part of the network range.")
 
 BEGIN_METHOD(network, Family)
-    auto signature() const {
-        return Signature{.self = type::Network(),
-                         .result = builder::typeByID("hilti::AddressFamily"),
-                         .id = "family",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Network(),
+                                           .result = builder::typeByID("hilti::AddressFamily"),
+                                           .id = "family",
+                                           .args = {},
+                                           .doc = R"(
 Returns the protocol family of the network, which can be IPv4 or IPv6.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(network, Prefix)
-    auto signature() const {
-        return Signature{.self = type::Network(), .result = type::Address(), .id = "prefix", .args = {}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Network(), .result = type::Address(), .id = "prefix", .args = {}, .doc = R"(
 Returns the network's prefix as a masked IP address.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(network, Length)
-    auto signature() const {
-        return Signature{.self = type::Network(),
-                         .result = type::SignedInteger(64),
-                         .id = "length",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Network(), .result = type::SignedInteger(64), .id = "length", .args = {}, .doc = R"(
 Returns the length of the network's prefix.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/port.h
+++ b/hilti/toolchain/include/ast/operators/port.h
@@ -12,14 +12,15 @@ STANDARD_OPERATOR_2(port, Equal, type::Bool(), type::Port(), type::Port(), "Comp
 STANDARD_OPERATOR_2(port, Unequal, type::Bool(), type::Port(), type::Port(), "Compares two port values.")
 
 BEGIN_METHOD(port, Protocol)
-    auto signature() const {
-        return Signature{.self = type::Port(),
-                         .result = builder::typeByID("hilti::Protocol"),
-                         .id = "protocol",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Port(),
+                                           .result = builder::typeByID("hilti::Protocol"),
+                                           .id = "protocol",
+                                           .args = {},
+                                           .doc = R"(
 Returns the protocol the port is using (such as UDP or TCP).
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/regexp.h
+++ b/hilti/toolchain/include/ast/operators/regexp.h
@@ -16,12 +16,12 @@
 namespace hilti::operator_ {
 
 BEGIN_METHOD(regexp, Match)
-    auto signature() const {
-        return Signature{.self = type::RegExp(),
-                         .result = type::SignedInteger(32),
-                         .id = "match",
-                         .args = {{"data", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::RegExp(),
+                                           .result = type::SignedInteger(32),
+                                           .id = "match",
+                                           .args = {{"data", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Matches the regular expression against *data*. If it matches, returns an
 integer that's greater than zero. If multiple patterns have been compiled for
 parallel matching, that integer will be the ID of the matching pattern. Returns
@@ -31,16 +31,17 @@ and adding more data wouldn't change anything. The expression is considered
 anchored, as though it starts with an implicit ``^`` regexp operator, to the
 beginning of the data.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(regexp, Find)
-    auto signature() const {
-        return Signature{.self = type::RegExp(),
-                         .result = type::Tuple({type::SignedInteger(32), type::Bytes()}),
-                         .id = "find",
-                         .args = {{"data", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::RegExp(),
+                                           .result = type::Tuple({type::SignedInteger(32), type::Bytes()}),
+                                           .id = "find",
+                                           .args = {{"data", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Searches the regular expression in *data* and returns the matching part.
 Different from ``match``, this does not anchor the expression to the beginning
 of the data: it will find matches at arbitrary starting positions. Returns a
@@ -50,16 +51,17 @@ the regular expression. (Note: Currently this function has a runtime that's
 quadratic in the size of *data*; consider using `match` if performance is an
 issue.)
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(regexp, MatchGroups)
-    auto signature() const {
-        return Signature{.self = type::RegExp(),
-                         .result = type::Vector(type::Bytes()),
-                         .id = "match_groups",
-                         .args = {{"data", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::RegExp(),
+                                           .result = type::Vector(type::Bytes()),
+                                           .id = "match_groups",
+                                           .args = {{"data", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Matches the regular expression against *data*. If it matches, returns a vector
 with one entry for each capture group defined by the regular expression;
 starting at index 1. Each of these entries is a view locating the matching
@@ -70,31 +72,33 @@ regexp operator, to the beginning of the data. This method is not compatible
 with pattern sets and will throw a runtime exception if used with a regular
 expression compiled from a set.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(regexp, TokenMatcher)
-    auto signature() const {
-        return Signature{.self = type::RegExp(),
-                         .result = builder::typeByID("hilti::MatchState"),
-                         .id = "token_matcher",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::RegExp(),
+                                           .result = builder::typeByID("hilti::MatchState"),
+                                           .id = "token_matcher",
+                                           .args = {},
+                                           .doc = R"(
 Initializes state for matching regular expression incrementally against chunks
 of future input. The expression is considered anchored, as though it starts
 with an implicit ``^`` regexp operator, to the beginning of the data.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(regexp_match_state, AdvanceBytes)
-    auto signature() const {
-        return Signature{.self = type::Library("::hilti::rt::regexp::MatchState"),
-                         .result = type::Tuple({type::SignedInteger(32), type::stream::View()}),
-                         .id = "advance",
-                         .args = {{"data", type::constant(type::Bytes())},
-                                  {"final", type::Bool(), false, expression::Ctor(ctor::Bool(true))}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Library("::hilti::rt::regexp::MatchState"),
+                                           .result = type::Tuple({type::SignedInteger(32), type::stream::View()}),
+                                           .id = "advance",
+                                           .args = {{"data", type::constant(type::Bytes())},
+                                                    {"final", type::Bool(), false, expression::Ctor(ctor::Bool(true))}},
+                                           .doc = R"(
 Feeds a chunk of data into the token match state, continuing matching where it
 left off last time. If *final* is true, this is assumed to be the final piece
 of data; any further advancing will then lead to an exception. Returns a
@@ -103,16 +107,17 @@ returned by ``regexp::match()``; and (2) the number of bytes in *data* consumed
 by the matching. The state must not be used again once an integer larger
 or equal zero has been returned.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(regexp_match_state, AdvanceView)
-    auto signature() const {
-        return Signature{.self = type::Library("::hilti::rt::regexp::MatchState"),
-                         .result = type::Tuple({type::SignedInteger(32), type::stream::View()}),
-                         .id = "advance",
-                         .args = {{"data", type::constant(type::stream::View())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Library("::hilti::rt::regexp::MatchState"),
+                                           .result = type::Tuple({type::SignedInteger(32), type::stream::View()}),
+                                           .id = "advance",
+                                           .args = {{"data", type::constant(type::stream::View())}},
+                                           .doc = R"(
 Feeds a chunk of data into the token match state, continuing matching where it
 left off last time. If the underlying view is frozen, this will be assumed to
 be last piece of data; any further advancing will then lead to an exception.
@@ -121,6 +126,7 @@ that returned by ``regexp::match()``; and (2) a new view that's trimming *data*
 to the part not yet consumed. The state must not be used again once an integer
 larger or equal zero has been returned.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/result.h
+++ b/hilti/toolchain/include/ast/operators/result.h
@@ -12,14 +12,16 @@ STANDARD_OPERATOR_1(result, Deref, operator_::dereferencedType(0), type::constan
                     "result is in an error state.");
 
 BEGIN_METHOD(result, Error)
-    auto signature() const {
-        return Signature{.self = type::Result(type::Wildcard()),
-                         .result = type::Error(),
-                         .id = "error",
-                         .args = {},
-                         .doc =
-                             "Retrieves the error stored inside the result instance. Will throw a ``NoError`` "
-                             "exception if the result is not in an error state."};
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Result(type::Wildcard()),
+                      .result = type::Error(),
+                      .id = "error",
+                      .args = {},
+                      .doc =
+                          "Retrieves the error stored inside the result instance. Will throw a ``NoError`` "
+                          "exception if the result is not in an error state."};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/set.h
+++ b/hilti/toolchain/include/ast/operators/set.h
@@ -41,14 +41,12 @@ STANDARD_OPERATOR_2(set, Delete, type::void_, type::Set(type::Wildcard()), opera
                     "Removes an element from the set.")
 
 BEGIN_METHOD(set, Clear)
-    auto signature() const {
-        return Signature{.self = type::Set(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "clear",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Set(type::Wildcard()), .result = type::void_, .id = "clear", .args = {}, .doc = R"(
 Removes all elements from the set.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/stream.h
+++ b/hilti/toolchain/include/ast/operators/stream.h
@@ -56,27 +56,29 @@ STANDARD_OPERATOR_2(stream::iterator, SumAssign, type::stream::Iterator(), type:
                     type::UnsignedInteger(64), "Advances the iterator by the given number of stream.")
 
 BEGIN_METHOD(stream::iterator, Offset)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::Iterator()),
-                         .result = type::UnsignedInteger(64),
-                         .id = "offset",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::Iterator()),
+                                           .result = type::UnsignedInteger(64),
+                                           .id = "offset",
+                                           .args = {},
+                                           .doc = R"(
 Returns the offset of the byte that the iterator refers to relative to the
 beginning of the underlying stream value.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::iterator, IsFrozen)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::Iterator()),
-                         .result = type::Bool(),
-                         .id = "is_frozen",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::Iterator()),
+                                           .result = type::Bool(),
+                                           .id = "is_frozen",
+                                           .args = {},
+                                           .doc = R"(
 Returns whether the stream value that the iterator refers to has been frozen.
 )"};
+        return _signature;
     }
 END_METHOD
 
@@ -100,77 +102,82 @@ STANDARD_OPERATOR_2x(stream::view, UnequalBytes, Unequal, type::Bool(), type::co
                      type::constant(type::Bytes()), "Compares a stream view and a bytes instance lexicographically.");
 
 BEGIN_METHOD(stream::view, Offset)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::UnsignedInteger(64),
-                         .id = "offset",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::UnsignedInteger(64),
+                                           .id = "offset",
+                                           .args = {},
+                                           .doc = R"(
 Returns the offset of the view's starting position within the associated stream value.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, AdvanceBy)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "advance",
-                         .args = {{"i", type::stream::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::View(),
+                                           .id = "advance",
+                                           .args = {{"i", type::stream::Iterator()}},
+                                           .doc = R"(
 Advances the view's starting position to a given iterator *i*, returning the new
 view. The iterator must be referring to the same stream values as the view, and
 it must be equal or ahead of the view's starting position.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, AdvanceToNextData)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "advance_to_next_data",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::View(),
+                                           .id = "advance_to_next_data",
+                                           .args = {},
+                                           .doc = R"(
 Advances the view's starting position to the next non-gap position. This always
 advances the input by at least one byte.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, Limit)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "limit",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::View(),
+                                           .id = "limit",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Returns a new view that keeps the current start but cuts off the end *i*
 characters from that beginning. The returned view will not be able to expand any
 further.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, AdvanceTo)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "advance",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::View(),
+                                           .id = "advance",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Advances the view's starting position by *i* stream, returning the new view.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, Find)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::Tuple({type::Bool(), type::stream::Iterator()}),
-                         .id = "find",
-                         .args = {{"needle", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::Tuple({type::Bool(), type::stream::Iterator()}),
+                                           .id = "find",
+                                           .args = {{"needle", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Searches *needle* inside the view's content. Returns a tuple of a boolean and an
 iterator. If *needle* was found, the boolean will be true and the iterator will point
 to its first occurrence. If *needle* was not found, the boolean will be false and
@@ -180,69 +187,77 @@ trim until that position and then restart the search from there if more data
 gets appended to the underlying stream value). Note that for a simple yes/no result,
 you should use the ``in`` operator instead of this method, as it's more efficient.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, At)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::Iterator(),
-                         .id = "at",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::Iterator(),
+                                           .id = "at",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Returns an iterator representing the offset *i* inside the view.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, StartsWith)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::Bool(),
-                         .id = "starts_with",
-                         .args = {{"b", type::constant(type::Bytes())}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::Bool(),
+                                           .id = "starts_with",
+                                           .args = {{"b", type::constant(type::Bytes())}},
+                                           .doc = R"(
 Returns true if the view starts with *b*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, SubIterators)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "sub",
-                         .args = {{"begin", type::stream::Iterator()}, {"end", type::stream::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::stream::View()),
+                      .result = type::stream::View(),
+                      .id = "sub",
+                      .args = {{"begin", type::stream::Iterator()}, {"end", type::stream::Iterator()}},
+                      .doc = R"(
 Returns a new view of the subsequence from *begin* up to (but not including)
 *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, SubIterator)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "sub",
-                         .args = {{"end", type::stream::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::stream::View()),
+                                           .result = type::stream::View(),
+                                           .id = "sub",
+                                           .args = {{"end", type::stream::Iterator()}},
+                                           .doc = R"(
 Returns a new view of the subsequence from the beginning of the stream up to
 (but not including) *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream::view, SubOffsets)
-    auto signature() const {
-        return Signature{.self = type::constant(type::stream::View()),
-                         .result = type::stream::View(),
-                         .id = "sub",
-                         .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::stream::View()),
+                      .result = type::stream::View(),
+                      .id = "sub",
+                      .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
+                      .doc = R"(
 Returns a new view of the subsequence from offset *begin* to (but not including)
 offset *end*. The offsets are relative to the beginning of the view.
 )"};
+        return _signature;
     }
 END_METHOD
 
@@ -258,56 +273,62 @@ STANDARD_OPERATOR_2x(stream, SumAssignBytes, SumAssign, type::Stream(), type::St
                      "Concatenates data to the stream.");
 
 BEGIN_METHOD(stream, Freeze)
-    auto signature() const {
-        return Signature{.self = type::Stream(), .result = type::void_, .id = "freeze", .args = {}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Stream(), .result = type::void_, .id = "freeze", .args = {}, .doc = R"(
 Freezes the stream value. Once frozen, one cannot append any more data to a
 frozen stream value (unless it gets unfrozen first). If the value is
 already frozen, the operation does not change anything.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream, Unfreeze)
-    auto signature() const {
-        return Signature{.self = type::Stream(), .result = type::void_, .id = "unfreeze", .args = {}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Stream(), .result = type::void_, .id = "unfreeze", .args = {}, .doc = R"(
 Unfreezes the stream value. A unfrozen stream value can be further modified. If
 the value is already unfrozen (which is the default), the operation does not
 change anything.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream, IsFrozen)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Stream()),
-                         .result = type::Bool(),
-                         .id = "is_frozen",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Stream()),
+                                           .result = type::Bool(),
+                                           .id = "is_frozen",
+                                           .args = {},
+                                           .doc = R"(
 Returns true if the stream value has been frozen.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream, At)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Stream()),
-                         .result = type::stream::Iterator(),
-                         .id = "at",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Stream()),
+                                           .result = type::stream::Iterator(),
+                                           .id = "at",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Returns an iterator representing the offset *i* inside the stream value.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(stream, Trim)
-    auto signature() const {
-        return Signature{.self = type::Stream(),
-                         .result = type::void_,
-                         .id = "trim",
-                         .args = {{"i", type::stream::Iterator()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Stream(),
+                                           .result = type::void_,
+                                           .id = "trim",
+                                           .args = {{"i", type::stream::Iterator()}},
+                                           .doc = R"(
 Trims the stream value by removing all data from its beginning up to (but not
 including) the position *i*. The iterator *i* will remain valid afterwards and
 will still point to the same location, which will now be the beginning of the stream's
@@ -316,6 +337,7 @@ their offsets as well. The effect of this operation is undefined if *i* does not
 actually refer to a location inside the stream value. Trimming is permitted
 even on frozen values.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/string.h
+++ b/hilti/toolchain/include/ast/operators/string.h
@@ -23,16 +23,17 @@ STANDARD_OPERATOR_2(string, Sum, type::String(), type::String(), type::String(),
                     "Returns the concatenation of two strings.");
 
 BEGIN_METHOD(string, Encode)
-    auto signature() const {
-        return Signature{.self = type::constant(type::String()),
-                         .result = type::Bytes(),
-                         .id = "encode",
-                         .args = {{"charset", type::Enum(type::Wildcard()), false,
-                                   builder::id("hilti::Charset::UTF8")}},
-                         .doc =
-                             R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::String()),
+                      .result = type::Bytes(),
+                      .id = "encode",
+                      .args = {{"charset", type::Enum(type::Wildcard()), false, builder::id("hilti::Charset::UTF8")}},
+                      .doc =
+                          R"(
 Converts the string into a binary representation encoded with the given character set.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/string.h
+++ b/hilti/toolchain/include/ast/operators/string.h
@@ -42,7 +42,10 @@ BEGIN_OPERATOR_CUSTOM(string, Modulo)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const { return {{{}, type::String()}, {{}, type::Any()}}; }
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::String()}, {{}, type::Any()}};
+        return _operands;
+    }
 
     void validate(const expression::ResolvedOperator& /* i */, operator_::position_t /* p */) const {
         // TODO(robin): Not sure if we need this restriction. Let's try without.

--- a/hilti/toolchain/include/ast/operators/struct.h
+++ b/hilti/toolchain/include/ast/operators/struct.h
@@ -55,9 +55,10 @@ BEGIN_OPERATOR_CUSTOM(struct_, Unset)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -82,9 +83,10 @@ BEGIN_OPERATOR_CUSTOM_x(struct_, MemberNonConst, Member)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -111,9 +113,11 @@ BEGIN_OPERATOR_CUSTOM_x(struct_, MemberConst, Member)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::constant(type::Struct(type::Wildcard())), false, {}, "struct"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands =
+            {{{}, type::constant(type::Struct(type::Wildcard())), false, {}, "struct"},
+             {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -140,9 +144,10 @@ BEGIN_OPERATOR_CUSTOM(struct_, TryMember)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Struct(type::Wildcard()), false, {}, "struct"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -167,9 +172,11 @@ BEGIN_OPERATOR_CUSTOM(struct_, HasMember)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::constant(type::Struct(type::Wildcard())), false, {}, "struct"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands =
+            {{{}, type::constant(type::Struct(type::Wildcard())), false, {}, "struct"},
+             {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -201,7 +208,7 @@ public:
         };
 
         static operator_::Kind kind() { return operator_::Kind::MemberCall; }
-        std::vector<operator_::Operand> operands() const { return _operands; }
+        const std::vector<operator_::Operand>& operands() const { return _operands; }
         Type result(const hilti::node::Range<Expression>& /* ops */) const { return _result; }
         bool isLhs() const { return false; }
         auto priority() const { return hilti::operator_::Priority::Normal; }

--- a/hilti/toolchain/include/ast/operators/time.h
+++ b/hilti/toolchain/include/ast/operators/time.h
@@ -27,22 +27,25 @@ STANDARD_OPERATOR_2(time, Lower, type::Bool(), type::Time(), type::Time(), "Comp
 STANDARD_OPERATOR_2(time, LowerEqual, type::Bool(), type::Time(), type::Time(), "Compares the times.");
 
 BEGIN_METHOD(time, Seconds)
-    auto signature() const {
-        return Signature{.self = type::Time(), .result = type::Real(), .id = "seconds", .args = {}, .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::Time(), .result = type::Real(), .id = "seconds", .args = {}, .doc = R"(
 Returns the time as a real value representing seconds since the UNIX epoch.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(time, Nanoseconds)
-    auto signature() const {
-        return Signature{.self = type::Time(),
-                         .result = type::UnsignedInteger(64),
-                         .id = "nanoseconds",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Time(),
+                                           .result = type::UnsignedInteger(64),
+                                           .id = "nanoseconds",
+                                           .args = {},
+                                           .doc = R"(
 Returns the time as an integer value representing nanoseconds since the UNIX epoch.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/operators/tuple.h
+++ b/hilti/toolchain/include/ast/operators/tuple.h
@@ -44,8 +44,9 @@ BEGIN_OPERATOR_CUSTOM(tuple, Index)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Tuple(type::Wildcard())}, {{}, type::UnsignedInteger(64)}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Tuple(type::Wildcard())}, {{}, type::UnsignedInteger(64)}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -81,8 +82,10 @@ BEGIN_OPERATOR_CUSTOM(tuple, Member)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Tuple(type::Wildcard())}, {{}, type::Member(type::Wildcard()), false, {}, "<id>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Tuple(type::Wildcard())},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<id>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {
@@ -107,17 +110,17 @@ BEGIN_OPERATOR_CUSTOM(tuple, CustomAssign)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
+    const std::vector<Operand>& operands() const {
         // The operator gets instantiated only through the normalizer, but this is used for documentation.
-        return {{
-                    {},
-                    type::Member(type::Wildcard()),
-                    false,
-                    {},
-                    "(x, ..., y)",
-                },
-                {{}, type::Tuple(type::Wildcard()), false, {}, "<tuple>"}};
-        return {};
+        static std::vector<Operand> _operands = {{
+                                                     {},
+                                                     type::Member(type::Wildcard()),
+                                                     false,
+                                                     {},
+                                                     "(x, ..., y)",
+                                                 },
+                                                 {{}, type::Tuple(type::Wildcard()), false, {}, "<tuple>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, operator_::position_t p) const {

--- a/hilti/toolchain/include/ast/operators/union.h
+++ b/hilti/toolchain/include/ast/operators/union.h
@@ -68,9 +68,11 @@ BEGIN_OPERATOR_CUSTOM_x(union_, MemberConst, Member)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::constant(type::Union(type::Wildcard())), false, {}, "union"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands =
+            {{{}, type::constant(type::Union(type::Wildcard())), false, {}, "union"},
+             {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, position_t p) const {
@@ -96,9 +98,10 @@ BEGIN_OPERATOR_CUSTOM_x(union_, MemberNonConst, Member)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Union(type::Wildcard()), false, {}, "union"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Union(type::Wildcard()), false, {}, "union"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, position_t p) const {
@@ -119,9 +122,10 @@ BEGIN_OPERATOR_CUSTOM(union_, HasMember)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Union(type::Wildcard()), false, {}, "union"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Union(type::Wildcard()), false, {}, "union"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const expression::ResolvedOperator& i, position_t p) const {

--- a/hilti/toolchain/include/ast/operators/vector.h
+++ b/hilti/toolchain/include/ast/operators/vector.h
@@ -45,133 +45,144 @@ STANDARD_OPERATOR_2(vector, SumAssign, operator_::sameTypeAs(0, "vector<*>"), ty
                     operator_::sameTypeAs(0, "vector<*>"), "Concatenates another vector to the vector.")
 
 BEGIN_METHOD(vector, Assign)
-    auto signature() const {
-        return Signature{.self = type::Vector(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "assign",
-                         .args = {{"i", type::UnsignedInteger(64)}, {"x", type::Any()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Vector(type::Wildcard()),
+                                           .result = type::void_,
+                                           .id = "assign",
+                                           .args = {{"i", type::UnsignedInteger(64)}, {"x", type::Any()}},
+                                           .doc = R"(
 Assigns *x* to the *i*th element of the vector. If the vector contains less
 than *i* elements a sufficient number of default-initialized elements is added
 to carry out the assignment.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, PushBack)
-    auto signature() const {
-        return Signature{.self = type::Vector(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "push_back",
-                         .args = {{"x", type::Any()}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Vector(type::Wildcard()),
+                                           .result = type::void_,
+                                           .id = "push_back",
+                                           .args = {{"x", type::Any()}},
+                                           .doc = R"(
 Appends *x* to the end of the vector.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, PopBack)
-    auto signature() const {
-        return Signature{.self = type::Vector(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "pop_back",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Vector(type::Wildcard()),
+                                           .result = type::void_,
+                                           .id = "pop_back",
+                                           .args = {},
+                                           .doc = R"(
 Removes the last element from the vector, which must be non-empty.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, Front)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
-                         .result = operator_::constantElementType(0),
-                         .id = "front",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                                           .result = operator_::constantElementType(0),
+                                           .id = "front",
+                                           .args = {},
+                                           .doc = R"(
 Returns the first element of the vector. It throws an exception if the vector is
 empty.
 )"};
+        return _signature;
     }
 END_METHOD
 
 
 BEGIN_METHOD(vector, Back)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
-                         .result = operator_::constantElementType(0),
-                         .id = "back",
-                         .args = {},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                                           .result = operator_::constantElementType(0),
+                                           .id = "back",
+                                           .args = {},
+                                           .doc = R"(
 Returns the last element of the vector. It throws an exception if the vector is
 empty.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, Reserve)
-    auto signature() const {
-        return Signature{.self = type::Vector(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "reserve",
-                         .args = {{"n", type::constant(type::UnsignedInteger(64))}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Vector(type::Wildcard()),
+                                           .result = type::void_,
+                                           .id = "reserve",
+                                           .args = {{"n", type::constant(type::UnsignedInteger(64))}},
+                                           .doc = R"(
 Reserves space for at least *n* elements. This operation does not change the
 vector in any observable way but provides a hint about the size that will be
 needed.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, Resize)
-    auto signature() const {
-        return Signature{.self = type::Vector(type::Wildcard()),
-                         .result = type::void_,
-                         .id = "resize",
-                         .args = {{"n", type::constant(type::UnsignedInteger(64))}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::Vector(type::Wildcard()),
+                                           .result = type::void_,
+                                           .id = "resize",
+                                           .args = {{"n", type::constant(type::UnsignedInteger(64))}},
+                                           .doc = R"(
 Resizes the vector to hold exactly *n* elements. If *n* is larger than the
 current size, the new slots are filled with default values. If *n* is smaller
 than the current size, the excessive elements are removed.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, At)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
-                         .result = operator_::iteratorType(0, true),
-                         .id = "at",
-                         .args = {{"i", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                                           .result = operator_::iteratorType(0, true),
+                                           .id = "at",
+                                           .args = {{"i", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Returns an iterator referring to the element at vector index *i*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, SubRange)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
-                         .result = operator_::sameTypeAs(0, "vector<*>"),
-                         .id = "sub",
-                         .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                      .result = operator_::sameTypeAs(0, "vector<*>"),
+                      .id = "sub",
+                      .args = {{"begin", type::UnsignedInteger(64)}, {"end", type::UnsignedInteger(64)}},
+                      .doc = R"(
 Extracts a subsequence of vector elements spanning from index *begin*
 to (but not including) index *end*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(vector, SubEnd)
-    auto signature() const {
-        return Signature{.self = type::constant(type::Vector(type::Wildcard())),
-                         .result = operator_::sameTypeAs(0, "vector<*>"),
-                         .id = "sub",
-                         .args = {{"end", type::UnsignedInteger(64)}},
-                         .doc = R"(
+    const auto& signature() const {
+        static auto _signature = Signature{.self = type::constant(type::Vector(type::Wildcard())),
+                                           .result = operator_::sameTypeAs(0, "vector<*>"),
+                                           .id = "sub",
+                                           .args = {{"end", type::UnsignedInteger(64)}},
+                                           .doc = R"(
 Extracts a subsequence of vector elements spanning from the beginning
 to (but not including) the index *end* as a new vector.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/hilti/toolchain/include/ast/type.h
+++ b/hilti/toolchain/include/ast/type.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <list>
-#include <set>
+#include <unordered_set>
 #include <utility>
 
 #include <hilti/ast/id.h>
@@ -44,7 +43,7 @@ class supportsWildcard {};
 class takesArguments {};
 } // namespace trait
 
-using ResolvedState = std::set<uintptr_t>;
+using ResolvedState = std::unordered_set<uintptr_t>;
 
 /** Additional flags to associated with types. */
 enum class Flag {

--- a/hilti/toolchain/include/ast/type.h
+++ b/hilti/toolchain/include/ast/type.h
@@ -169,13 +169,13 @@ public:
     /** Implements the `Type` interface. */
     bool hasFlag(type::Flag f) const { return _state().flags.has(f); }
     /** Implements the `Type` interface. */
-    type::Flags flags() const { return _state().flags; }
+    const type::Flags& flags() const { return _state().flags; }
     /** Implements the `Type` interface. */
     bool _isConstant() const { return _state().flags.has(type::Flag::Constant); }
     /** Implements the `Type` interface. */
-    std::optional<ID> typeID() const { return _state().id; }
+    const std::optional<ID>& typeID() const { return _state().id; }
     /** Implements the `Type` interface. */
-    std::optional<ID> cxxID() const { return _state().cxx; }
+    const std::optional<ID>& cxxID() const { return _state().cxx; }
     /** Implements the `Type` interface. */
     const type::detail::State& _state() const { return _state_; }
     /** Implements the `Type` interface. */

--- a/hilti/toolchain/src/compiler/coercion.cc
+++ b/hilti/toolchain/src/compiler/coercion.cc
@@ -16,6 +16,7 @@
 #include <hilti/ast/types/optional.h>
 #include <hilti/ast/types/reference.h>
 #include <hilti/ast/types/result.h>
+#include <hilti/base/logger.h>
 #include <hilti/compiler/coercion.h>
 #include <hilti/compiler/plugin.h>
 #include <hilti/global.h>
@@ -981,17 +982,18 @@ static CoercedExpression _coerceExpression(const Expression& e, const Type& src,
     _result = result::Error();
 
 exit:
-    HILTI_DEBUG(logging::debug::Operator,
-                util::fmt("coercing %s %s (%s) to %s%s (%s) -> %s [%s] (%s) (#%d)",
-                          (e_is_const ? "const" : "non-const"), to_node(src),
-                          util::replace(src.typename_(), "hilti::type::", ""), (dst_is_const ? "" : "non-const "),
-                          to_node(dst), util::replace(dst.typename_(), "hilti::type::", ""),
-                          (_result ?
-                               util::fmt("%s %s (%s)", (_result.coerced->isConstant() ? "const" : "non-const"),
-                                         _result.coerced->type(),
-                                         util::replace(_result.coerced->type().typename_(), "hilti::type::", "")) :
-                               "fail"),
-                          to_string(style), e.meta().location(), _line));
+    if ( logger().isEnabled(logging::debug::Operator) )
+        HILTI_DEBUG(logging::debug::Operator,
+                    util::fmt("coercing %s %s (%s) to %s%s (%s) -> %s [%s] (%s) (#%d)",
+                              (e_is_const ? "const" : "non-const"), to_node(src),
+                              util::replace(src.typename_(), "hilti::type::", ""), (dst_is_const ? "" : "non-const "),
+                              to_node(dst), util::replace(dst.typename_(), "hilti::type::", ""),
+                              (_result ?
+                                   util::fmt("%s %s (%s)", (_result.coerced->isConstant() ? "const" : "non-const"),
+                                             _result.coerced->type(),
+                                             util::replace(_result.coerced->type().typename_(), "hilti::type::", "")) :
+                                   "fail"),
+                              to_string(style), e.meta().location(), _line));
 
 #undef RETURN
 

--- a/hilti/toolchain/src/compiler/coercion.cc
+++ b/hilti/toolchain/src/compiler/coercion.cc
@@ -611,21 +611,26 @@ static Result<Type> _coerceParameterizedType(const Type& src, const Type& dst, b
         return {};
 
     bool have_wildcard = false;
-    for ( auto&& [p1, p2] : util::zip2(params1, params2) ) {
-        auto t1 = p1.tryAs<Type>();
-        auto t2 = p2.tryAs<Type>();
 
-        if ( ! (t1 && t2) )
-            // Don't have a generic node comparison for the individual
-            // parameters, so just stop here and decline. (Note that the case
-            // of src == dst has been handled already, that usually does it.)
+    for ( auto&& [p1, p2] : util::zip2(params1, params2) ) {
+        // If we cannot get both parametres as types, we don't have a generic
+        // node comparison for the individual parameters, so just stop here and
+        // decline. (Note that the case of src == dst has been handled already,
+        // that usually does it.)
+
+        auto t1 = p1.tryAs<Type>();
+        if ( ! t1 )
+            return {};
+
+        auto t2 = p2.tryAs<Type>();
+        if ( ! t2 )
+            return {};
+
+        if ( ! coerceType(*t1, *t2, style) )
             return {};
 
         if ( t2->isWildcard() )
             have_wildcard = true;
-
-        if ( ! coerceType(*t1, *t2, style) )
-            return {};
     }
 
     // If one of the parameter types is a wildcard, we return the original type

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -615,7 +615,7 @@ struct TypeVisitor : OptimizerVisitor, visitor::PreOrder<bool, TypeVisitor> {
             case Stage::COLLECT: {
                 const auto type = innermostType(x.type());
 
-                const auto type_id = type.typeID();
+                const auto& type_id = type.typeID();
 
                 if ( ! type_id )
                     break;

--- a/spicy/toolchain/include/ast/operators/bitfield.h
+++ b/spicy/toolchain/include/ast/operators/bitfield.h
@@ -56,9 +56,11 @@ BEGIN_OPERATOR_CUSTOM(bitfield, Member)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<hilti::operator_::Operand> operands() const {
-        return {{{}, type::constant(type::Bitfield(type::Wildcard())), false, {}, "bitfield"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<attribute>"}};
+    const std::vector<hilti::operator_::Operand>& operands() const {
+        static std::vector<hilti::operator_::Operand> _operands =
+            {{{}, type::constant(type::Bitfield(type::Wildcard())), false, {}, "bitfield"},
+             {{}, type::Member(type::Wildcard()), false, {}, "<attribute>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, hilti::operator_::position_t p) const {

--- a/spicy/toolchain/include/ast/operators/sink.h
+++ b/spicy/toolchain/include/ast/operators/sink.h
@@ -28,74 +28,80 @@ filters attached, this returns the value after filtering.
 )");
 
 BEGIN_METHOD(sink, Close)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "close",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "close",
+                                                             .args = {},
+                                                             .doc = R"(
 Closes a sink by disconnecting all parsing units. Afterwards the sink's state
 is as if it had just been created (so new units can be connected). Note that a
 sink is automatically closed when the unit it is part of is done parsing. Also
 note that a previously connected parsing unit can *not* be reconnected; trying
 to do so will still throw a ``UnitAlreadyConnected`` exception.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, Connect)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "connect",
-                                           .args = {{"u", type::StrongReference(type::Unit(type::Wildcard()))}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                        .result = type::void_,
+                                        .id = "connect",
+                                        .args = {{"u", type::StrongReference(type::Unit(type::Wildcard()))}},
+                                        .doc = R"(
 Connects a parsing unit to a sink. All subsequent write operations to the sink will pass their
 data on to this parsing unit. Each unit can only be connected to a single sink. If
 the unit is already connected, a ``UnitAlreadyConnected`` exception is thrown.
 However, a sink can have more than one unit connected to it.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, ConnectMIMETypeString)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "connect_mime_type",
-                                           .args = {{"mt", type::String()}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "connect_mime_type",
+                                                             .args = {{"mt", type::String()}},
+                                                             .doc = R"(
 Connects parsing units to a sink for all parsers that support a given MIME
 type. All subsequent write operations to the sink will pass their data on to
 these parsing units. The MIME type may have wildcards for type or subtype, and
 the method will then connect units for all matching parsers.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, ConnectMIMETypeBytes)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "connect_mime_type",
-                                           .args = {{"mt", type::constant(type::Bytes())}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "connect_mime_type",
+                                                             .args = {{"mt", type::constant(type::Bytes())}},
+                                                             .doc = R"(
 Connects parsing units to a sink for all parsers that support a given MIME
 type. All subsequent write operations to the sink will pass their data on to
 these parsing units. The MIME type may have wildcards for type or subtype, and
 the method will then connect units for all matching parsers.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, ConnectFilter)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = hilti::type::void_,
-                                           .id = "connect_filter",
-                                           .args = {{"filter", hilti::type::StrongReference(
-                                                                   spicy::type::Unit(type::Wildcard()))}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                        .result = hilti::type::void_,
+                                        .id = "connect_filter",
+                                        .args = {{"filter",
+                                                  hilti::type::StrongReference(spicy::type::Unit(type::Wildcard()))}},
+                                        .doc = R"(
 Connects a filter unit to the sink that will transform its input transparently
 before forwarding it for parsing to other connected units.
 
@@ -107,97 +113,104 @@ the chain.
 Filters must be added before the first data chunk is written into the sink. If
 data has already been written when a filter is added, an error is triggered.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, Gap)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "gap",
-                                           .args = {{"seq", type::UnsignedInteger(64)},
-                                                    {"len", type::UnsignedInteger(64)}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "gap",
+                                                             .args = {{"seq", type::UnsignedInteger(64)},
+                                                                      {"len", type::UnsignedInteger(64)}},
+                                                             .doc = R"(
 Reports a gap in the input stream. *seq* is the sequence number of the first
 byte missing, *len* is the length of the gap.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, SequenceNumber)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = type::constant(spicy::type::Sink()),
-                                           .result = type::UnsignedInteger(64),
-                                           .id = "sequence_number",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = type::constant(spicy::type::Sink()),
+                                                             .result = type::UnsignedInteger(64),
+                                                             .id = "sequence_number",
+                                                             .args = {},
+                                                             .doc = R"(
 Returns the current sequence number of the sink's input stream, which is one
 beyond the index of the last byte that has been put in order and delivered so far.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, SetAutoTrim)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "set_auto_trim",
-                                           .args = {{"enable", type::Bool()}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "set_auto_trim",
+                                                             .args = {{"enable", type::Bool()}},
+                                                             .doc = R"(
 Enables or disables auto-trimming. If enabled (which is the default) sink input
 data is trimmed automatically once in-order and processed. See ``trim()`` for
 more information about trimming.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, SetInitialSequenceNumber)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "set_initial_sequence_number",
-                                           .args =
-                                               {
-                                                   {"seq", type::UnsignedInteger(64)},
-                                               },
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "set_initial_sequence_number",
+                                                             .args =
+                                                                 {
+                                                                     {"seq", type::UnsignedInteger(64)},
+                                                                 },
+                                                             .doc = R"(
 Sets the sink's initial sequence number. All sequence numbers given to other
 methods are then assumed to be absolute numbers beyond that initial number. If
 the initial number is not set, the sink implicitly uses zero instead.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, SetPolicy)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "set_policy",
-                                           .args =
-                                               {
-                                                   {"policy",
-                                                    type::Enum(type::Wildcard())}, // TODO(robin): Specify full type
-                                               },
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                        .result = type::void_,
+                                        .id = "set_policy",
+                                        .args =
+                                            {
+                                                {"policy",
+                                                 type::Enum(type::Wildcard())}, // TODO(robin): Specify full type
+                                            },
+                                        .doc = R"(
 Sets a sink's reassembly policy for ambiguous input. As long as data hasn't
 been trimmed, a sink will detect overlapping chunks. This policy decides how to
 handle ambiguous overlaps. The default (and currently only) policy is
 ``ReassemblerPolicy::First``, which resolves ambiguities by taking the data
 from the chunk that came first.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, Skip)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "skip",
-                                           .args =
-                                               {
-                                                   {"seq", type::UnsignedInteger(64)},
-                                               },
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "skip",
+                                                             .args =
+                                                                 {
+                                                                     {"seq", type::UnsignedInteger(64)},
+                                                                 },
+                                                             .doc = R"(
 Skips ahead in the input stream. *seq* is the sequence number where to continue
 parsing. If there's still data buffered before that position it will be
 ignored; if auto-skip is also active, it will be immediately deleted as well.
@@ -205,19 +218,20 @@ If new data is passed in later that comes before *seq*, that will likewise be
 ignored. If the input stream is currently stuck inside a gap, and *seq* lies
 beyond that gap, the stream will resume processing at *seq*.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, Trim)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "trim",
-                                           .args =
-                                               {
-                                                   {"seq", type::UnsignedInteger(64)},
-                                               },
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "trim",
+                                                             .args =
+                                                                 {
+                                                                     {"seq", type::UnsignedInteger(64)},
+                                                                 },
+                                                             .doc = R"(
 Deletes all data that's still buffered internally up to *seq*. If processing the
 input stream hasn't reached *seq* yet, parsing will also skip ahead to *seq*.
 
@@ -227,18 +241,19 @@ able to detect any further data mismatches.
 Note that by default, auto-trimming is enabled, which means all data is trimmed
 automatically once in-order and processed.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(sink, Write)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Sink(),
-                                           .result = type::void_,
-                                           .id = "write",
-                                           .args = {{"data", type::Bytes()},
-                                                    {"seq", type::UnsignedInteger(64), true},
-                                                    {"len", type::UnsignedInteger(64), true}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
+                                                             .result = type::void_,
+                                                             .id = "write",
+                                                             .args = {{"data", type::Bytes()},
+                                                                      {"seq", type::UnsignedInteger(64), true},
+                                                                      {"len", type::UnsignedInteger(64), true}},
+                                                             .doc = R"(
 Passes data on to all connected parsing units. Multiple *write* calls act like
 passing input in incrementally: The units will parse the pieces as if they were
 a single stream of data. If no sequence number *seq* is provided, the data is
@@ -256,6 +271,7 @@ is undefined.
 .. todo:: The error semantics for multiple units aren't great.
 
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/spicy/toolchain/include/ast/operators/unit.h
+++ b/spicy/toolchain/include/ast/operators/unit.h
@@ -242,12 +242,13 @@ public:
 } // namespace unit
 
 BEGIN_METHOD(unit, Offset)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::UnsignedInteger(64),
-                                           .id = "offset",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::UnsignedInteger(64),
+                                        .id = "offset",
+                                        .args = {},
+                                        .doc = R"(
 Returns the offset of the current location in the input stream relative to the
 unit's start. If executed from inside a field hook, the offset will represent
 the first byte that the field has been parsed from. If this method is called
@@ -255,66 +256,74 @@ before the unit's parsing has begun, it will throw a runtime exception. Once
 parsing has started, the offset will remain available for the unit's entire
 life time.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, Position)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::stream::Iterator(),
-                                           .id = "position",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::stream::Iterator(),
+                                        .id = "position",
+                                        .args = {},
+                                        .doc = R"(
 Returns an iterator to the current position in the unit's input stream. If
 executed from inside a field hook, the position will represent the first byte
 that the field has been parsed from. If this method is called before the unit's
 parsing has begun, it will throw a runtime exception.
 )"};
+        return _signature;
     }
 END_METHOD
 
 
 BEGIN_METHOD(unit, Input)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::stream::Iterator(),
-                                           .id = "input",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::stream::Iterator(),
+                                        .id = "input",
+                                        .args = {},
+                                        .doc = R"(
 Returns an iterator referring to the input location where the current unit has
 begun parsing. If this method is called before the units parsing has begun, it
 will throw a runtime exception. Once available, the input position will remain
 accessible for the unit's entire life time.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, SetInput)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::void_,
-                                           .id = "set_input",
-                                           .args = {{"i", type::constant(hilti::type::stream::Iterator())}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::void_,
+                                        .id = "set_input",
+                                        .args = {{"i", type::constant(hilti::type::stream::Iterator())}},
+                                        .doc = R"(
 Moves the current parsing position to *i*. The iterator *i* must be into the
 input of the current unit, or the method will throw a runtime exception.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, Find)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::Optional(hilti::type::stream::Iterator()),
-                                           .id = "find",
-                                           .args =
-                                               {
-                                                   {"needle", type::constant(hilti::type::Bytes())},
-                                                   {"dir", type::constant(hilti::type::Enum(type::Wildcard())), true},
-                                                   {"start", type::constant(hilti::type::stream::Iterator()), true},
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::Optional(hilti::type::stream::Iterator()),
+                                        .id = "find",
+                                        .args =
+                                            {
+                                                {"needle", type::constant(hilti::type::Bytes())},
+                                                {"dir", type::constant(hilti::type::Enum(type::Wildcard())), true},
+                                                {"start", type::constant(hilti::type::stream::Iterator()), true},
 
-                                               },
-                                           .doc = R"(
+                                            },
+                                        .doc = R"(
 Searches a *needle* pattern inside the input region defined by where the unit
 began parsing and its current parsing position. If executed from inside a field
 hook, the current parasing position will represent the *first* byte that the
@@ -324,17 +333,19 @@ of that region and scan forward. If the direction is
 and scan backward. In either case, a starting position can also be explicitly
 given, but must lie inside the same region.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, ConnectFilter)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::void_,
-                                           .id = "connect_filter",
-                                           .args = {{"filter", hilti::type::StrongReference(
-                                                                   spicy::type::Unit(type::Wildcard()))}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::void_,
+                                        .id = "connect_filter",
+                                        .args = {{"filter",
+                                                  hilti::type::StrongReference(spicy::type::Unit(type::Wildcard()))}},
+                                        .doc = R"(
 Connects a separate filter unit to transform the unit's input transparently
 before parsing. The filter unit will see the original input, and this unit will
 receive everything the filter passes on through ``forward()``.
@@ -342,47 +353,54 @@ receive everything the filter passes on through ``forward()``.
 Filters can be connected only before a unit's parsing begins. The latest
 possible point is from inside the target unit's ``%init`` hook.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, Forward)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::void_,
-                                           .id = "forward",
-                                           .args = {{"data", hilti::type::Bytes()}},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::void_,
+                                        .id = "forward",
+                                        .args = {{"data", hilti::type::Bytes()}},
+                                        .doc = R"(
 If the unit is connected as a filter to another one, this method forwards
 transformed input over to that other one to parse. If the unit is not connected,
 this method will silently discard the data.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, ForwardEod)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::void_,
-                                           .id = "forward_eod",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::void_,
+                                        .id = "forward_eod",
+                                        .args = {},
+                                        .doc = R"(
 If the unit is connected as a filter to another one, this method signals that
 other one that end of its input has been reached. If the unit is not connected,
 this method will not do anything.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, Backtrack)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = hilti::type::void_,
-                                           .id = "backtrack",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = hilti::type::void_,
+                                        .id = "backtrack",
+                                        .args = {},
+                                        .doc = R"(
 Aborts parsing at the current position and returns back to the most recent
 ``&try`` attribute. Turns into a parse error if there's no ``&try`` in scope.
 )"};
+        return _signature;
     }
 END_METHOD
 
@@ -399,26 +417,29 @@ static inline auto contextResult(bool is_const) {
 }
 
 BEGIN_METHOD(unit, ContextConst)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
-                                           .result = contextResult(true),
-                                           .id = "context",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature =
+            hilti::operator_::Signature{.self = hilti::type::constant(spicy::type::Unit(type::Wildcard())),
+                                        .result = contextResult(true),
+                                        .id = "context",
+                                        .args = {},
+                                        .doc = R"(
 Returns a reference to the ``%context`` instance associated with the unit.
 )"};
+        return _signature;
     }
 END_METHOD
 
 BEGIN_METHOD(unit, ContextNonConst)
-    auto signature() const {
-        return hilti::operator_::Signature{.self = spicy::type::Unit(type::Wildcard()),
-                                           .result = contextResult(false),
-                                           .id = "context",
-                                           .args = {},
-                                           .doc = R"(
+    const auto& signature() const {
+        static auto _signature = hilti::operator_::Signature{.self = spicy::type::Unit(type::Wildcard()),
+                                                             .result = contextResult(false),
+                                                             .id = "context",
+                                                             .args = {},
+                                                             .doc = R"(
 Returns a reference to the ``%context`` instance associated with the unit.
 )"};
+        return _signature;
     }
 END_METHOD
 

--- a/spicy/toolchain/include/ast/operators/unit.h
+++ b/spicy/toolchain/include/ast/operators/unit.h
@@ -61,9 +61,10 @@ BEGIN_OPERATOR_CUSTOM(unit, Unset)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, hilti::operator_::position_t p) const {
@@ -88,9 +89,10 @@ BEGIN_OPERATOR_CUSTOM_x(unit, MemberNonConst, Member)
     bool isLhs() const { return true; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, hilti::operator_::position_t p) const {
@@ -120,9 +122,10 @@ BEGIN_OPERATOR_CUSTOM_x(unit, MemberConst, Member)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::constant(type::Unit(type::Wildcard())), false, {}, "unit"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::constant(type::Unit(type::Wildcard())), false, {}, "unit"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, position_t p) const {
@@ -149,9 +152,10 @@ BEGIN_OPERATOR_CUSTOM(unit, TryMember)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::Unit(type::Wildcard()), false, {}, "unit"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, position_t p) const {
@@ -176,9 +180,10 @@ BEGIN_OPERATOR_CUSTOM(unit, HasMember)
     bool isLhs() const { return false; }
     auto priority() const { return hilti::operator_::Priority::Normal; }
 
-    std::vector<Operand> operands() const {
-        return {{{}, type::constant(type::Unit(type::Wildcard())), false, {}, "unit"},
-                {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+    const std::vector<Operand>& operands() const {
+        static std::vector<Operand> _operands = {{{}, type::constant(type::Unit(type::Wildcard())), false, {}, "unit"},
+                                                 {{}, type::Member(type::Wildcard()), false, {}, "<field>"}};
+        return _operands;
     }
 
     void validate(const hilti::expression::ResolvedOperator& i, position_t p) const {
@@ -209,7 +214,7 @@ public:
         };
 
         static Kind kind() { return Kind::MemberCall; }
-        std::vector<Operand> operands() const { return _operands; }
+        const std::vector<Operand>& operands() const { return _operands; }
         Type result(const hilti::node::Range<Expression>& /* ops */) const { return _result; }
         bool isLhs() const { return false; }
         auto priority() const { return hilti::operator_::Priority::Normal; }


### PR DESCRIPTION
This PR collects a number of performance tweaks to speed up JIT. With a larger test grammar I saw these changes speed up JIT by around 30%.