### PR TITLE
Fix sign-unsigned comparison.

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1286,7 +1286,7 @@ public:
             throw WouldBlock("end of stream view");
 
         auto p = unsafeBegin();
-        for ( int i = 0; i < n; ++i )
+        for ( uint64_t i = 0; i < n; ++i )
             dst[i] = *p++;
 
         return View(SafeConstIterator(p), _end);


### PR DESCRIPTION
This is flagged by `-Wsign-compare` which we do not typically activate.