### PR TITLE
Allow activating JIT debug streams via `HILTI_DEBUG`.

### DIFF
--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -10,6 +10,7 @@
 
 #include <hilti/rt/json.h>
 #include <hilti/rt/libhilti.h>
+#include <hilti/rt/util.h>
 
 #include <hilti/ast/declaration.h>
 #include <hilti/ast/detail/visitor.h>
@@ -253,6 +254,12 @@ void Driver::dumpUnit(const Unit& unit) {
 
 Result<Nothing> Driver::parseOptions(int argc, char** argv) {
     int num_output_types = 0;
+
+    if ( const auto& arg = rt::getenv("HILTI_DEBUG"); arg && ! arg->empty() ) {
+        for ( const auto& s : util::split(*arg, ",") )
+            // Ignore unknown streams.
+            _driver_options.logger->debugEnable(s);
+    }
 
     opterr = 0; // don't print errors
     std::string option_string = "ABlL:cCpPvjhvVdX:o:D:TUEeSRg" + hookAddCommandLineOptions();

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -6,9 +6,11 @@
 #include <iostream>
 
 #include <hilti/rt/libhilti.h>
+#include <hilti/rt/util.h>
 
 #include <spicy/rt/libspicy.h>
 
+#include <hilti/base/util.h>
 #include <hilti/compiler/init.h>
 #include <hilti/hilti.h>
 
@@ -116,6 +118,12 @@ void SpicyDriver::usage() {
 void SpicyDriver::parseOptions(int argc, char** argv) {
     hilti::driver::Options driver_options;
     hilti::Options compiler_options;
+
+    if ( const auto& arg = hilti::rt::getenv("HILTI_DEBUG"); arg && ! arg->empty() ) {
+        for ( const auto& s : hilti::util::split(*arg, ",") )
+            // Ignore unknown streams.
+            driver_options.logger->debugEnable(s);
+    }
 
     driver_options.execute_code = true;
     driver_options.include_linker = true;

--- a/spicy/toolchain/bin/spicy-dump/main.cc
+++ b/spicy/toolchain/bin/spicy-dump/main.cc
@@ -112,6 +112,12 @@ void SpicyDump::parseOptions(int argc, char** argv) {
     hilti::Options hilti_compiler_options;
     spicy::Options spicy_compiler_options;
 
+    if ( const auto& arg = hilti::rt::getenv("HILTI_DEBUG"); arg && ! arg->empty() ) {
+        for ( const auto& s : hilti::util::split(*arg, ",") )
+            // Ignore unknown streams.
+            driver_options.logger->debugEnable(s);
+    }
+
     driver_options.execute_code = true;
     driver_options.include_linker = true;
     driver_options.logger = std::make_unique<hilti::Logger>();

--- a/tests/hilti/tools/hiltic-env-compiler-debug.hlt
+++ b/tests/hilti/tools/hiltic-env-compiler-debug.hlt
@@ -1,0 +1,6 @@
+# @TEST-DOC: Checks compiler debug streams can be toggled via `HILTI_DEBUG`.
+#
+# @TEST-EXEC-FAIL: hiltic -c -o /dev/null %INPUT 2>&1 | grep -q "[debug/compiler]"
+# @TEST-EXEC: HILTI_DEBUG=compiler hiltic -c -o /dev/null %INPUT 2>&1 | grep -q "[debug/compiler]"
+
+module test {}

--- a/tests/spicy/tools/spicyc-env-compiler-debug.spicy
+++ b/tests/spicy/tools/spicyc-env-compiler-debug.spicy
@@ -1,0 +1,6 @@
+# @TEST-DOC: Checks compiler debug streams can be toggled via `HILTI_DEBUG`.
+#
+# @TEST-EXEC-FAIL: spicyc -c -o /dev/null %INPUT 2>&1 | grep -q "[debug/compiler]"
+# @TEST-EXEC: HILTI_DEBUG=compiler spicyc -c -o /dev/null %INPUT 2>&1 | grep -q "[debug/compiler]"
+
+module test;


### PR DESCRIPTION
Previously to activate debugs streams during JIT one needed to pass streams to activate via a command line argument `-D`. This can make it hard to debug compilation issues if one cannot edit the compiler invocation (e.g., the compiler invocation for out-of-tree Spicy analyzers in Zeek lives in the installation of spicy-plugin).

With this patch we now support activating streams listed under a compiler's `-D help` via `HILTI_DEBUG`. Since `HILTI_DEBUG` is already used to activate HILTI runtime flags not necessarily supported by a compiler, we ignore activation errors from unknown streams.

Closes #1296.