### PR TITLE
Streamline runtime exception hierarchy.

### DIFF
--- a/hilti/runtime/include/exception.h
+++ b/hilti/runtime/include/exception.h
@@ -81,14 +81,14 @@ inline std::ostream& operator<<(std::ostream& stream, const Exception& e) { retu
 
 #define HILTI_EXCEPTION_IMPL(name) name::name::~name() = default;
 
-/** Base class for exceptions thrown by the runtime system. */
+/** Base class for exceptions thrown during runtime when encountering unexpected input/situations. */
 HILTI_EXCEPTION(RuntimeError, Exception)
 
-/** Base class for exceptions created by HILTI programs. */
-HILTI_EXCEPTION(UserException, Exception)
+/** Base class for exceptions indicating non-recoverable misuse of some functionality. */
+HILTI_EXCEPTION(UsageError, Exception)
 
 /** Base class for exceptions which can be recovered. */
-HILTI_EXCEPTION(RecoverableFailure, Exception)
+HILTI_EXCEPTION(RecoverableFailure, RuntimeError)
 
 /** Thrown when an `assert` statement fails. */
 HILTI_EXCEPTION(AssertionFailure, RuntimeError)
@@ -97,7 +97,7 @@ HILTI_EXCEPTION(AssertionFailure, RuntimeError)
  * Exception triggered y the ".?" operator to signal to host applications that
  * a struct attribute isn't set.
  */
-HILTI_EXCEPTION(AttributeNotSet, Exception)
+HILTI_EXCEPTION(AttributeNotSet, RuntimeError)
 
 /**
  * Exception triggered when a division by zero is attempted.
@@ -105,7 +105,7 @@ HILTI_EXCEPTION(AttributeNotSet, Exception)
 HILTI_EXCEPTION(DivisionByZero, RuntimeError)
 
 /** Thrown for trouble encountered while managing the runtime environment. */
-HILTI_EXCEPTION(EnvironmentError, Exception)
+HILTI_EXCEPTION(EnvironmentError, UsageError)
 
 /** Exception indicating access to an already expired weak reference. **/
 HILTI_EXCEPTION(ExpiredReference, RuntimeError)

--- a/hilti/runtime/src/exception.cc
+++ b/hilti/runtime/src/exception.cc
@@ -10,7 +10,7 @@
 using namespace hilti::rt;
 
 HILTI_EXCEPTION_IMPL(RuntimeError)
-HILTI_EXCEPTION_IMPL(UserException)
+HILTI_EXCEPTION_IMPL(UsageError)
 HILTI_EXCEPTION_IMPL(RecoverableFailure)
 
 HILTI_EXCEPTION_IMPL(AssertionFailure)

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -147,7 +147,7 @@ TEST_CASE("Error") {
     CHECK_EQ(fmt("%s", result::Error("could not foo the bar")), "could not foo the bar");
 }
 
-TEST_CASE("Exception") { CHECK_EQ(to_string(UserException("my error")), "<exception: my error>"); }
+TEST_CASE("Exception") { CHECK_EQ(to_string(UsageError("my error")), "<exception: my error>"); }
 
 TEST_CASE("Vector") {
     CHECK_EQ(to_string(vector::Empty()), "[]");

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -324,7 +324,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder<cxx::declaration::Type, Vis
             scope = scope.namespace_();
 
         std::string base_ns = "::hilti::rt";
-        std::string base_cls = "UserException";
+        std::string base_cls = "UsageError";
 
         if ( auto b = n.baseType() ) {
             auto x = cxx::ID(cg->compile(*b, codegen::TypeUsage::Ctor));

--- a/spicy/runtime/include/driver.h
+++ b/spicy/runtime/include/driver.h
@@ -198,7 +198,7 @@ struct ConnectionState {
 } // namespace driver
 
 /** Exception thrown when a unit type is requested for parsing that isn't useable. */
-HILTI_EXCEPTION(InvalidUnitType, UserException);
+HILTI_EXCEPTION(InvalidUnitType, UsageError);
 
 /**
  * Runtime driver to retrieve and feed Spicy parsers.

--- a/spicy/runtime/include/mime.h
+++ b/spicy/runtime/include/mime.h
@@ -15,7 +15,7 @@ namespace spicy::rt {
 /**
  * Exception thrown by MIMEType if it cannot parse a type specification.
  */
-HILTI_EXCEPTION(InvalidMIMEType, UserException)
+HILTI_EXCEPTION(InvalidMIMEType, UsageError)
 
 namespace mime {
 

--- a/spicy/runtime/include/sink.h
+++ b/spicy/runtime/include/sink.h
@@ -26,7 +26,7 @@ namespace spicy::rt {
 /**
  * Exception thrown when sink operations fail due to usage errors.
  */
-HILTI_EXCEPTION(SinkError, UserException)
+HILTI_EXCEPTION(SinkError, UsageError)
 
 namespace sink {
 enum class ReassemblerPolicy { First };

--- a/spicy/runtime/include/unit-context.h
+++ b/spicy/runtime/include/unit-context.h
@@ -16,7 +16,7 @@ namespace spicy::rt {
  * Exception thrown on attempts to use a context not matching what the unit
  * expects.
  */
-HILTI_EXCEPTION(ContextMismatch, UserException)
+HILTI_EXCEPTION(ContextMismatch, UsageError)
 
 /**
  * Type-erased wrapper around an instance of a parsing unit's `%context` type.

--- a/spicy/runtime/src/sink.cc
+++ b/spicy/runtime/src/sink.cc
@@ -149,10 +149,6 @@ bool Sink::_deliver(std::optional<hilti::rt::Bytes> data, uint64_t rseq, uint64_
             // Sinks are operating independently from the writer, so we
             // don't forward errors on.
             s->resumable.resume();
-        } catch ( const hilti::rt::RecoverableFailure& err ) {
-            SPICY_RT_DEBUG_VERBOSE(
-                fmt("parse error in connected unit %s, aborting delivery (%s)", s->parser->name, err.what()));
-            s->skip_delivery = true;
         } catch ( const hilti::rt::RuntimeError& err ) {
             SPICY_RT_DEBUG_VERBOSE(
                 fmt("error in connected unit %s, aborting delivery (%s)", s->parser->name, err.what()));
@@ -411,9 +407,6 @@ void Sink::_close(bool orderly) {
                         s->resumable.resume();
                     else
                         s->resumable.abort();
-                } catch ( const hilti::rt::RecoverableFailure& err ) {
-                    SPICY_RT_DEBUG_VERBOSE(
-                        fmt("parse error in connected unit %s during close (%s)", s->parser->name, err.what()));
                 } catch ( const hilti::rt::RuntimeError& err ) {
                     SPICY_RT_DEBUG_VERBOSE(
                         fmt("error in connected unit %s during close (%s)", s->parser->name, err.what()));


### PR DESCRIPTION
We were a bit inconsistent in the structure of exceptions that could
happen during runtime, making it hard for host applications for
consistently handle trouble. We tweak this, as follows:

- We now only have two general subcategories of exceptions under the
  top-level `hilti::rt::Exception`:

    - `RuntimeError`: non-fatal errors that mean a host
      applications cannot complete the current line of processing,
      but can otherwise continue. This is the main exception that
      host applications should catch, and then proceed
      appropriately.

    - `UsageError`: fatal errors that indicate something about
      using the runtime environment was fundamentally wrong, and a
      host application should abort.

- Almost all other exceptions are now derived from `RuntimeError`,
  including Spicy's `ParseError` and `RecoverableFailure`, so that
  they can treated consistently.
