### PR TITLE
Update docs for changes in spicy-plugin [skip CI].

### DIFF
--- a/doc/zeek.rst
+++ b/doc/zeek.rst
@@ -513,8 +513,10 @@ the pieces going into such an event definition:
         ``$file``
             Refers to the file that's currently being processed by
             Zeek. On the Zeek-side this will turn into a parameter of
-            Zeek type ``fa_file``. This ID can be used only with file
-            analyzers.
+            Zeek type ``fa_file``. This ID can be used with file or protocol
+            analyzers. For protocol analyzers it refers to the most recently
+            opened, but not yet closed file, see :ref:`zeek::file_begin
+            <spicy_file_begin>` and :ref:`zeek::file_end <spicy_file_end>`.
 
         ``$packet``
             Refers to the packet that's currently being processed by


### PR DESCRIPTION
With zeek/spicy-plugin#201 `$file` became available for protocol analyzers. This patch updates the docs to reflect that.