### PR TITLE
Fix gcc-13 warning about pessimizing move.

### DIFF
--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -858,7 +858,7 @@ std::vector<Node> nodes(T t) {
  */
 template<typename T, typename... Ts>
 std::vector<Node> nodes(T t, Ts... ts) {
-    return util::concat(std::move(nodes(t)), nodes(std::move(ts)...));
+    return util::concat(nodes(t), nodes(std::move(ts)...));
 }
 
 /**


### PR DESCRIPTION
We were using `std::move` on a temporary which prevents RVO. It also triggered a very noisy warning from gcc-13.