### PR TITLE
Fix handling of `--show-backtraces` flag.

### DIFF
--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -39,7 +39,7 @@ constexpr int OPT_CXX_LINK = 1000;
 constexpr int OPT_CXX_ENABLE_DYNAMIC_GLOBALS = 1001;
 
 static struct option long_driver_options[] = {{"abort-on-exceptions", required_argument, nullptr, 'A'},
-                                              {"show-backtraces", required_argument, nullptr, 'B'},
+                                              {"show-backtraces", no_argument, nullptr, 'B'},
                                               {"compiler-debug", required_argument, nullptr, 'D'},
                                               {"cxx-enable-dynamic-globals", no_argument, nullptr,
                                                OPT_CXX_ENABLE_DYNAMIC_GLOBALS},


### PR DESCRIPTION
This flag was intended and always documented as a toggle, but instead implemented as an argument taking a value (which was never evaluated). This patch fixes the implementation to align with itend and documentation.