### PR TITLE
Fix test for doctest-2.4.8.

### DIFF
--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -371,7 +371,9 @@ TEST_CASE("advance") {
 
         // Match on `A`.
         {
-            auto [rc, ncur] = re.tokenMatcher().advance(cur);
+            int rc;
+            hilti::rt::stream::View ncur;
+            std::tie(rc, ncur) = re.tokenMatcher().advance(cur);
             CHECK_EQ(rc, 1);
             CHECK_EQ(ncur, stream::View(cur.begin() + 1, cur.end()));
             cur = ncur;
@@ -388,7 +390,9 @@ TEST_CASE("advance") {
 
         // Match on `B`.
         {
-            auto [rc, ncur] = re.tokenMatcher().advance(cur);
+            int rc;
+            hilti::rt::stream::View ncur;
+            std::tie(rc, ncur) = re.tokenMatcher().advance(cur);
             CHECK_EQ(rc, 1);
             CHECK_EQ(ncur.offset(), 1 + 1024 + 1);
         }


### PR DESCRIPTION
This test was originally developed against the version on `main` (`doctest-2.4.9`), but produced errors with the version on this branch.

This patch slightly adjusts the test code in non-functional way so it can build on this branch as well.