### PR TITLE
Do not force locale on users of libhilti.

### DIFF
--- a/hilti/runtime/src/init.cc
+++ b/hilti/runtime/src/init.cc
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <clocale>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -22,9 +21,6 @@ using namespace hilti::rt::detail;
 void hilti::rt::init() {
     if ( globalState()->runtime_is_initialized )
         return;
-
-    if ( ! setlocale(LC_CTYPE, "") )
-        warning("cannot set locale");
 
     if ( ! globalState()->configuration )
         globalState()->configuration = std::make_unique<hilti::rt::Configuration>();


### PR DESCRIPTION
Setting a locale from a library can interfere negatively with the rest of the application. We previously would set a locale inside `hilti::rt::init`, but we probably do not need it at all.