### PR TITLE
Implement bytes::DecodeErrorStrategy::ESCAPE

### DIFF
--- a/hilti/lib/hilti.hlt
+++ b/hilti/lib/hilti.hlt
@@ -8,7 +8,7 @@ public type AddressFamily = enum { IPv4, IPv6 } &cxxname="hilti::rt::AddressFami
 public type RealType = enum { IEEE754_Single, IEEE754_Double } &cxxname="hilti::rt::real::Type";
 public type Protocol = enum { TCP, UDP, ICMP } &cxxname="hilti::rt::Protocol";
 public type Charset = enum { ASCII, UTF8 } &cxxname="hilti::rt::bytes::Charset";
-public type DecodeErrorStrategy = enum { IGNORE, REPLACE, STRICT } &cxxname="hilti::rt::bytes::DecodeErrorStrategy";
+public type DecodeErrorStrategy = enum { IGNORE, REPLACE, STRICT, ESCAPE } &cxxname="hilti::rt::bytes::DecodeErrorStrategy";
 public type Captures = vector<bytes>;
 
 public type MatchState = struct {

--- a/hilti/runtime/include/types/string.h
+++ b/hilti/runtime/include/types/string.h
@@ -16,7 +16,8 @@ namespace string {
 HILTI_RT_ENUM_WITH_DEFAULT(DecodeErrorStrategy, IGNORE,
                            IGNORE,  // skip data
                            REPLACE, // replace with a place-holder
-                           STRICT   // throw a runtime error
+                           STRICT,  // throw a runtime error
+                           ESCAPE   // replace with escaped hex value (\xHH)
 );
 
 /**

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -104,6 +104,9 @@ std::string Bytes::decode(bytes::Charset cs, bytes::DecodeErrorStrategy errors) 
             return Bytes(str(), cs, errors).str();
 
         case bytes::Charset::ASCII: {
+            if ( errors.value() == DecodeErrorStrategy::ESCAPE )
+                return escapeBytes(str());
+
             std::string s;
             for ( auto c : *this ) {
                 if ( c >= 32 && c < 0x7f )
@@ -113,6 +116,7 @@ std::string Bytes::decode(bytes::Charset cs, bytes::DecodeErrorStrategy errors) 
                         case DecodeErrorStrategy::IGNORE: break;
                         case DecodeErrorStrategy::REPLACE: s += "?"; break;
                         case DecodeErrorStrategy::STRICT: throw RuntimeError("illegal ASCII character in string");
+                        case DecodeErrorStrategy::ESCAPE: cannot_be_reached();
                     }
                 }
             }
@@ -232,6 +236,7 @@ std::string to_string(const bytes::DecodeErrorStrategy& x, tag /*unused*/) {
         case bytes::DecodeErrorStrategy::IGNORE: return "Charset::IGNORE";
         case bytes::DecodeErrorStrategy::REPLACE: return "Charset::REPLACE";
         case bytes::DecodeErrorStrategy::STRICT: return "Charset::STRICT";
+        case bytes::DecodeErrorStrategy::ESCAPE: return "Charset::ESCAPE";
     }
 
     cannot_be_reached();

--- a/spicy/lib/spicy.spicy
+++ b/spicy/lib/spicy.spicy
@@ -37,7 +37,8 @@ public type Charset = enum {
 public type DecodeErrorStrategy = enum {
     IGNORE,  # data is skipped but processing continues
     REPLACE, # data is replaced with a valid place-holder and processing continues
-    STRICT   # runtime error is triggered
+    STRICT,  # runtime error is triggered
+    ESCAPE   # data is replaced with an escaped hex value (\xHH) and processing continues
 } &cxxname="hilti::rt::bytes::DecodeErrorStrategy";
 
 ## Captures state for incremental regular expression matching.


### PR DESCRIPTION
Implement a new `bytes::DecodeErrorStrategy` that behaves the same way as `print` which is also what `bytes.decode()` used to return before #1255.

Very much WIP. Lots missing:
- Handling of UTF8 charset
- Handling places `bytes::DecodeErrorStrategy` applies other than `bytes.decode()` (like the `Bytes` constructor? Maybe other types?)
- Documentation updates
- ~~Check of `std::stringstream` is the best way to do the hex conversion~~
- Check that existing tests pass
- Add new tests
- ~~Fix lint errors~~