### PR TITLE
Bump reproc dependency to fix building with gcc-13.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ environment:
     IMAGE_MACOS_VENTURA: ghcr.io/cirruslabs/macos-ventura-base:latest
 
     # Branches to use for spicy-plugin and spicy-analyzers tests.
-    ZEEK_SPICY_BRANCH:      main
+    ZEEK_SPICY_BRANCH:      release/1.3
     ZEEK_ANALYZERS_BRANCH:  main
 
     # Cache HILTI C++ compilation.


### PR DESCRIPTION
The recently released gcc-13 is supported by Zeek LTS releases and users reported issues from building Spicy with that compiler, see #1416.

This patch bump the reproc dependency to a recent development snapshot which addresses that (currently their latest `main` still cannot build without hard errors). Since this could pull in breaking changes in `3rdparty/reproc` this is technically a breaking change, but after discussion the consensus among the merge masters was that this was acceptable, e.g., since this we hope and expect this to not be directly visible by users.