### PR TITLE
Add bitwise operators `&`, `|`, and `^` for booleans.

### DIFF
--- a/doc/autogen/types/bool.rst
+++ b/doc/autogen/types/bool.rst
@@ -1,5 +1,17 @@
 .. rubric:: Operators
 
+.. spicy:operator:: bool_::BitAnd bool t:bool <sp> op:& <sp> t:bool
+
+    Computes the bit-wise 'and' of the two boolean values.
+
+.. spicy:operator:: bool_::BitOr bool t:bool <sp> op:| <sp> t:bool
+
+    Computes the bit-wise 'or' of the two boolean values.
+
+.. spicy:operator:: bool_::BitXor bool t:bool <sp> op:^ <sp> t:bool
+
+    Computes the bit-wise 'xor' of the two boolean values.
+
 .. spicy:operator:: bool_::Equal bool t:bool <sp> op:== <sp> t:bool
 
     Compares two boolean values.

--- a/hilti/toolchain/include/ast/operators/bool.h
+++ b/hilti/toolchain/include/ast/operators/bool.h
@@ -10,5 +10,11 @@ namespace hilti::operator_ {
 
 STANDARD_OPERATOR_2(bool_, Equal, type::Bool(), type::Bool(), type::Bool(), "Compares two boolean values.")
 STANDARD_OPERATOR_2(bool_, Unequal, type::Bool(), type::Bool(), type::Bool(), "Compares two boolean values.")
+STANDARD_OPERATOR_2(bool_, BitAnd, type::Bool(), type::Bool(), type::Bool(),
+                    "Computes the bit-wise 'and' of the two boolean values.");
+STANDARD_OPERATOR_2(bool_, BitOr, type::Bool(), type::Bool(), type::Bool(),
+                    "Computes the bit-wise 'or' of the two boolean values.");
+STANDARD_OPERATOR_2(bool_, BitXor, type::Bool(), type::Bool(), type::Bool(),
+                    "Computes the bit-wise 'xor' of the two boolean values.");
 
 } // namespace hilti::operator_

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -92,6 +92,9 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
 
     result_t operator()(const operator_::bool_::Equal& n) { return binary(n, "=="); }
     result_t operator()(const operator_::bool_::Unequal& n) { return binary(n, "!="); }
+    result_t operator()(const operator_::bool_::BitAnd& n) { return binary(n, "&"); }
+    result_t operator()(const operator_::bool_::BitOr& n) { return binary(n, "|"); }
+    result_t operator()(const operator_::bool_::BitXor& n) { return binary(n, "^"); }
 
     /// bytes::Iterator
 

--- a/tests/hilti/types/bool/operators.hlt
+++ b/tests/hilti/types/bool/operators.hlt
@@ -1,0 +1,36 @@
+# @TEST-EXEC: ${HILTIC} -dj %INPUT
+
+module Foo {
+
+assert True == True;
+assert False == False;
+
+assert True != False;
+assert False != True;
+assert False != True;
+
+assert True && True;
+assert ! ( False && False );
+assert ! ( True && False );
+assert ! ( False && True );
+
+assert True & True;
+assert ! ( False & False );
+assert ! ( True & False );
+assert ! ( False & True );
+
+assert True || True;
+assert ! ( False || False );
+assert True || False;
+assert False || True;
+
+assert True | True;
+assert ! ( False | False );
+assert True | False;
+assert False | True;
+
+assert ! (True ^ True);
+assert ! ( False ^ False );
+assert True ^ False;
+assert False ^ True;
+}


### PR DESCRIPTION
Closes #1435.