### PR TITLE
Bring implementation of `Sink::write` in line with declaration.

### DIFF
--- a/doc/autogen/types/sink.rst
+++ b/doc/autogen/types/sink.rst
@@ -102,7 +102,7 @@
     Note that by default, auto-trimming is enabled, which means all data
     is trimmed automatically once in-order and processed.
 
-.. spicy:method:: sink::write sink write False void (inout data: bytes, [ seq: uint<64> ], [ len: uint<64> ])
+.. spicy:method:: sink::write sink write False void (data: bytes, [ seq: uint<64> ], [ len: uint<64> ])
 
     Passes data on to all connected parsing units. Multiple *write* calls
     act like passing input in incrementally: The units will parse the

--- a/spicy/toolchain/include/ast/operators/sink.h
+++ b/spicy/toolchain/include/ast/operators/sink.h
@@ -250,7 +250,7 @@ BEGIN_METHOD(sink, Write)
         static auto _signature = hilti::operator_::Signature{.self = spicy::type::Sink(),
                                                              .result = type::void_,
                                                              .id = "write",
-                                                             .args = {{"data", type::Bytes()},
+                                                             .args = {{"data", type::constant(type::Bytes())},
                                                                       {"seq", type::UnsignedInteger(64), true},
                                                                       {"len", type::UnsignedInteger(64), true}},
                                                              .doc = R"(

--- a/tests/spicy/types/sink/write.spicy
+++ b/tests/spicy/types/sink/write.spicy
@@ -5,8 +5,10 @@ module Mini;
 
 import spicy;
 
+const b123 = b"123";
+
 public type Main = unit {
-    a: bytes &size=2 { self.data.write(b"123"); }
+    a: bytes &size=2 { self.data.write(b123); }
     b: bytes &size=5 { self.data.write(b"4567"); }
     c: bytes &size=3 { self.data.write(b""); }
     d: bytes &size=5 { self.data.write(b"890"); }


### PR DESCRIPTION
In `spicy_rt.hlt` `Sink::write` is declared as taking an `in` `data` parameter while the C++ implementation declared a mutable parameter, i.e., `inout`. Surprisingly, this resolved fine most of the time, but failed to resolve when actually passing a `const` value.

This patch brings the implementation in line with the declaration so they actually match.

Closes #1322.