### PR TITLE
Do not include generated Doxygen documentation in RTD search results

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,13 @@ sphinx:
 python:
   install:
     - requirements: doc/requirements.txt
+
+search:
+  ignore:
+    - "doxygen-output/*"
+    - "_static/*"
+    # Defaults.
+    - search.html
+    - search/index.html
+    - 404.html
+    - 404/index.html


### PR DESCRIPTION
Doxygen documentation is likely not relevant for users and hides results they are looking for. Also, Doxygen already comes with its own search which is reachable the developer documentation.

Closes #1516.