### PR TITLE
Add coercion for optionals that only differ in constness of their inner types.

### DIFF
--- a/hilti/toolchain/include/ast/expressions/ternary.h
+++ b/hilti/toolchain/include/ast/expressions/ternary.h
@@ -22,6 +22,8 @@ public:
         return condition() == other.condition() && true_() == other.true_() && false_() == other.false_();
     }
 
+    void setFalse(const Expression& expr) { children()[2] = expr; }
+
     /** Implements `Expression` interface. */
     bool isLhs() const { return false; }
     /** Implements `Expression` interface. */

--- a/hilti/toolchain/src/compiler/coercion.cc
+++ b/hilti/toolchain/src/compiler/coercion.cc
@@ -424,6 +424,16 @@ struct VisitorType : public visitor::PreOrder<std::optional<Type>, VisitorType> 
     }
 
     result_t operator()(const type::Optional& r) {
+        if ( auto t = dst.tryAs<type::Optional>() ) {
+            const auto& s = r.dereferencedType();
+            const auto& d = t->dereferencedType();
+
+            if ( type::sameExceptForConstness(s, d) && (style & CoercionStyle::Assignment) )
+                // Assignments copy, so it's safe to turn  into the
+                // destination without considering constness.
+                return dst;
+        }
+
         if ( auto t = dst.tryAs<type::Bool>(); (style & CoercionStyle::ContextualConversion) && t )
             return dst;
 

--- a/hilti/toolchain/src/compiler/visitors/validator.cc
+++ b/hilti/toolchain/src/compiler/visitors/validator.cc
@@ -276,10 +276,11 @@ struct VisitorPost : public hilti::visitor::PreOrder<void, VisitorPost>, public 
     }
 
     void operator()(const expression::Ternary& n, position_t p) {
-        if ( ! hilti::type::sameExceptForConstness(n.true_().type(), n.false_().type()) )
+        if ( ! hilti::type::sameExceptForConstness(n.true_().type(), n.false_().type()) ) {
             error(fmt("types of alternatives do not match in ternary expression (%s vs. %s)", n.true_().type(),
                       n.false_().type()),
                   p);
+        }
     }
 
     void operator()(const expression::UnresolvedID& n, position_t p) {

--- a/tests/spicy/types/optional/coercion.spicy
+++ b/tests/spicy/types/optional/coercion.spicy
@@ -1,0 +1,18 @@
+# @TEST-EXEC: ${SPICYC} -j %INPUT >output
+#
+# @TEST-DOC: Regression test for #1143.
+
+module Foo;
+
+type Bar = struct {
+  wutang: bytes &optional;
+};
+
+type BarTuple = tuple<
+  wutang: optional<bytes>
+>;
+
+public function make_bar_tuple(bar: Bar): BarTuple {
+  local nope: optional<bytes>;
+  return tuple(bar?.wutang ? optional(bar.wutang) : nope);
+}


### PR DESCRIPTION
There are some situations where that's fine to coerce, so adding that.
Also adding a coercion for ternary expressions that coerces the 2dn
expression into the type of the 1st (which we already assume provides
the result type).

Closes #1143.
Closes #1220.