### PR TITLE
Avoid unneeded temporaries when appending `View` to `Bytes`.

### DIFF
--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -211,7 +211,10 @@ Result<Bytes> Bytes::match(const RegExp& re, unsigned int group) const {
     return groups.at(group);
 }
 
-void Bytes::append(const stream::View& view) { Base::append(view.data()); }
+void Bytes::append(const stream::View& view) {
+    for ( auto block = view.firstBlock(); block; block = view.nextBlock(block) )
+        Base::append(reinterpret_cast<const char*>(block->start), block->size);
+}
 
 namespace hilti::rt::detail::adl {
 std::string to_string(const Bytes& x, tag /*unused*/) { return fmt("b\"%s\"", escapeBytes(x.str(), true)); }

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -350,7 +350,7 @@ std::tuple<bool, UnsafeConstIterator> View::_findBackward(const Bytes& needle, U
     }
 }
 
-void View::_force_vtable() { }
+void View::_force_vtable() {}
 
 bool View::startsWith(const Bytes& b) const {
     _ensureValid();
@@ -467,10 +467,7 @@ void Stream::append(const char* data, size_t len) {
 
 Bytes stream::View::data() const {
     Bytes s;
-
-    for ( auto block = firstBlock(); block; block = nextBlock(block) )
-        s.append(std::string(reinterpret_cast<const char*>(block->start), block->size));
-
+    s.append(*this);
     return s;
 }
 


### PR DESCRIPTION
We used `View::data` to constructs a new `Bytes` to append from. Since we cannot reuse the temporary in the append but have to copy the data this introduced unneeded overhead. This patch inlines the low-level `View` block iteration into `Bytes::append`.

I looked at this coming from zeek/spicy-dns#7, and with that particular test case where many small views are appended the speedup is only ~1.5%. I suspect the speedup to be bigger the bigger the view we append.

In order to amortize reallocation costs I also looked into aggressively reserving capacity in the different `append` overloads, e.g., if the new size is bigger than the current capacity, reserve double the needed capacity in anticipation of more append operations to come. This did not make a noticeable difference, probably due to the underlying `std::string::append` already doing something similar.