### PR TITLE
Fix import segfault.

### DIFF
--- a/hilti/toolchain/src/compiler/context.cc
+++ b/hilti/toolchain/src/compiler/context.cc
@@ -124,8 +124,7 @@ std::optional<CacheEntry> Context::lookupUnit(const hilti::rt::filesystem::path&
         ast_extension = path.extension();
 
     if ( auto x = _unit_cache_by_path.find(util::normalizePath(path)); x != _unit_cache_by_path.end() ) {
-        ID scope_ = scope ? *scope : ID();
-        if ( scope_ == x->second->unit->cacheIndex().scope && x->second->unit->extension() == *ast_extension )
+        if ( x->second->unit->extension() == *ast_extension )
             return *x->second;
     }
 


### PR DESCRIPTION
This removes a check that a previous change had introduced, which was
actually semantically wrong. I don't quite recall why I had added
that, I think it had seemed necessary for some reason, but the test
suite runs fine without it at least.

(No test because the reproducer requires spicyz.)

Closes #1224.