### PR TITLE
Allow resolving of unit parameters before `self` is fully resolved.

### DIFF
--- a/hilti/toolchain/src/compiler/visitors/scope-builder.cc
+++ b/hilti/toolchain/src/compiler/visitors/scope-builder.cc
@@ -169,6 +169,9 @@ struct Visitor : public visitor::PostOrder<void, Visitor> {
     }
 
     void operator()(const type::Struct& t, position_t p) {
+        for ( auto&& x : t.parameterRefs() )
+            p.parent().scope()->insert(std::move(x));
+
         if ( ! p.node.as<Type>().typeID() )
             // We need to associate the type ID with the declaration we're
             // creating, so wait for that to have been set by the resolver.
@@ -176,9 +179,6 @@ struct Visitor : public visitor::PostOrder<void, Visitor> {
 
         if ( t.selfRef() )
             p.node.scope()->insert(t.selfRef());
-
-        for ( auto&& x : t.parameterRefs() )
-            p.parent().scope()->insert(std::move(x));
     }
 };
 

--- a/spicy/toolchain/src/compiler/visitors/resolver.cc
+++ b/spicy/toolchain/src/compiler/visitors/resolver.cc
@@ -115,7 +115,7 @@ struct Visitor : public hilti::visitor::PreOrder<void, Visitor> {
     };
 #endif
 
-    // Log debug message recording resolving a epxxression.
+    // Log debug message recording resolving a expression.
     void logChange(const Node& old, const Expression& nexpr) {
         HILTI_DEBUG(logging::debug::Resolver,
                     hilti::util::fmt("[%s] %s -> expression %s (%s)", old.typename_(), old, nexpr, old.location()));

--- a/tests/spicy/types/unit/params-resolve.spicy
+++ b/tests/spicy/types/unit/params-resolve.spicy
@@ -1,0 +1,24 @@
+# @TEST-DOC: Validate that unit parameters shadown globals of same name. This is a regression test for #1452.
+#
+# @TEST-EXEC: echo | spicy-driver -d %INPUT
+
+module foo;
+
+# This unit should pick up the value passed during initialization at runtime, not the global.
+type X = unit(x: uint64) {
+    var x: uint64 = x;
+};
+
+public type A = unit {
+    x: X(4711);
+    on %done { assert self.x.x == 4711; }
+};
+
+global x: uint64 = 0;
+
+# Since the parameter shadows the global of different type this compiles without type errors.
+type Z = unit(z: uint64) {
+    var z: uint64 = z;
+};
+
+global z: real = 0;


### PR DESCRIPTION
When constructing the list of declarations in a scope we previously would not emit any items for struct types without fully resolved type. This lead to the situation where when resolving references to a unit parameter we might end up resolving them to similarly named globals since they were available before the struct type was resolved.

This patch makes sure that we emit at least unit parameters at struct scope level, even if we cannot emit `self` yet. This improves the situation around globals mentioned above and is likley okay since `self` should only ever resolve to something at struct scope.

Closes #1452.