### PR TITLE
Declare Spicy pygments extension as parallel-safe. [skip CI]

### DIFF
--- a/doc/scripts/spicy-pygments.py
+++ b/doc/scripts/spicy-pygments.py
@@ -8,6 +8,10 @@ from sphinx.highlighting import lexers
 def setup(app):
     lexers['spicy'] = SpicyLexer()
     lexers['spicy-evt'] = SpicyEvtLexer()
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }
 
 
 class SpicyLexer(RegexLexer):


### PR DESCRIPTION
We previously would not declare that the Spicy pygments highlighter is safe to execute in parallel (reading or writing of sources). Sphinx then assumed that the extension was not safe to run in parallel and instead ran jobs sequentially.

This patch declares the extension as able to execute in parallel. Since the extension does not manage any external state this is safe.