### PR TITLE
Skip failure notifications for unsuccessfull non-error runs.

### DIFF
--- a/.github/workflows/email-failure.yml
+++ b/.github/workflows/email-failure.yml
@@ -8,7 +8,7 @@ name: Email about Cirrus CI failures
 jobs:
   continue:
     name: After Cirrus CI Failure
-    if: github.event.check_suite.app.name == 'Cirrus CI' && github.event.check_suite.conclusion != 'success'
+    if: github.event.check_suite.app.name == 'Cirrus CI' && contains(fromJson('["cancelled", "neutral", "skipped"]'), github.event.check_suite.conclusion)
     runs-on: ubuntu-latest
     steps:
       - uses: octokit/request-action@v2.x


### PR DESCRIPTION
We previously would send out a failure notification if a run was e.g., cancelled since a PR got merged before CI completed. With this PR we now skip such "uninteresting" events (cancelled, neutral, and skipped CI conclusions).