### PR TITLE
Add library function to parse an address from string or bytes.

### DIFF
--- a/doc/autogen/spicy-functions.spicy
+++ b/doc/autogen/spicy-functions.spicy
@@ -120,7 +120,7 @@ Parses an address from a string. The address can be in standard IPv4 or IPv6
 ASCII represententation. The function raises ``InvalidArgument`` if the string
 could not be parsed.
 
-.. _spicy_parse_address:
+.. _spicy_parse_address_2:
 
 .. rubric:: ``function spicy::parse_address(b: bytes) : addr``
 

--- a/doc/autogen/spicy-functions.spicy
+++ b/doc/autogen/spicy-functions.spicy
@@ -94,21 +94,37 @@ values. Formatted strings cannot exceed 128 bytes.
 The format string can contain format specifiers supported by POSIX strftime, see
 https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html.
 
-This function can raise InvalidArgument if the timestamp could not be
+This function can raise ``InvalidArgument`` if the timestamp could not be
 converted to local time or formatted.
 
 .. _spicy_strptime:
 
 .. rubric:: ``function spicy::strptime(buf: string, format: string) : time``
 
-Parse time from string.
+Parses time from a string.
 
 This function uses the currently active locale and timezone to parse values.
 
 The format string can contain format specifiers supported by POSIX strptime, see
 https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html.
 
-This function raises InvalidArgument if the string could not be parsed
-with the given format string, or OutOfRange if the parsed time value cannot
+This function raises ``InvalidArgument`` if the string could not be parsed
+with the given format string, or ``OutOfRange`` if the parsed time value cannot
 be represented.
+
+.. _spicy_parse_address:
+
+.. rubric:: ``function spicy::parse_address(s: string) : addr``
+
+Parses an address from a string. The address can be in standard IPv4 or IPv6
+ASCII represententation. The function raises ``InvalidArgument`` if the string
+could not be parsed.
+
+.. _spicy_parse_address:
+
+.. rubric:: ``function spicy::parse_address(b: bytes) : addr``
+
+Parses an address from a bytes instance. The address can be in standard IPv4
+or IPv6 ASCII represententation. The function raises ``InvalidArgument`` if the
+string could not be parsed.
 

--- a/doc/scripts/autogen-spicy-lib
+++ b/doc/scripts/autogen-spicy-lib
@@ -100,12 +100,17 @@ awk -v "target=$1" -v "ns=$2" '
         else
             result = " : " result;
 
+        postfix = ""
+        if ( name in functions )
+            postfix = sprintf("_%d", functions[name] + 1);
+
         if ( target == "functions" ) {
-            printf(".. _spicy_%s:\n\n", name);
+            printf(".. _spicy_%s%s:\n\n", name, postfix);
             printf(".. rubric:: ``function %s::%s(%s)%s``\n\n", ns, name, args, result);
             printf("%s\n\n", comment);
         }
 
+        functions[name] = 1;
         comment = "";
         next;
     }

--- a/hilti/runtime/include/types/address.h
+++ b/hilti/runtime/include/types/address.h
@@ -28,7 +28,7 @@ public:
      *
      * @param addr string representation, as in `1.2.3.4` or `2001:db8:85a3:8d3:1319:8a2e:370:7348`.
      *
-     * @throws RuntimeError if it cannot parse the address into a valid IPv4 or IPv6 address.
+     * @throws InvalidArgument if it cannot parse the address into a valid IPv4 or IPv6 address.
      */
     explicit Address(const std::string& addr) { _parse(addr); }
 
@@ -101,7 +101,7 @@ private:
     void _init(struct in_addr addr);
     void _init(struct in6_addr addr);
 
-    // Throws RuntimeError if it cannot parse the address.
+    // Throws ``InvalidArgument`` if it cannot parse the address.
     void _parse(const std::string& addr);
 
     uint64_t _a1 = 0; // The 8 more significant bytes.
@@ -116,6 +116,24 @@ extern Result<std::tuple<Address, Bytes>> unpack(const Bytes& data, AddressFamil
 
 /** Unpacks an address from binary representation, following the protocol for `unpack` operator. */
 extern Result<std::tuple<Address, stream::View>> unpack(const stream::View& data, AddressFamily family, ByteOrder fmt);
+
+/**
+ * Parses an address from a IPv4 or IPv6 string representation.
+ *
+ * @param addr string representation, as in ``1.2.3.4`` or ``2001:db8:85a3:8d3:1319:8a2e:370:7348``.
+ *
+ * @throws InvalidArgument if it cannot parse the address into a valid IPv4 or IPv6 address.
+ */
+inline Address parse(const Bytes& data) { return Address(data.str()); }
+
+/**
+ * Parses an address from a IPv4 or IPv6 string representation.
+ *
+ * @param addr string representation, as in ``1.2.3.4`` or ``2001:db8:85a3:8d3:1319:8a2e:370:7348``.
+ *
+ * @throws InvalidArgument if it cannot parse the address into a valid IPv4 or IPv6 address.
+ */
+inline Address parse(const std::string& data) { return Address(data); }
 
 } // namespace address
 

