### PR TITLE
Initialize `Bytes` internal control block for all constructors.

### DIFF
--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -177,9 +177,9 @@ public:
      */
     Bytes(std::string s, bytes::Charset cs, bytes::DecodeErrorStrategy errors = bytes::DecodeErrorStrategy::REPLACE);
 
-    Bytes(Base&& str) : Base(std::move(str)), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
-    Bytes(const Bytes& xs) : Base(xs), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
-    Bytes(Bytes&& xs) noexcept : Base(std::move(xs)), _control(std::make_shared<Base*>(static_cast<Base*>(this))) {}
+    Bytes(Base&& str) : Base(std::move(str)) {}
+    Bytes(const Bytes& xs) : Base(xs) {}
+    Bytes(Bytes&& xs) noexcept : Base(std::move(xs)) {}
 
     /** Replaces the contents of this `Bytes` with another `Bytes`.
      *
@@ -524,7 +524,7 @@ public:
 
 private:
     friend bytes::Iterator;
-    std::shared_ptr<Base*> _control;
+    std::shared_ptr<Base*> _control = std::make_shared<Base*>(static_cast<Base*>(this));
 
     void invalidateIterators() { _control = std::make_shared<Base*>(static_cast<Base*>(this)); }
 };

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -40,8 +40,7 @@ std::tuple<bool, Bytes::const_iterator> Bytes::find(const Bytes& v, const const_
     }
 }
 
-Bytes::Bytes(std::string s, bytes::Charset cs, DecodeErrorStrategy errors)
-    : _control(std::make_shared<Base*>(static_cast<Base*>(this))) {
+Bytes::Bytes(std::string s, bytes::Charset cs, DecodeErrorStrategy errors) {
     switch ( cs.value() ) {
         case bytes::Charset::UTF8: {
             // Data supposedly is already in UTF-8, but let's validate it.

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -104,7 +104,7 @@ std::string Bytes::decode(bytes::Charset cs, bytes::DecodeErrorStrategy errors) 
 
         case bytes::Charset::ASCII: {
             std::string s;
-            for ( auto c : *this ) {
+            for ( auto c : str() ) {
                 if ( c >= 32 && c < 0x7f )
                     s += static_cast<char>(c);
                 else {

--- a/tests/Baseline/hilti.types.bytes.decode/output
+++ b/tests/Baseline/hilti.types.bytes.decode/output
@@ -2,3 +2,4 @@
 testing
 test??ng?
 testüng
+123?

--- a/tests/hilti/types/bytes/decode.hlt
+++ b/tests/hilti/types/bytes/decode.hlt
@@ -9,4 +9,5 @@ hilti::print(b"testing".decode(hilti::Charset::ASCII));
 hilti::print(b"testüng\n".decode(hilti::Charset::ASCII));
 hilti::print(b"testüng".decode(hilti::Charset::UTF8));
 assert b"testüng".decode(hilti::Charset::UTF8) == b"testüng".decode(); # Check default
+hilti::print(b" 123\x01 ".strip().decode(hilti::Charset::ASCII));
 }


### PR DESCRIPTION
Closes #1390.