### PR TITLE
Mention unit switch statements in conditional parsing docs.

### DIFF
--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -1319,6 +1319,9 @@ time the field is next in line.
     :exec: printf '\01\02\03\04' | spicy-driver %INPUT; printf '\02\02\03\04' | spicy-driver %INPUT
     :show-with: foo.spicy
 
+For repeated cases of conditional parsing unit :ref:`parse_switch` statements
+might allow for more compact and easier to maintain code.
+
 .. _parse_lookahead:
 
 Look-Ahead


### PR DESCRIPTION
Instead of decorating many fields with `if` conditions for certain grammars a simpler approach can be to use a unit switch statement with branch-by-expressions. Add a link to unit switch from the conditional parsing section.