### PR TITLE
fix build with empty CMAKE_CXX_FLAGS_{DEBUG,RELEASE}

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -61,13 +61,17 @@ foreach (lib hilti-rt hilti-rt-debug)
 endforeach ()
 
 # Build hilti-rt with release flags.
-string(REPLACE " " ";" cxx_flags_release ${CMAKE_CXX_FLAGS_RELEASE})
+if (CMAKE_CXX_FLAGS_RELEASE)
+    string(REPLACE " " ";" cxx_flags_release ${CMAKE_CXX_FLAGS_RELEASE})
+endif ()
 target_compile_options(hilti-rt-objects PRIVATE ${cxx_flags_release})
 target_compile_options(hilti-rt-objects PRIVATE "-g;-O3;-DNDEBUG;-Wall")
 target_compile_definitions(hilti-rt-objects PRIVATE "HILTI_RT_BUILD_TYPE_RELEASE")
 
 # Build hilti-rt-debug with debug flags.
-string(REPLACE " " ";" cxx_flags_debug ${CMAKE_CXX_FLAGS_DEBUG})
+if (CMAKE_CXX_FLAGS_DEBUG)
+    string(REPLACE " " ";" cxx_flags_debug ${CMAKE_CXX_FLAGS_DEBUG})
+endif ()
 target_compile_options(hilti-rt-debug-objects PRIVATE ${cxx_flags_debug})
 target_compile_options(hilti-rt-debug-objects PRIVATE "-UNDEBUG;-O0;-Wall")
 target_compile_definitions(hilti-rt-debug-objects PRIVATE "HILTI_RT_BUILD_TYPE_DEBUG")

--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -39,14 +39,18 @@ foreach (lib spicy-rt spicy-rt-debug)
 endforeach ()
 
 # Build spicy-rt with release flags.
-string(REPLACE " " ";" cxx_flags_release ${CMAKE_CXX_FLAGS_RELEASE})
+if (CMAKE_CXX_FLAGS_RELEASE)
+    string(REPLACE " " ";" cxx_flags_release ${CMAKE_CXX_FLAGS_RELEASE})
+endif ()
 target_compile_options(spicy-rt-objects PRIVATE ${cxx_flags_release})
 target_compile_options(spicy-rt-objects PRIVATE "-g;-O3;-DNDEBUG;-Wall")
 target_compile_definitions(spicy-rt-objects PRIVATE "HILTI_RT_BUILD_TYPE_RELEASE")
 target_link_libraries(spicy-rt-objects PUBLIC hilti-rt-objects)
 
 # Build spicy-rt-debug with debug flags.
-string(REPLACE " " ";" cxx_flags_debug ${CMAKE_CXX_FLAGS_DEBUG})
+if (CMAKE_CXX_FLAGS_DEBUG)
+    string(REPLACE " " ";" cxx_flags_debug ${CMAKE_CXX_FLAGS_DEBUG})
+endif ()
 target_compile_options(spicy-rt-debug-objects PRIVATE ${cxx_flags_debug})
 target_compile_options(spicy-rt-debug-objects PRIVATE "-UNDEBUG;-O0;-Wall")
 target_compile_definitions(spicy-rt-debug-objects PRIVATE "HILTI_RT_BUILD_TYPE_DEBUG")


### PR DESCRIPTION
Fix the following build failure if `CMAKE_CXX_FLAGS_{DEBUG,RELEASE}` is empty:

```
CMake Error at auxil/spicy/spicy/hilti/runtime/CMakeLists.txt:70 (string):
  string sub-command REPLACE requires at least four arguments.

CMake Error at auxil/spicy/spicy/spicy/runtime/CMakeLists.txt:49 (string):
  string sub-command REPLACE requires at least four arguments.
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>