### PR TITLE
Add stringification to UnitContext.

### DIFF
--- a/spicy/runtime/include/unit-context.h
+++ b/spicy/runtime/include/unit-context.h
@@ -98,3 +98,11 @@ inline void setContext(hilti::rt::StrongReference<Context>& context, const std::
 } // namespace detail
 
 } // namespace spicy::rt
+
+namespace hilti::rt::detail::adl {
+
+inline std::string to_string(const spicy::rt::UnitContext& ctx, rt::detail::adl::tag /*unused*/) {
+    return "<unit context>";
+}
+
+} // namespace hilti::rt::detail::adl

--- a/spicy/runtime/src/tests/unit-context.cc
+++ b/spicy/runtime/src/tests/unit-context.cc
@@ -1,6 +1,7 @@
 // Copyright (c) 2020-2021 by the Zeek Project. See LICENSE for details.
 
 #include <hilti/rt/doctest.h>
+#include <hilti/rt/extension-points.h>
 #include <hilti/rt/type-info.h>
 #include <hilti/rt/types/bytes.h>
 
@@ -45,6 +46,11 @@ TEST_CASE("create and set") {
 
     // Catch type mismatch
     CHECK_THROWS_AS(detail::setContext(__context, c, &hilti::rt::type_info::string), ContextMismatch);
+}
+
+TEST_CASE("to_string") {
+    auto b = hilti::rt::reference::make_strong<hilti::rt::Bytes>("x"_b);
+    CHECK_EQ(hilti::rt::to_string(UnitContext(std::move(b), &hilti::rt::type_info::bytes)), "<unit context>");
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Not adding this in the first place broke e.g., `-X flow` or `-X trace`.