### PR TITLE
Use unique filename for all object files generated during JIT.

### DIFF
--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -303,8 +303,11 @@ hilti::Result<Nothing> JIT::_compile() {
             }
         }
 
-        auto obj = hilti::rt::filesystem::canonical(path);
-        obj.replace_extension(".o");
+        // We explicitly create the object file in the temporary directory.
+        // This ensures that we use a temp path for object files created for
+        // C++ files added by users as well.
+        auto obj = hilti::rt::filesystem::temp_directory_path() /
+                   util::fmt("%s_%" PRIx64 ".o", path.filename().c_str(), _hash);
 
         args.emplace_back("-o");
         args.push_back(obj);

--- a/tests/hilti/tools/hiltic-jit-cc-input.cc
+++ b/tests/hilti/tools/hiltic-jit-cc-input.cc
@@ -1,0 +1,12 @@
+// @TEST-DOC: Validates that object files for C++ inputs are not generated next to source.
+//
+// Initially we expect four files (stdout, stderr, log, input).
+// @TEST-EXEC: test $(find . -type f | wc -l) -eq 4
+//
+// JIT the C++ file and keep the output file. It should end in the temp dir.
+// @TEST-EXEC: hiltic -jT %INPUT
+//
+// We still expect four files (stdout, stderr, log, input).
+// @TEST-EXEC: test $(find . -type f | wc -l) -eq 4
+
+void f() {}


### PR DESCRIPTION
We previously would derive the name of the object file to generate for a given C++ input file directly from the input filename by just replacing the extension. This caused us to generate object files directly next to C++ files added explicitly to the JIT job. Multiple jobs using the same C++ input file could then race on the object file.

With this patch we make sure that object files are always generated with taking the JIT has into account. We also fix the location of object files to always be in a system temp directory.

Closes #1367.