### PR TITLE
Fix stdlib exception leak in `bytes::sub`

### DIFF
--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -294,7 +295,13 @@ public:
      * @param offset of one byeond end of subrage
      * @return a `Bytes` instance for the subrange
      */
-    Bytes sub(Offset from, Offset to) const { return {substr(from, to - from)}; }
+    Bytes sub(Offset from, Offset to) const {
+        try {
+            return {substr(from, to - from)};
+        } catch ( const std::out_of_range& ) {
+            throw OutOfRange(fmt("start index %s out of range for bytes with length %d", from, size()));
+        }
+    }
 
     /**
      * Extracts a subrange of bytes from the beginning.

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -332,6 +332,10 @@ TEST_CASE("sub") {
     SUBCASE("end iterator") {
         CHECK_EQ(b.sub(b.begin()), ""_b);
         CHECK_EQ(b.sub(b.end()), b);
+
+        const auto bb = "123"_b;
+        CHECK_THROWS_WITH_AS(b.sub(bb.begin()), "start and end iterator cannot belong to different bytes",
+                             const InvalidArgument&);
     }
 
     SUBCASE("start/end iterator") {
@@ -340,8 +344,8 @@ TEST_CASE("sub") {
 
         const auto bb = "123"_b;
         // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
-        CHECK_THROWS_WITH_AS(b.sub(b.begin(), bb.begin()),
-                             "cannot perform arithmetic with iterators into different bytes", const InvalidArgument&);
+        CHECK_THROWS_WITH_AS(b.sub(b.begin(), bb.begin()), "start and end iterator cannot belong to different bytes",
+                             const InvalidArgument&);
     }
 }
 


### PR DESCRIPTION
Closes #1436.