### PR TITLE
Use safe helper to get runtime configuration.

### DIFF
--- a/spicy/runtime/src/parser.cc
+++ b/spicy/runtime/src/parser.cc
@@ -7,6 +7,7 @@
 #include <hilti/rt/types/bytes.h>
 #include <hilti/rt/types/stream.h>
 
+#include <spicy/rt/configuration.h>
 #include <spicy/rt/debug.h>
 #include <spicy/rt/global-state.h>
 #include <spicy/rt/parser.h>
@@ -19,12 +20,12 @@ HILTI_EXCEPTION_IMPL(MissingData);
 HILTI_EXCEPTION_IMPL(ParseError)
 
 void spicy::rt::accept_input() {
-    if ( const auto& hook = globalState()->configuration->hook_accept_input )
+    if ( const auto& hook = configuration::get().hook_accept_input )
         (*hook)();
 }
 
 void spicy::rt::decline_input(const std::string& reason) {
-    if ( const auto& hook = globalState()->configuration->hook_decline_input )
+    if ( const auto& hook = configuration::get().hook_decline_input )
         (*hook)(reason);
 }
 


### PR DESCRIPTION
We previously would directly access a value from the configuration in the global state in functions for `accept_input` and `decline_input`. This is only safe if the configuration was created previously, but would read uninitialized memory if e.g., a parser using these functions is embedded in code not doing that.

With this patch we use a safe accessor for the configuration which ensures that it always contains a good value.