### PR TITLE
Fix stringification of `DecodeErrorStrategy`.

### DIFF
--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -113,6 +113,12 @@ TEST_CASE("bytes::Charset") {
     CHECK_EQ(to_string(Enum(bytes::Charset::Undef)), "Charset::Undef");
 }
 
+TEST_CASE("bytes::DecodeErrorStrategy") {
+    CHECK_EQ(to_string(Enum(bytes::DecodeErrorStrategy::IGNORE)), "DecodeErrorStrategy::IGNORE");
+    CHECK_EQ(to_string(Enum(bytes::DecodeErrorStrategy::REPLACE)), "DecodeErrorStrategy::REPLACE");
+    CHECK_EQ(to_string(Enum(bytes::DecodeErrorStrategy::STRICT)), "DecodeErrorStrategy::STRICT");
+}
+
 TEST_CASE("bytes::Side") {
     CHECK_EQ(to_string(Enum(bytes::Side::Left)), "Side::Left");
     CHECK_EQ(to_string(Enum(bytes::Side::Right)), "Side::Right");

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -231,9 +231,9 @@ std::string to_string(const bytes::Charset& x, tag /*unused*/) {
 
 std::string to_string(const bytes::DecodeErrorStrategy& x, tag /*unused*/) {
     switch ( x.value() ) {
-        case bytes::DecodeErrorStrategy::IGNORE: return "Charset::IGNORE";
-        case bytes::DecodeErrorStrategy::REPLACE: return "Charset::REPLACE";
-        case bytes::DecodeErrorStrategy::STRICT: return "Charset::STRICT";
+        case bytes::DecodeErrorStrategy::IGNORE: return "DecodeErrorStrategy::IGNORE";
+        case bytes::DecodeErrorStrategy::REPLACE: return "DecodeErrorStrategy::REPLACE";
+        case bytes::DecodeErrorStrategy::STRICT: return "DecodeErrorStrategy::STRICT";
     }
 
     cannot_be_reached();


### PR DESCRIPTION
This was pointed out by Simeon Miteff in #1384.