### PR TITLE
Fixes for building with gcc13

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -2,7 +2,7 @@
 # to CMake because we directly pick out the pieces where we need
 # them.
 
-option(DOCTEST_NO_INSTALL  "Skip the installation process" ON)
+option(DOCTEST_NO_INSTALL "Skip the installation process" ON)
 add_subdirectory(doctest)
 
 add_subdirectory(justrx)
@@ -29,3 +29,15 @@ set(REPROC_OBJECT_LIBRARIES ON)
 add_subdirectory(reproc)
 set_property(TARGET reproc PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET reproc++ PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# GCC-13 warns about code in reproc++. This is fixed upstream with
+# DaanDeMeyer/reproc@0b23d88894ccedde04537fa23ea55cb2f8365342, but that patch
+# has not landed in a release yet. Disable the warning if the compiler knows
+# about it.
+#
+# TODO(bbannier): Drop this once reproc puts out a release officially supporting gcc-13.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-Wno-changes-meaning" _has_no_changes_meaning_flag)
+if (_has_no_changes_meaning_flag)
+    set_property(TARGET reproc++ PROPERTY COMPILE_OPTIONS "-Wno-changes-meaning")
+endif ()

--- a/hilti/runtime/include/intrusive-ptr.h
+++ b/hilti/runtime/include/intrusive-ptr.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <type_traits>
 #include <utility>

--- a/hilti/toolchain/include/ast/operators/tuple.h
+++ b/hilti/toolchain/include/ast/operators/tuple.h
@@ -148,10 +148,14 @@ BEGIN_OPERATOR_CUSTOM(tuple, CustomAssign)
             return;
         }
 
