### PR TITLE
Build debian-11 instead of centos stream 8 in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -408,6 +408,8 @@ docker_alpine_3_12_task:
     type: application/gzip
 
 docker_centos_stream_8_task:
+  skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''
+
   container:
     dockerfile: docker/Dockerfile.centos-stream-8
     cpu: 4
@@ -516,8 +518,6 @@ docker_debian10_task:
     type: application/gzip
 
 docker_debian11_task:
-  skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''
-
   container:
     dockerfile: docker/Dockerfile.debian-11
     cpu: 4


### PR DESCRIPTION
Since the Zeek container image is based on debian-11 this allows testing against Spicy versions from branches in zeek/spicy-plugin.

Closes zeek/spicy-plugin#169.