### PR TITLE
Add fast pass for iterator difference in `offset()`.

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -201,9 +201,9 @@ struct VisitorPass2 : public hilti::visitor::PreOrder<void, VisitorPass2> {
     }
 
     result_t operator()(const operator_::unit::Offset& n, position_t p) {
-        auto begin = builder::deref(builder::member(n.op0(), ID("__begin")));
-        auto cur = builder::deref(builder::member(n.op0(), ID("__position")));
-        replaceNode(&p, builder::cast(builder::difference(cur, begin), type::UnsignedInteger(64)));
+        auto begin = builder::memberCall(builder::deref(builder::member(n.op0(), ID("__begin"))), "offset", {});
+        auto cur = builder::memberCall(builder::deref(builder::member(n.op0(), ID("__position"))), "offset", {});
+        replaceNode(&p, builder::grouping(builder::difference(cur, begin)));
     }
 
     result_t operator()(const operator_::unit::Position& n, position_t p) {

--- a/tests/Baseline/spicy.optimization.feature_requirements/noopt.hlt
+++ b/tests/Baseline/spicy.optimization.feature_requirements/noopt.hlt
@@ -196,7 +196,7 @@ const bool __feat%foo__X6%supports_sinks = True;
 const bool __feat%foo__X6%synchronization = True;
 
 method hook void foo::X1::__on_0x25_init() {
-    cast<uint<64>>((*self.__position) - (*self.__begin));
+    ((*self.__position).offset() - (*self.__begin).offset());
 }
 
 method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X1::__parse_stage1(inout value_ref<stream> __data, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {

--- a/tests/Baseline/spicy.optimization.feature_requirements/opt.hlt
+++ b/tests/Baseline/spicy.optimization.feature_requirements/opt.hlt
@@ -85,7 +85,7 @@ const bool __feat%foo__X6%supports_sinks = True;
 const bool __feat%foo__X6%synchronization = False;
 
 method hook void foo::X1::__on_0x25_init() {
-    cast<uint<64>>((*self.__position) - (*self.__begin));
+    ((*self.__position).offset() - (*self.__begin).offset());
 }
 
 init function void __register_foo_X1() {


### PR DESCRIPTION
When generating code for `offset()` we previously would use the difference of safe iterator which has extra code to make sure the two iterators belong to the same stream. This check can never fail when computing `offset()` so use a fast pass in that case.