### PR TITLE
Produce `hilti::rt::Bool` when casting to boolean.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/coercions.cc
+++ b/hilti/toolchain/src/compiler/codegen/coercions.cc
@@ -85,7 +85,7 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const type::StrongReference& src) {
         if ( auto t = dst.tryAs<type::Bool>() )
-            return fmt("static_cast<bool>(%s)", expr);
+            return fmt("::hilti::rt::Bool(static_cast<bool>(%s))", expr);
 
         if ( auto t = dst.tryAs<type::ValueReference>() )
             return fmt("%s.derefAsValue()", expr);
@@ -112,7 +112,7 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const type::Result& src) {
         if ( auto t = dst.tryAs<type::Bool>() )
-            return fmt("static_cast<bool>(%s)", expr);
+            return fmt("::hilti::rt::Bool(static_cast<bool>(%s))", expr);
 
         if ( auto t = dst.tryAs<type::Optional>() )
             return fmt("static_cast<%s>(%s)", cg->compile(dst, codegen::TypeUsage::Storage), expr);
@@ -122,7 +122,7 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const type::SignedInteger& src) {
         if ( dst.isA<type::Bool>() )
-            return fmt("static_cast<bool>(%s)", expr);
+            return fmt("::hilti::rt::Bool(static_cast<bool>(%s))", expr);
 
         if ( auto t = dst.tryAs<type::SignedInteger>() )
             return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", t->width(), expr);
@@ -174,7 +174,7 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const type::UnsignedInteger& src) {
         if ( dst.isA<type::Bool>() )
-            return fmt("static_cast<bool>(%s)", expr);
+            return fmt("::hilti::rt::Bool(static_cast<bool>(%s))", expr);
 
         if ( auto t = dst.tryAs<type::SignedInteger>() )
             return fmt("::hilti::rt::integer::safe<int%d_t>(%s)", t->width(), expr);
@@ -187,7 +187,7 @@ struct Visitor : public hilti::visitor::PreOrder<std::string, Visitor> {
 
     result_t operator()(const type::WeakReference& src) {
         if ( auto t = dst.tryAs<type::Bool>() )
-            return fmt("static_cast<bool>(%s)", expr);
+            return fmt("::hilti::rt::Bool(static_cast<bool>(%s))", expr);
 
         if ( auto t = dst.tryAs<type::StrongReference>() )
             return fmt("::hilti::rt::StrongReference<%s>(%s)",

--- a/tests/hilti/types/reference/strong-ref.hlt
+++ b/tests/hilti/types/reference/strong-ref.hlt
@@ -16,6 +16,7 @@ assert x == y;
 assert *x == *y;
 assert !(x != y);
 assert !(*x != *y);
+True? cast<bool>(x): True;
 
 *x += b"123";
 assert *x == b"xyz123";

--- a/tests/hilti/types/reference/weak-from-strong-ref.hlt
+++ b/tests/hilti/types/reference/weak-from-strong-ref.hlt
@@ -20,6 +20,8 @@ assert x;
 assert y;
 assert ! z;
 
+True? cast<bool>(x): True;
+
 x = new b"abc";
 hilti::print(x);
 hilti::print(y);

--- a/tests/hilti/types/result/conversion.hlt
+++ b/tests/hilti/types/result/conversion.hlt
@@ -41,4 +41,6 @@ hilti::print(o);
 y(x(True));
 y(x(False));
 
+True? cast<bool>(x(True)): True;
+
 }


### PR DESCRIPTION
For `cast<bool>(...) we would previously produce C++ `bool` values which
could have lead to C++ ambiguities when used together with boolean
literals, e.g.,

    True ? cast<bool>(1): False;

would produce either a `bool` or a `hilti::rt::Bool` where either type
can implicitly convert to the other type.

We now always produce `hilti::rt::Bool` from casts which removes the
ambiguity. For the majority of types we still go through their
`explicit` bool conversion operator which is needed in other places as
well.

Closes #1217.