--- a/hilti/runtime/src/types/address.cc
+++ b/hilti/runtime/src/types/address.cc
@@ -17,7 +17,7 @@ void Address::_parse(const std::string& addr) {
         if ( inet_pton(AF_INET, addr.c_str(), &v4) > 0 )
             _init(v4);
         else
-            throw RuntimeError(fmt("cannot parse IPv4 address '%s'", addr));
+            throw InvalidArgument(fmt("cannot parse IPv4 address '%s'", addr));
     }
 
     else {
@@ -25,7 +25,7 @@ void Address::_parse(const std::string& addr) {
         if ( inet_pton(AF_INET6, addr.c_str(), &v6) > 0 )
             _init(v6);
         else
-            throw RuntimeError(fmt("cannot parse IPv6 address '%s'", addr));
+            throw InvalidArgument(fmt("cannot parse IPv6 address '%s'", addr));
     }
 
     // Allow IPv6 addresses to decay to IPv4 addresses to allow specifying

--- a/spicy/lib/spicy.spicy
+++ b/spicy/lib/spicy.spicy
@@ -134,18 +134,28 @@ public function getenv(name: string) : optional<string> &cxxname="::hilti::rt::g
 ## The format string can contain format specifiers supported by POSIX strftime, see
 ## https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.html.
 ##
-## This function can raise InvalidArgument if the timestamp could not be
+## This function can raise ``InvalidArgument`` if the timestamp could not be
 ## converted to local time or formatted.
 public function strftime(format: string, timestamp: time) : string &cxxname="::hilti::rt::strftime" &have_prototype;
 
-## Parse time from string.
+## Parses time from a string.
 ##
 ## This function uses the currently active locale and timezone to parse values.
 ##
 ## The format string can contain format specifiers supported by POSIX strptime, see
 ## https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html.
 ##
-## This function raises InvalidArgument if the string could not be parsed
-## with the given format string, or OutOfRange if the parsed time value cannot
+## This function raises ``InvalidArgument`` if the string could not be parsed
+## with the given format string, or ``OutOfRange`` if the parsed time value cannot
 ## be represented.
 public function strptime(buf: string, format: string) : time &cxxname="::hilti::rt::strptime" &have_prototype;
+
+## Parses an address from a string. The address can be in standard IPv4 or IPv6
+## ASCII represententation. The function raises ``InvalidArgument`` if the string
+## could not be parsed.
+public function parse_address(s: string) : addr &cxxname="::hilti::rt::address::parse" &have_prototype;
+
+## Parses an address from a bytes instance. The address can be in standard IPv4
+## or IPv6 ASCII represententation. The function raises ``InvalidArgument`` if the
+## string could not be parsed.
+public function parse_address(b: bytes) : addr &cxxname="::hilti::rt::address::parse" &have_prototype;

--- a/tests/spicy/lib/parse-address.spicy
+++ b/tests/spicy/lib/parse-address.spicy
@@ -1,0 +1,14 @@
+# @TEST-EXEC: ${SPICYC} -j %INPUT
+#
+# @TEST-DOC: Exercise ``spicy::parse_address()``
+
+module Test;
+
+import spicy;
+
+# We only test basic functionality because the parsing itself is unit-tested
+# inside the runtime librart.
+assert spicy::parse_address("2001:0db8:85a3:0000:0000:8a2e:0370:7334") == [2001:0db8:85a3:0000:0000:8a2e:0370:7334];
+assert spicy::parse_address(b"192.168.1.1") == 192.168.1.1;
+assert spicy::parse_address(b"2001:db8::FFFF:192.168.0.5") == [2001:db8::ffff:c0a8:5];
+assert-exception spicy::parse_address("Foo");


### PR DESCRIPTION
    ## Parses an address from a string. The address can be in standard IPv4 or IPv6
    ## ASCII representation. The function raises ``InvalidArgument`` if the string
    ## could not be parsed.
    public function parse_address(s: string) : addr;

    ## Parses an address from a bytes instance. The address can be in standard IPv4
    ## or IPv6 ASCII representation. The function raises ``InvalidArgument`` if the
    ## string could not be parsed.
    public function parse_address(b: bytes) : addr;

Closes #1294.