### PR TITLE
Prevent unnecessarily executable stack with GNU toolchain.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -7,6 +7,11 @@ add_subdirectory(doctest)
 
 add_subdirectory(justrx)
 
+# The GNU toolchain by default assumes that any assembly files (of which the
+# fiber library contains at least one) need an executable stack; explictly
+# disable that since we do not need executable stacks and some package linters
+# call this out as needlessly insecure.
+set(CMAKE_ASM_FLAGS ${CMAKE_ASM_FLAGS} -Wa,--noexecstack)
 set(FIBER_SHARED OFF)
 set(FIBER_OBJECT ON)
 add_subdirectory(fiber)


### PR DESCRIPTION
The GNU toolchain seems to default to marking the stack of any archive
as executable if it contains assembly sources. This is the case in Spicy
since we link against 3rdparty/fiber which contains assembly source
files. If Spicy is linked statically this propagates into the binary,
for shared linkage only into libhilti; in each case this can be
confirmed with e.g., `readelf -Wl <artifact>`.

With this patch we explicitly request that the stack not to be marked
executable whenever we link fiber assembly files. Since the library does
not provide a CMake customization point for the flags we set the flag
globally for any 3rdparty sources.

Closes #1210.