### PR TITLE
Fix signedness warning.

### DIFF
--- a/spicy/toolchain/src/compiler/visitors/resolver.cc
+++ b/spicy/toolchain/src/compiler/visitors/resolver.cc
@@ -273,7 +273,7 @@ struct Visitor : public hilti::visitor::PreOrder<void, Visitor> {
             // Transparently map void fields that aim to parse data into
             // skipping bytes fields. Use of such void fields is deprecated and
             // will be removed later.
-            int ok_attrs = 0;
+            size_t ok_attrs = 0;
             const auto& attrs = u.attributes()->attributes();
             for ( const auto& a : attrs ) {
                 if ( a.tag() == "&requires" )


### PR DESCRIPTION
    warning: comparison of integer expressions of different signedness

Debian Bullsye, gcc (Debian 10.2.1-6) 10.2.1 20210110.