### PR TITLE
Clarify docs on `SPICY_VERSION` [skip CI].

### DIFF
--- a/doc/programming/language/conditional.rst
+++ b/doc/programming/language/conditional.rst
@@ -14,10 +14,10 @@ version:
 
 .. spicy-code::
 
-    @if SPICY_VERSION < 10000
-        <code for Spicy versions older than 1.0>
+    @if SPICY_VERSION < 10401
+        <code for Spicy versions older than 1.4.1>
     @else
-        <code for Spicy versions equal or newer than 1.0>
+        <code for Spicy versions equal or newer than 1.4.1>
     @endif
 
 


### PR DESCRIPTION
We previously didn't make clear how minor and patch versions are encoded
in `SPICY_VERSION`. This patch modifies the given example so all three
values are different from `0`.

Closes #1240.