### PR TITLE
Clean up dependencies for ubuntu-22 image.

### DIFF
--- a/docker/Dockerfile.ubuntu-22
+++ b/docker/Dockerfile.ubuntu-22
@@ -11,19 +11,13 @@ CMD ["sh"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/opt/spicy/bin:${PATH}"
 
+# Spicy build and test dependencies.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 less sudo \
- # Spicy build and test dependencies.
  && apt-get install -y --no-install-recommends git cmake ninja-build ccache bison flex g++ libfl-dev zlib1g-dev libssl-dev jq locales-all make \
  # Spicy doc dependencies.
  && apt-get install -y --no-install-recommends python3 python3-pip python3-sphinx python3-sphinx-rtd-theme python3-setuptools python3-wheel doxygen \
  && pip3 install "btest>=0.66" pre-commit \
- # Install a recent CMake.
- && mkdir -p /opt/cmake \
- && curl -L https://github.com/Kitware/CMake/releases/download/v3.18.0/cmake-3.18.0-Linux-x86_64.tar.gz | tar xzvf - -C /opt/cmake --strip-components 1 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/opt/cmake/bin:${PATH}"
 
 WORKDIR /root


### PR DESCRIPTION
The distribution already comes with a new-enough CMake so we do not need to install one out of band.