### PR TITLE
Only run lint CI task from scheduled builds or PRs.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,7 @@ environment:
     HILTI_CXX_COMPILER_LAUNCHER: ccache
 
 lint_task:
+  skip: $CIRRUS_CRON == '' && $CIRRUS_PR == ''
   container:
     dockerfile: ci/Dockerfile
     cpu: 4


### PR DESCRIPTION
With proper caching now implementing, the linting task takes most of the time in a CI run since it executes uncacheable clang-tidy jobs. This PR only executes clang-tidy for PRs and in scheduled builds (currently: just a nightly build). This should make execute CI much faster will.