### PR TITLE
Add support for passing arbitrary C++ compiler flags.

### DIFF
--- a/doc/programming/extending.rst
+++ b/doc/programming/extending.rst
@@ -278,3 +278,13 @@ If your C++ code requires additional include files outside of standard
 include paths, you can set the environment variable
 ``HILTI_CXX_INCLUDE_DIRS`` to a colon-separated list of additional
 directories for ``spicyc`` to use when compiling C++ code.
+
+Passing arbitrary compiler flags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to set arbitrary compiler flags you can use the environment
+variable ``HILTI_CXX_FLAGS``. If this value is set it will be added verbatim as
+the last argument to the compiler invocation used when compiling C++ code.
+
+.. warning:: Prefer using ``HILTI_CXX_INCLUDE_DIRS`` for setting include paths
+  since paths set this way will be searched before implicit paths.

--- a/doc/toolchain.rst
+++ b/doc/toolchain.rst
@@ -61,9 +61,16 @@ control the compilation process:
         during JIT. Setting this variable to an empty value disables use of
         ``ccache`` in that case.
 
+    ``HILTI_CXX_FLAGS``
+        Specifies additional flags to pass during C++ compilation. This will be
+        added after all implicit arguments. Use ``HILTI_CXX_INCLUDE_DIRS`` to
+        specify additional include directories.
+
     ``HILTI_CXX_INCLUDE_DIRS``
-        Specified additional, colon-separated C++ include directory to
-        search for header files.
+        Specifies additional, colon-separated C++ include directories to
+        search for header files. Directories passed via
+        ``HILTI_CXX_INCLUDE_DIRS`` will be searched for headers before any
+        header search paths implicit in Spicy C++ compilation.
 
     ``HILTI_JIT_PARALLELISM``
         Set to specify the maximum number of background compilation jobs to run

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -305,13 +305,16 @@ hilti::Result<Nothing> JIT::_compile() {
             args.push_back(i);
         }
 
-        if ( auto path = getenv("HILTI_CXX_INCLUDE_DIRS") ) {
-            for ( auto&& dir : hilti::rt::split(path, ":") ) {
+        if ( auto path = hilti::rt::getenv("HILTI_CXX_INCLUDE_DIRS") ) {
+            for ( auto&& dir : hilti::rt::split(*path, ":") ) {
                 if ( ! dir.empty() ) {
                     args.insert(args.begin(), {"-I", std::string(dir)});
                 }
             }
         }
+
+        if ( auto flags = hilti::rt::getenv("HILTI_CXX_FLAGS") )
+            args.push_back(*flags);
 
         // We explicitly create the object file in the temporary directory.
         // This ensures that we use a temp path for object files created for

--- a/tests/hilti/hiltic/jit/cxx-flags.hlt
+++ b/tests/hilti/hiltic/jit/cxx-flags.hlt
@@ -1,0 +1,20 @@
+# @TEST-EXEC: HILTI_CXX_FLAGS=-DRETURN_VALUE=42 ${HILTIC} -j %INPUT my-test.cc
+#
+# @TEST-DOC: Ensure hiltic honors the environment variable HILTI_CXX_INCLUDE_DIRS
+
+module Test {
+
+declare public int<64> test_cc() &cxxname="test_cc";
+
+assert(test_cc() == 42);
+
+}
+
+@TEST-START-FILE my-test.cc
+
+#include <cstdint>
+#include <hilti/rt/types/integer.h>
+
+hilti::rt::integer::safe<int64_t> test_cc() { return RETURN_VALUE; }
+
+@TEST-END-FILE


### PR DESCRIPTION
This adds a magic environment variable `HILTI_CXX_FLAGS` which if set specifies compiler flags which should be passed during C++ compilation after implicit flags. This could be used to e.g., set defines, or set low-level compiler flags.

Even with this flag, for passing include directories one should still use `HILTI_CXX_INCLUDE_DIRS` since they are searched before any implicitly added paths.