### PR TITLE
ASAN fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,14 @@ endif ()
 if (USE_SANITIZERS)
     # Recommended flags per https://github.com/google/sanitizers/wiki/AddressSanitizer
     set(sanitizer_cxx_flags
-        "-fsanitize=${USE_SANITIZERS} -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1 -shared-libsan"
-    )
-    set(sanitizer_ld_flags "-fsanitize=${USE_SANITIZERS} -frtlib-add-rpath -shared-libsan")
+        "-fsanitize=${USE_SANITIZERS} -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1")
+    set(sanitizer_ld_flags "-fsanitize=${USE_SANITIZERS}")
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(sanitizer_cxx_flags "${sanitizer_cxx_flags} -shared-libasan")
+        set(sanitizer_ld_flags "${sanitizer_ld_flags} -frtlib-add-rpath -shared-libasan")
+    endif ()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${sanitizer_cxx_flags}")
     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} ${sanitizer_cxx_flags}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${sanitizer_ld_flags}")

--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -47,20 +47,25 @@ static const auto FiberGuardFlags = 0; // leak sanitizer may abort with "Tracer 
 
 #endif
 
+// Pre-allocate this so that we don't need to create a std::string on the fly
+// when HILTI_RT_FIBER_DEBUG executes. That avoids a false positive with
+// ASAN during fiber switching when using GCC/libc++.
+static const std::string debug_stream_fibers = "fibers";
+
 // Wrapper similar to HILTI_RT_DEBUG that adds the current fiber to the message.
 #define HILTI_RT_FIBER_DEBUG(tag, msg)                                                                                 \
     {                                                                                                                  \
         if ( ::hilti::rt::detail::globalState()->debug_logger &&                                                       \
-             ::hilti::rt::detail::globalState()->debug_logger->isEnabled("fibers") )                                   \
-            ::hilti::rt::debug::detail::print("fibers",                                                                \
+             ::hilti::rt::detail::globalState()->debug_logger->isEnabled(debug_stream_fibers) )                        \
+            ::hilti::rt::debug::detail::print(debug_stream_fibers,                                                     \
                                               fmt("[%s/%s] %s", *context::detail::get()->fiber.current, tag, msg));    \
     }
 
 #define HILTI_RT_FIBER_DEBUG_NO_CONTEXT(tag, msg)                                                                      \
     {                                                                                                                  \
         if ( ::hilti::rt::detail::globalState()->debug_logger &&                                                       \
-             ::hilti::rt::detail::globalState()->debug_logger->isEnabled("fibers") )                                   \
-            ::hilti::rt::debug::detail::print("fibers", fmt("[none/%s] %s", tag, msg));                                \
+             ::hilti::rt::detail::globalState()->debug_logger->isEnabled(debug_stream_fibers) )                        \
+            ::hilti::rt::debug::detail::print(debug_stream_fibers, fmt("[none/%s] %s", tag, msg));                     \
     }
 
 extern "C" {


### PR DESCRIPTION
- Skip clang-specific ASAN flags with other compilers.
- Fix ASAN false positive with GCC.
