### PR TITLE
Fix incorrect offset computation in `advanceToNextData`.

### DIFF
--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -197,13 +197,16 @@ View View::advanceToNextData() const {
         c = c->next();
     }
 
+    // Iterator to zero point in original stream. All offsets are relative to this.
+    const auto zero = _begin - _begin.offset();
+
     // If we have found a non-gap chunk its offset points to the next data.
     if ( c )
-        return View(_begin + c->offset(), _end);
+        return View(zero + c->offset(), _end);
 
     // If we have seen a previous chunk, return a View starting after its end.
     if ( last_end )
-        return View(_begin + *last_end, _end);
+        return View(zero + *last_end, _end);
 
     // If we have not found a next non-gap chunk simply return a view at the next
     // byte. Since this is a gap chunk this can cause recovery in the caller.

--- a/tests/Baseline/spicy.types.unit.synchronize-on-gap/output
+++ b/tests/Baseline/spicy.types.unit.synchronize-on-gap/output
@@ -11,11 +11,16 @@
 [spicy-verbose]     - got container item
 [spicy-verbose]     failed to parse list element, will try to synchronize at next possible element
 [spicy-verbose]     - state: type=sync::Xs input="<gap>..." stream=0xXXXXXXXX offsets=0/1/1027 chunks=3 frozen=no mode=default trim=no lah=n/a lah_token="n/a" recovering=yes
-[spicy-verbose]     - state: type=sync::Xs input="C" stream=0xXXXXXXXX offsets=0/1026/1027 chunks=3 frozen=no mode=default trim=no lah=1 lah_token="C" recovering=yes
+[spicy-verbose]     - state: type=sync::Xs input="BC" stream=0xXXXXXXXX offsets=0/1025/1027 chunks=3 frozen=no mode=default trim=no lah=1 lah_token="B" recovering=yes
 [spicy-verbose]     successfully synchronized
+[spicy-verbose]     - state: type=sync::Xs input="BC" stream=0xXXXXXXXX offsets=0/1025/1027 chunks=3 frozen=no mode=default trim=no lah=1 lah_token="B" recovering=no
+[spicy-verbose]     - parsing production: Ctor: anon -> /(A|B|C)/ (regexp) (container 'xs')
+[spicy-verbose]       - consuming look-ahead token
+[spicy-verbose]     - got container item
+[spicy-verbose]     - state: type=sync::Xs input="C" stream=0xXXXXXXXX offsets=0/1026/1027 chunks=3 frozen=no mode=default trim=no lah=1 lah_token="C" recovering=no
 [spicy-verbose]     - state: type=sync::Xs input="C" stream=0xXXXXXXXX offsets=0/1026/1027 chunks=3 frozen=no mode=default trim=no lah=1 lah_token="C" recovering=no
 [spicy-verbose]     - parsing production: Ctor: anon -> /(A|B|C)/ (regexp) (container 'xs')
 [spicy-verbose]       - consuming look-ahead token
 [spicy-verbose]     - got container item
 [spicy-verbose]     suspending to wait for more input for stream 0xXXXXXXXX, currently have 0
-[$xs=[b"A", b"C"]]
+[$xs=[b"A", b"B", b"C"]]


### PR DESCRIPTION
To compute the next `View` in `advanceToNextData` after a gap chunk we would previously compute offsets incorrectly in that we would implicitly assume that the begin of the original `View` started with zero offset. This is unlikely true for any but the most trivial cases and often caused e.g., resynchronization to jump to incorrect offsets much after the correct position.

With this patch we now use a correct offset computation.

Closes #1303.