### PR TITLE
Fix/clarify bitfield docs.

### DIFF
--- a/doc/programming/examples/_parse-bitfield-enum.spicy.output
+++ b/doc/programming/examples/_parse-bitfield-enum.spicy.output
@@ -1,3 +1,3 @@
-# Automatically generated; do not edit. -- <HASH> printf '\41' | spicy-driver %INPUT/printf '\41' | spicy-driver %INPUT/False
-# printf '\41' | spicy-driver foo.spicy
+# Automatically generated; do not edit. -- <HASH> printf '\x21' | spicy-driver %INPUT/printf '\x21' | spicy-driver %INPUT/False
+# printf '\x21' | spicy-driver foo.spicy
 X::A, X::B

--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -933,7 +933,7 @@ Bitfields parse an integer value of a given size, and then make
 selected smaller bit ranges within that value available individually
 through dedicated identifiers. For example, the following unit parses
 4 bytes as an ``uint32`` and then makes the value of bit 0 available
-as ``f.x1``, bits 1 to 2 as ``f.x2``, and bits 3 to 5 as ``f.x3``,
+as ``f.x1``, bits 1 to 2 as ``f.x2``, and bits 3 to 4 as ``f.x3``,
 respectively:
 
 .. spicy-code:: parse-bitfield.spicy
@@ -994,7 +994,7 @@ range to an enum, using ``$$`` to access the parsed value:
     };
 
 .. spicy-output:: parse-bitfield-enum.spicy
-    :exec: printf '\41' | spicy-driver %INPUT
+    :exec: printf '\x21' | spicy-driver %INPUT
     :show-with: foo.spicy
 
 .. _parse_bytes:


### PR DESCRIPTION
We now use `\xNN` with `printf` here. While that's technically not portable, it's much more readable and it works in the settings where we usually generate the docs. Indeed, we already rely on that in a couple other places as well.

Closes #1298.