### PR TITLE
Fix when GH `email-failure` action sends notification.

### DIFF
--- a/.github/workflows/email-failure.yml
+++ b/.github/workflows/email-failure.yml
@@ -9,7 +9,7 @@ name: Email about Cirrus CI failures
 jobs:
   continue:
     name: After Cirrus CI Failure
-    if: github.event.check_suite.app.name == 'Cirrus CI' && contains(fromJson('["cancelled", "neutral", "skipped"]'), github.event.check_suite.conclusion)
+    if: github.event.check_suite.app.name == 'Cirrus CI' && contains(fromJson('["failure", "timed_out", "action_required", "startup_failure"]'), github.event.check_suite.conclusion)
     runs-on: ubuntu-latest
     steps:
       - uses: octokit/request-action@v2.x

--- a/.github/workflows/email-success.yml
+++ b/.github/workflows/email-success.yml
@@ -8,7 +8,7 @@ on:
 name: Email about successful Cirrus CI builds
 jobs:
   continue:
-    name: After Cirrus CI Failure
+    name: After Cirrus CI Success
     if: github.event.check_suite.app.name == 'Cirrus CI' && github.event.check_suite.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In order to detect whether to send out a failure email we previously would check that the action conclusion contained certain statuses. This check seems to have been nonsensical as we only notified for benign failure reasons (the check would have made a little more sense if negated, but would have then also notified on successes).

With this patch we instead explicitly enumerate the failure conclusions to trigger on, see
https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_suite--check_suite-object for the full list of conclusions.