### PR TITLE
Install full nlohmann JSON header as well.

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -120,6 +120,8 @@ install_headers(${PROJECT_SOURCE_DIR}/3rdparty/ArticleEnumClass-v2
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/SafeInt hilti/rt/3rdparty/SafeInt SafeInt.hpp)
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/tinyformat hilti/rt/3rdparty/tinyformat)
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/json/include/nlohmann hilti/rt/3rdparty/nlohmann)
+install_headers(${PROJECT_SOURCE_DIR}/3rdparty/json/single_include/nlohmann
+                hilti/rt/3rdparty/nlohmann)
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/filesystem/include/ghc hilti/rt/3rdparty/ghc)
 install_headers(${PROJECT_SOURCE_DIR}/3rdparty/any hilti/rt/3rdparty/any)
 


### PR DESCRIPTION
We previously would only install the nlohmann header with forward declaration while in `hilti/rt/json.h` we include the full header. With that it was impossible to include this header in user code.

This patch makes sure we install the full header as well.