### PR TITLE
Search `HILTI_CXX_INCLUDE_DIRS` paths before default include paths.

### DIFF
--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -297,8 +297,7 @@ hilti::Result<Nothing> JIT::_compile() {
         if ( auto path = getenv("HILTI_CXX_INCLUDE_DIRS") ) {
             for ( auto&& dir : hilti::rt::split(path, ":") ) {
                 if ( ! dir.empty() ) {
-                    args.emplace_back("-I");
-                    args.emplace_back(dir);
+                    args.insert(args.begin(), {"-I", std::string(dir)});
                 }
             }
         }


### PR DESCRIPTION
We used to append the paths from `HILTI_CXX_INCLUDE_DIRS` path to the
internal default include paths, so that they were searched last. This
change turns around the priority to search them first. That seems both
more useful and more intuitive.

Addresses https://github.com/zeek/spicy-plugin/issues/134.
