### PR TITLE
Improve efficiency of `startsWith` for long inputs.

### DIFF
--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -195,7 +195,7 @@ std::string replace(std::string s, std::string_view o, std::string_view n);
  *
  * \note This function is not UTF8-aware.
  */
-inline bool startsWith(const std::string& s, const std::string& prefix) { return s.find(prefix) == 0; }
+bool startsWith(const std::string& s, const std::string& prefix);
 
 /**
  * Python-style enumerate() that returns an iterable yielding pairs `(index,

--- a/hilti/runtime/src/util.cc
+++ b/hilti/runtime/src/util.cc
@@ -377,6 +377,18 @@ std::string hilti::rt::replace(std::string s, std::string_view o, std::string_vi
     return s;
 }
 
+bool hilti::rt::startsWith(const std::string& s, const std::string& prefix) {
+    if ( s.size() < prefix.size() )
+        return false;
+
+    for ( size_t i = 0; i < prefix.size(); ++i ) {
+        if ( s[i] != prefix[i] )
+            return false;
+    }
+
+    return true;
+}
+
 hilti::rt::ByteOrder hilti::rt::systemByteOrder() {
 #ifdef LITTLE_ENDIAN
     return ByteOrder::Little;


### PR DESCRIPTION
We previously would always search for _any occurrence_ of `prefix` in the given string and only later check whether it was at the beginning; this could have meant potentially lots of work for long input strings.

With this patch we examine at most the first `prefix.size()` characters of the string.