### PR TITLE
Fix returned value for `<unit>.position()`.

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -201,7 +201,7 @@ struct VisitorPass2 : public hilti::visitor::PreOrder<void, VisitorPass2> {
     }
 
     result_t operator()(const operator_::unit::Position& n, position_t p) {
-        replaceNode(&p, builder::member(n.op0(), ID("__position")));
+        replaceNode(&p, builder::deref(builder::member(n.op0(), ID("__position"))));
     }
 
     result_t operator()(const operator_::unit::Input& n, position_t p) {

--- a/tests/spicy/types/unit/offset.spicy
+++ b/tests/spicy/types/unit/offset.spicy
@@ -6,13 +6,22 @@ module Mini;
 import spicy;
 
 type Sub = unit {
-    on %init   { print "Sub:init", self.offset(), self.position(); }
-    x: uint16  { print "Sub:x", self.offset(), self.position(); }
-    y: uint8   { print "Sub:y", self.offset(), self.position(); }
+    on %init { print "Sub:init", self.offset(), self.position(); }
+    x: uint16 { print "Sub:x", self.offset(), self.position(); }
+    y: uint8 { print "Sub:y", self.offset(), self.position(); }
 };
 
 public type Test = unit {
-    on %init           { print "Main:init", self.offset(), self.position(); }
-    : Sub[3]   foreach { print "Main:Sub", self.offset(), self.position(); }
-    on %done           { print "Main:done", self.offset(), self.position(); }
+    on %init {
+        print "Main:init", self.offset(), self.position();
+        assert self.position().offset() == self.offset();
+    }
+    : Sub[3] foreach {
+        print "Main:Sub", self.offset(), self.position();
+        assert self.position().offset() == self.offset();
+    }
+    on %done {
+        print "Main:done", self.offset(), self.position();
+        assert self.position().offset() == self.offset();
+    }
 };


### PR DESCRIPTION
We declared this method to return an iterator, but potentially returned an optional iterator. This patch add an additional deref so we get the correct value.

Closes #1508.