### PR TITLE
Search user module paths before system paths.

### DIFF
--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -120,7 +120,7 @@ Result<std::shared_ptr<Unit>> Unit::fromImport(const std::shared_ptr<Context>& c
     if ( parse_plugin->get().library_paths )
         library_paths = util::concat(std::move(library_paths), (*parse_plugin->get().library_paths)(context));
 
-    library_paths = util::concat(std::move(library_paths), context->options().library_paths);
+    library_paths = util::concat(context->options().library_paths, library_paths);
 
     auto path = util::findInPaths(name, library_paths);
     if ( ! path ) {


### PR DESCRIPTION
With, e.g., `spicyz -L /x/y/z`, we used to append the given module
path to the internal system paths, so that it was searched last. This
change turns around the priority to search `/x/y/x` first, before the
internal ones. That seems both more useful and more intuitive.
