### PR TITLE
Fix code generation when a module's file could be imported through

### DIFF
--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -23,6 +23,8 @@ inline const DebugStream AstCodegen("ast-codegen");
 inline const DebugStream Compiler("compiler");
 } // namespace hilti::logging::debug
 
+std::unordered_map<ID, unsigned int> Unit::_uid_cache;
+
 template<typename PluginMember, typename... Args>
 bool runHook(bool* modified, const Plugin& plugin, const Node* module, const std::string& extension, PluginMember hook,
              const std::string& debug_msg, const Args&... args) {
@@ -45,6 +47,15 @@ bool runHook(bool* modified, const Plugin& plugin, const Node* module, const std
     }
 
     return logger().errors() == 0;
+}
+
+ID Unit::_makeUniqueID(const ID& id) {
+    if ( auto i = _uid_cache.find(id); i != _uid_cache.end() )
+        return ID(util::fmt("%s_%s", id, ++(i->second)));
+    else {
+        _uid_cache[id] = 1;
+        return id;
+    }
 }
 
 Unit::~Unit() { _destroyModule(); }

--- a/tests/spicy/types/unit/import-from-type-names.spicy
+++ b/tests/spicy/types/unit/import-from-type-names.spicy
@@ -1,0 +1,17 @@
+# @TEST-EXEC: spicyc -d -j %INPUT -o z.hlto
+
+module z;
+import y;
+
+@TEST-START-FILE y.spicy
+module y;
+import x from bla;
+@TEST-END-FILE
+
+@TEST-START-FILE bla/x.spicy
+module x;
+
+type X = unit {
+	on %done {}
+};
+@TEST-END-FILE


### PR DESCRIPTION
different means.

This can happen when mixing normal import with  `import ... from`. A
previous change to support multiple units of the same name, missed
that we could run into namespacing trouble at code generation time in
this case. The problem was that we included the `from ...` scope into
the namespace, which doesn't work when we import the same module both
w/ and wo/ scope. Now we generate unique module IDs differently
through global state independent of file system paths.

Close #1227.