+        const auto& lhs_value = lhs.value();
+        const auto& lhs_type_elements = lhs_type.elements();
+        const auto& rhs_type_elements = rhs_type->elements();
+
         for ( auto j = 0U; j < lhs_type.elements().size(); j++ ) {
-            const auto& lhs_elem = lhs.value()[j];
-            const auto& lhs_elem_type = lhs_type.elements()[j].type();
-            const auto& rhs_elem_type = rhs_type->elements()[j].type();
+            const auto& lhs_elem = lhs_value[j];
+            const auto& lhs_elem_type = lhs_type_elements[j].type();
+            const auto& rhs_elem_type = rhs_type_elements[j].type();
 
             if ( ! lhs_elem.isLhs() )
                 p.node.addError(util::fmt("cannot assign to expression: %s", to_node(lhs_elem)));

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -445,7 +445,8 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
     result_t operator()(const operator_::result::Error& n) { return fmt("%s.errorOrThrow()", op0(n)); }
 
     result_t operator()(const operator_::generic::Pack& n) {
-        const auto& type = n.op0().as<expression::Ctor>().ctor().as<ctor::Tuple>().value()[0].type();
+        const auto& ctor = n.op0().as<expression::Ctor>().ctor().as<ctor::Tuple>().value();
+        const auto& type = ctor[0].type();
         auto args = tupleArguments(n, n.op0());
         return cg->pack(type, args[0], util::slice(args, 1, -1));
     }
@@ -527,8 +528,7 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
 
     // Optional
     result_t operator()(const operator_::optional::Deref& n) {
-        return {fmt("::hilti::rt::optional::value(%s)", op0(n)),
-                cxx::Side::LHS};
+        return {fmt("::hilti::rt::optional::value(%s)", op0(n)), cxx::Side::LHS};
     }
 
     /// Port

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -1297,7 +1297,8 @@ void Driver::_dumpDeclarations(const std::shared_ptr<Unit>& unit, const Plugin& 
     HILTI_DEBUG(logging::debug::AstDeclarations,
                 fmt("# [%s] %s", pluginForUnit(unit).get().component, unit->uniqueID()));
 
-    for ( const auto i : visitor::PreOrder<>().walk(unit->module()) ) {
+    auto v = visitor::PreOrder<>();
+    for ( const auto i : v.walk(unit->module()) ) {
         auto decl = i.node.tryAs<Declaration>();
         if ( ! decl )
             continue;

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -21,8 +21,19 @@
 #include <hilti/compiler/detail/cxx/unit.h>
 #include <hilti/compiler/jit.h>
 
+// GCC-13 warns about code in reproc++. This is fixed upstream with
+// DaanDeMeyer/reproc@0b23d88894ccedde04537fa23ea55cb2f8365342, but that patch
+// has not landed in a release yet. Disable the warning if the compiler knows
+// about it.
+//
+// TODO(bbannier): Drop this once reproc puts out a release officially supporting gcc-13.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wchanges-meaning"
 #include <reproc++/drain.hpp>
 #include <reproc++/reproc.hpp>
+#pragma GCC diagnostic pop
 
 using namespace hilti;
 

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1502,7 +1502,8 @@ void Optimizer::run() {
 
     // Clear cached information which might become outdated due to edits.
     for ( auto& unit : units ) {
-        for ( auto i : hilti::visitor::PreOrder<>().walk(&unit->module()) ) {
+        auto v = hilti::visitor::PreOrder<>();
+        for ( auto i : v.walk(&unit->module()) ) {
             i.node.clearScope();
         }
     }

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -461,7 +461,8 @@ void Unit::resetAST() {
 
     HILTI_DEBUG(logging::debug::Compiler, fmt("resetting nodes for module %s", uniqueID()));
 
-    for ( auto&& i : hilti::visitor::PreOrder<>().walk(&*_module) ) {
+    auto v = hilti::visitor::PreOrder<>();
+    for ( auto&& i : v.walk(&*_module) ) {
         i.node.clearScope();
         i.node.clearErrors();
     }

--- a/hilti/toolchain/src/compiler/visitors/coercer.cc
+++ b/hilti/toolchain/src/compiler/visitors/coercer.cc
@@ -582,9 +582,12 @@ struct Visitor : public visitor::PreOrder<void, Visitor> {
         bool changed = false;
         std::vector<Expression> new_elems;
 
+        const auto& lhs_type_elements = lhs_type.elements();
+        const auto& rhs_type_elements = rhs_type->elements();
+
         for ( auto i = 0U; i < lhs_type.elements().size(); i++ ) {
-            const auto& lhs_elem_type = lhs_type.elements()[i].type();
-            auto rhs_elem_type = rhs_type->elements()[i].type();
+            const auto& lhs_elem_type = lhs_type_elements[i].type();
+            auto rhs_elem_type = rhs_type_elements[i].type();
             auto rhs_elem =
                 expression::TypeWrapped(operator_::tuple::Index::Operator().instantiate({n.op1(), builder::integer(i)},
                                                                                         n.meta()),

--- a/hilti/toolchain/src/compiler/visitors/renderer.cc
+++ b/hilti/toolchain/src/compiler/visitors/renderer.cc
@@ -13,7 +13,8 @@ using util::fmt;
 static void render(const Node& n, std::ostream* out, std::optional<logging::DebugStream> dbg, bool include_scopes) {
     util::timing::Collector _("hilti/renderer");
 
-    for ( const auto i : visitor::PreOrder<>().walk(n) ) {
+    auto v = visitor::PreOrder<>();
+    for ( const auto i : v.walk(n) ) {
         if ( dbg )
             logger().debugSetIndent(*dbg, i.path.size());
 

--- a/hilti/toolchain/src/compiler/visitors/resolver.cc
+++ b/hilti/toolchain/src/compiler/visitors/resolver.cc
@@ -461,7 +461,8 @@ struct Visitor : public visitor::PostOrder<void, Visitor> {
             return;
 
         // Look for a `return` to infer the return type.
-        for ( const auto i : visitor::PreOrder<>().walk(&p.node) ) {
+        auto v = visitor::PreOrder<>();
+        for ( const auto i : v.walk(&p.node) ) {
             if ( auto x = i.node.tryAs<statement::Return>();
                  x && x->expression() && type::isResolved(x->expression()->type()) ) {
                 const auto& rt = x->expression()->type();
@@ -845,8 +846,9 @@ bool Visitor::resolveCast(const expression::UnresolvedOperator& u, position_t p)
     // We hardcode that a cast<> operator can always perform any
     // legal coercion. This helps in cases where we need to force a
     // specific coercion to take place.
-    const auto& expr = u.operands()[0];
-    const auto& dst = u.operands()[1].as<expression::Type_>().typeValue();
+    const auto& operands = u.operands();
+    const auto& expr = operands[0];
+    const auto& dst = operands[1].as<expression::Type_>().typeValue();
     const auto style = CoercionStyle::TryAllForMatching | CoercionStyle::ContextualConversion;
 
     if ( auto c = hilti::coerceExpression(expr, dst, style) ) {

--- a/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
@@ -177,7 +177,7 @@ public:
     void popState() { _states.pop_back(); }
 
     /** Returns the current parsing state. */
-    ParserState state() const { return _states.back(); }
+    const ParserState& state() const { return _states.back(); }
 
     /**
      * Returns an expression referencing the 1st version of a publicly

--- a/tests/hilti/statements/assert.hlt
+++ b/tests/hilti/statements/assert.hlt
@@ -2,6 +2,11 @@
 # @TEST-EXEC-FAIL: ${HILTIC} -j false1.hlt >>output 2>&1
 # @TEST-EXEC-FAIL: ${HILTIC} -j false2.hlt >>output 2>&1
 # @TEST-EXEC-FAIL: ${HILTIC} -j false3.hlt >>output 2>&1
+#
+# Since the output might contain compiler diagnostics for generated code, strip
+# out anything but the assertion messages under test.
+# @TEST-EXEC: grep AssertionFailure: output > output2 && mv output2 output
+#
 # @TEST-EXEC: btest-diff output
 
 @TEST-START-FILE true.hlt


### PR DESCRIPTION
gcc13 is part supported Zeek platforms, e.g., it comes as part of fedora-38. This PR collects a number of fixes required to build with gcc13, and also interesting issues it diagnoses around dangling references. We do not add CI here in the hope that that will be added e.g., in zeek/zeek as part of the platform support policy put forth there.