### PR TITLE
Fix search on RTD

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,5 +3,5 @@
 # Note: beware of https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 # and broken behavior with docutils 0.17.
 docutils==0.18.1
-sphinx_rtd_theme==1.2.0
+sphinx_rtd_theme==1.2.2
 Sphinx==6.2.1


### PR DESCRIPTION
This fixes the unavailability of search on [RTD](https://docs.zeek.org/projects/spicy/en). The related sphix_rt_theme issue is https://github.com/readthedocs/sphinx_rtd_theme/issues/1452. A temporary preview is available [here](https://docs.zeek.org/projects/spicy/en/topic-bbannier-rtd-search/).