### PR TITLE
Prevent internal error when passed invalid context.

### DIFF
--- a/spicy/toolchain/include/ast/types/unit.h
+++ b/spicy/toolchain/include/ast/types/unit.h
@@ -91,9 +91,10 @@ public:
     /** Returns the type set through ``%context`, if available. */
     hilti::optional_ref<const Type> contextType() const {
         if ( auto context = propertyItem("%context") )
-            return context->expression()->as<hilti::expression::Type_>().typeValue();
-        else
-            return {};
+            if ( auto ty = context->expression()->tryAs<hilti::expression::Type_>() )
+                return ty->typeValue();
+
+        return {};
     }
 
     /**

--- a/tests/Baseline/spicy.types.unit.context-fail/output
+++ b/tests/Baseline/spicy.types.unit.context-fail/output
@@ -4,4 +4,7 @@
 [error] <...>/context-fail.spicy:13:5: %context requires an argument
 [error] <...>/context-fail.spicy:14:5: %context requires a type
 [error] <...>/context-fail.spicy:17:17-20:2: unit cannot have more than one %context
+[error] <...>/context-fail.spicy:23:16: context() used with a unit which did not declare %context
+[error] <...>/context-fail.spicy:30:3: %context requires a type
+[error] <...>/context-fail.spicy:32:14: context() used with a unit which did not declare %context
 [error] spicyc: aborting after errors

--- a/tests/spicy/types/unit/context-fail.spicy
+++ b/tests/spicy/types/unit/context-fail.spicy
@@ -18,3 +18,15 @@ public type C = unit {
     %context = string;
     %context = bytes; # more than one context
 };
+
+type D = unit {
+    on %init { self.context(); }
+};
+
+# Regression test for #1386.
+function noop() {}
+public type Foo = unit {
+  %context = noop;
+
+  on %init { self.context(); }
+};


### PR DESCRIPTION
We previously would trigger an internal error when encountering `self.context()` in a unit which declared a `%context` to something which was not a type. With this patch we now reject such calls.

We picked a simplified implementation strategy: when querying a `Unit`'s `contextType` we still return an optional type to handle both units without context as well as units where %context does not point to a type; if a context is present but does not refer to a type we return an empty result. With that we potentially trigger two errors, from validating that `%context` refers to a type, and from validating that the unit had a `%context` when using `self.context()`, i.e., if the `%context` is invalid we continue parsing as if the unit had no `%context` at all. The alternative would have been to return e.g., a `Result<optional_ref<Type>>` from `contextType` to capture both the unset as well as invalid case and move some of the validation into `contextType` itself; this still would have led to a lot of manual unwrapping in users.

Closes #1386.