### PR TITLE
Do not forcibly make `strong_ref` `in` function parameters immutable.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -653,7 +653,7 @@ struct VisitorStorage : hilti::visitor::PreOrder<CxxTypes, VisitorStorage> {
         else
             t = "*";
 
-        return CxxTypes{.base_type = t, .param_in = fmt("const %s", t), .param_inout = fmt("%s", t)};
+        return CxxTypes{.base_type = t, .param_in = fmt("%s", t), .param_inout = fmt("%s", t)};
     }
 
     result_t operator()(const type::stream::View& n) { return CxxTypes{.base_type = "::hilti::rt::stream::View"}; }


### PR DESCRIPTION
We previously would always emit a `const` value when passing a `strong_ref` as a function parameter. This lead to the unintuitive error that non-const `strong_ref` parameters could not be modified or have non-const methods called on them (this would actually fail at codegen time).

With this patch we remove the special treatment of `strong_ref` parameter mutability.

Closes #1447.