### PR TITLE
Remove potential race during JIT when using `HILTI_CXX_COMPILER_LAUNCHER`.

### DIFF
--- a/hilti/toolchain/include/compiler/jit.h
+++ b/hilti/toolchain/include/compiler/jit.h
@@ -216,7 +216,7 @@ private:
     };
     JobRunner _runner;
 
-    std::size_t _hash;
+    std::size_t _hash = 0;
 };
 
 } // namespace hilti

--- a/tests/spicy/tools/spicyc-ccache-data-race.spicy
+++ b/tests/spicy/tools/spicyc-ccache-data-race.spicy
@@ -1,0 +1,37 @@
+# @TEST-DOC: This test validates that if the same module is included in multiple other modules, we create unique filenames. This avoids that concurrent JIT jobs work on the same file.
+#
+# @TEST-EXEC: rm -f /tmp/log
+# @TEST-EXEC: chmod +x wrapper.sh
+#
+# We expect exactly three files for this compilation (modules `a` and `foo` and linker script).
+# @TEST-EXEC: HILTI_CXX_COMPILER_LAUNCHER=$PWD/wrapper.sh spicyc -dj a.spicy
+# @TEST-EXEC test $(wc -l output) -eq 3
+#
+# We expect exactly three additional files for this compilation (modules `b` and `foo` and linker script).
+# @TEST-EXEC: HILTI_CXX_COMPILER_LAUNCHER=$PWD/wrapper.sh spicyc -dj b.spicy
+# @TEST-EXEC test $(wc -l output) -eq 6
+#
+# Each compiler invocation (and consequentially each compiled and created file should be unique).
+# @TEST-EXEC: test $(sort -u output | wc -l) -eq 6
+
+# A small helper script to intercept and log compiler invocations.
+# @TEST-START-FILE wrapper.sh
+#!/bin/sh
+echo "$@" >>output
+"$@"
+# @TEST-END-FILE
+
+# @TEST-START-FILE a.spicy
+module a;
+import foo;
+# @TEST-END-FILE
+
+# @TEST-START-FILE b.spicy
+module b;
+import foo;
+# @TEST-END-FILE
+
+# @TEST-START-FILE foo.spicy
+module foo;
+global N = 42;
+# @TEST-END-FILE


### PR DESCRIPTION
We previously would not create unique names for different JIT invocations if they came from the same directory. This causes issues if the same module is imported into different analyzers where previously we would generate the same C++ and object file name. Different JIT runs could then race on the same output files and e.g., remove each others inputs/outputs. As far as I can tell this was very unlikely to produce incorrect behavior at runtime.

We now include all input files from a JIT run in the JIT has. With that above race is not possible anymore.