### PR TITLE
feat: report paths as relative to binary

### DIFF
--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -417,7 +417,7 @@ using hilti::rt::createTemporaryFile; // NOLINT(misc-unused-using-decls)
 hilti::rt::filesystem::path currentExecutable();
 
 /** Returns the path relative to parent of the current executable. */
-hilti::rt::filesystem::path fromOrigin(const hilti::rt::filesystem::path &relativePath);
+hilti::rt::filesystem::path fromOrigin(const hilti::rt::filesystem::path& relativePath);
 
 /** Dumps a backtrace to stderr and then aborts execution. */
 [[noreturn]] extern void abort_with_backtrace();

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -416,6 +416,9 @@ using hilti::rt::createTemporaryFile; // NOLINT(misc-unused-using-decls)
 /** Returns the path of the current executable. */
 hilti::rt::filesystem::path currentExecutable();
 
+/** Returns the path relative to parent of the current executable. */
+hilti::rt::filesystem::path fromOrigin(const hilti::rt::filesystem::path &relativePath);
+
 /** Dumps a backtrace to stderr and then aborts execution. */
 [[noreturn]] extern void abort_with_backtrace();
 

--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -178,6 +178,11 @@ hilti::rt::filesystem::path util::currentExecutable() {
     return normalizePath(exe);
 }
 
+
+hilti::rt::filesystem::path util::fromOrigin(const hilti::rt::filesystem::path &relativePath) {
+  return normalizePath(util::currentExecutable().parent_path() / relativePath);
+}
+
 void util::abort_with_backtrace() {
     std::cerr << "\n--- Aborting" << std::endl;
     auto bt = hilti::rt::Backtrace().backtrace();

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -87,10 +87,10 @@ void Configuration::init(bool use_build_directory) {
         cxx_launcher = {};
 
     distbase = "${PROJECT_SOURCE_DIR}";
-    install_prefix = "${CMAKE_INSTALL_PREFIX}";
+    install_prefix = util::fromOrigin("../");
     build_directory = "${PROJECT_BINARY_DIR}";
-    lib_directory = (uses_build_directory ? "${PROJECT_BINARY_DIR}/lib" : "${CMAKE_INSTALL_FULL_LIBDIR}");
-    hiltic = (uses_build_directory ? "${PROJECT_BINARY_DIR}/bin/hiltic" : "${CMAKE_INSTALL_PREFIX}/bin/hiltic");
+    lib_directory = (uses_build_directory ? "${PROJECT_BINARY_DIR}/lib" : util::fromOrigin("../lib"));
+    hiltic = (uses_build_directory ? "${PROJECT_BINARY_DIR}/bin/hiltic" : util::fromOrigin("../bin/hiltic"));
     version_number = PROJECT_VERSION_NUMBER;
     version_string = PROJECT_VERSION_STRING_SHORT;
     version_string_long = PROJECT_VERSION_STRING_LONG;

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -95,6 +95,17 @@ void Configuration::init(bool use_build_directory) {
     version_string = PROJECT_VERSION_STRING_SHORT;
     version_string_long = PROJECT_VERSION_STRING_LONG;
 
+    std::string hilti_config_library_dirs =
+        util::replace("${HILTI_CONFIG_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string hilti_config_runtime_cxx_include_dirs =
+        util::replace("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string hilti_config_runtime_cxx_library_dirs =
+        util::replace("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string hilti_config_toolchain_cxx_include_dirs =
+        util::replace("${HILTI_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string hilti_config_toolchain_cxx_library_dirs =
+        util::replace("${HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+
     std::vector<std::string> library_paths;
 
     if ( auto hilti_library_paths = std::getenv("HILTI_PATH") ) {
@@ -102,25 +113,25 @@ void Configuration::init(bool use_build_directory) {
             util::transform(hilti::rt::split(hilti_library_paths, ":"), [](auto s) { return std::string(s); });
     }
     else {
-        library_paths = flatten({".", prefix("${HILTI_CONFIG_LIBRARY_DIRS}", "", installation_tag)});
+        library_paths = flatten({".", prefix(hilti_config_library_dirs, "", installation_tag)});
     }
 
     hilti_library_paths = util::transform(library_paths, [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_include_paths =
-        util::transform(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)),
+        util::transform(hilti::util::split(prefix(hilti_config_runtime_cxx_include_dirs, "", installation_tag)),
                         [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_library_paths =
-        util::transform(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)),
+        util::transform(hilti::util::split(prefix(hilti_config_runtime_cxx_library_dirs, "", installation_tag)),
                         [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_include_paths =
-        util::transform(hilti::util::split(prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
+        util::transform(hilti::util::split(prefix(hilti_config_toolchain_cxx_include_dirs, "", installation_tag)),
                         [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_library_paths =
-        util::transform(hilti::util::split(prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
+        util::transform(hilti::util::split(prefix(hilti_config_toolchain_cxx_library_dirs, "", installation_tag)),
                         [](auto s) { return hilti::rt::filesystem::path(s); });
 
     // We hardcode the main compiler flags here instead of injecting them from
@@ -141,11 +152,11 @@ void Configuration::init(bool use_build_directory) {
     // (3) it helps the optimizer to know that symbols won't be accessed
     // externally.
     runtime_cxx_flags_debug = flatten({"-fPIC", "-std=c++17", "-g", "-fvisibility=hidden",
-                                       prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
+                                       prefix(hilti_config_runtime_cxx_include_dirs, "-I", installation_tag),
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});
 
     runtime_cxx_flags_release = flatten({"-fPIC", "-std=c++17", "-g", "-O3", "-DNDEBUG", "-fvisibility=hidden",
-                                         prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
+                                         prefix(hilti_config_runtime_cxx_include_dirs, "-I", installation_tag),
                                          prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag)});
 
 
@@ -155,19 +166,19 @@ void Configuration::init(bool use_build_directory) {
     if ( auto libhilti_pch = precompiled_libhilti(*this, false) )
         runtime_cxx_flags_release.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
 
-    runtime_ld_flags_debug = flatten(
-        {prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag),
-         prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
+    runtime_ld_flags_debug = flatten({prefix(hilti_config_runtime_cxx_library_dirs, "-L", installation_tag),
+                                      prefix(hilti_config_runtime_cxx_library_dirs, "-Wl,-rpath,", installation_tag),
+                                      prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
+                                      prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag),
+                                      prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag),
+                                      prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
 
-    runtime_ld_flags_release = flatten(
-        {prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag),
-         prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
+    runtime_ld_flags_release = flatten({prefix(hilti_config_runtime_cxx_library_dirs, "-L", installation_tag),
+                                        prefix(hilti_config_runtime_cxx_library_dirs, "-Wl,-rpath,", installation_tag),
+                                        prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
+                                        prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag),
+                                        prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag),
+                                        prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
 
     hlto_cxx_flags_debug = runtime_cxx_flags_debug;
     hlto_cxx_flags_release = runtime_cxx_flags_release;

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -94,8 +94,10 @@ void Configuration::init(bool use_build_directory) {
     uses_build_directory = use_build_directory;
     std::string installation_tag = (use_build_directory ? "BUILD" : "INSTALL");
 
-    spicyc = (uses_build_directory ? "${PROJECT_BINARY_DIR}/bin/spicyc" : "${CMAKE_INSTALL_PREFIX}/bin/spicyc");
-
+    spicyc = (uses_build_directory ? "${PROJECT_BINARY_DIR}/bin/spicyc" : hilti::util::fromOrigin("../bin/spicyc"));
+    if (!hilti::rt::filesystem::exists(spicyc)) {
+      spicyc = "${CMAKE_INSTALL_PREFIX}/bin/spicyc";
+    }
     std::vector<std::string> library_paths;
 
     if ( auto path = std::getenv("SPICY_PATH") ) {

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -95,57 +95,66 @@ void Configuration::init(bool use_build_directory) {
     std::string installation_tag = (use_build_directory ? "BUILD" : "INSTALL");
 
     spicyc = (uses_build_directory ? "${PROJECT_BINARY_DIR}/bin/spicyc" : hilti::util::fromOrigin("../bin/spicyc"));
-    if (!hilti::rt::filesystem::exists(spicyc)) {
-      spicyc = "${CMAKE_INSTALL_PREFIX}/bin/spicyc";
+    if ( ! hilti::rt::filesystem::exists(spicyc) ) {
+        spicyc = "${CMAKE_INSTALL_PREFIX}/bin/spicyc";
     }
+
+    auto install_prefix = hilti::util::fromOrigin("../");
+    std::string spicy_config_library_dirs =
+        hilti::util::replace("${SPICY_CONFIG_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string spicy_config_runtime_cxx_include_dirs =
+        hilti::util::replace("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string spicy_config_runtime_cxx_library_dirs =
+        hilti::util::replace("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string spicy_config_toolchain_cxx_include_dirs =
+        hilti::util::replace("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+    std::string spicy_config_toolchain_cxx_library_dirs =
+        hilti::util::replace("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "${CMAKE_INSTALL_PREFIX}", install_prefix);
+
     std::vector<std::string> library_paths;
 
     if ( auto path = std::getenv("SPICY_PATH") ) {
         library_paths = hilti::util::transform(hilti::util::split(path, ":"), [](auto s) { return std::string(s); });
     }
     else {
-        library_paths = flatten({".", prefix("${SPICY_CONFIG_LIBRARY_DIRS}", "", installation_tag)});
+        library_paths = flatten({".", prefix(spicy_config_library_dirs, "", installation_tag)});
     }
 
     spicy_library_paths = hilti::util::transform(library_paths, [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_include_paths =
-        hilti::util::transform(hilti::util::split(
-                                   prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)),
+        hilti::util::transform(hilti::util::split(prefix(spicy_config_runtime_cxx_include_dirs, "", installation_tag)),
                                [](auto s) { return hilti::rt::filesystem::path(s); });
 
     runtime_cxx_library_paths =
-        hilti::util::transform(hilti::util::split(
-                                   prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)),
+        hilti::util::transform(hilti::util::split(prefix(spicy_config_runtime_cxx_library_dirs, "", installation_tag)),
                                [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_include_paths =
         hilti::util::transform(hilti::util::split(
-                                   prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                                   prefix(spicy_config_toolchain_cxx_include_dirs, "", installation_tag)),
                                [](auto s) { return hilti::rt::filesystem::path(s); });
 
     toolchain_cxx_library_paths =
         hilti::util::transform(hilti::util::split(
-                                   prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                                   prefix(spicy_config_toolchain_cxx_library_dirs, "", installation_tag)),
                                [](auto s) { return hilti::rt::filesystem::path(s); });
 
-    runtime_cxx_flags_debug = flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
+    runtime_cxx_flags_debug = flatten({prefix(spicy_config_runtime_cxx_include_dirs, "-I", installation_tag),
                                        prefix("${SPICY_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});
 
-    runtime_cxx_flags_release = flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
+    runtime_cxx_flags_release = flatten({prefix(spicy_config_runtime_cxx_include_dirs, "-I", installation_tag),
                                          prefix("${SPICY_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag)});
 
-    runtime_ld_flags_debug =
-        flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag)});
+    runtime_ld_flags_debug = flatten({prefix(spicy_config_runtime_cxx_library_dirs, "-L", installation_tag),
+                                      prefix(spicy_config_runtime_cxx_library_dirs, "-Wl,-rpath,", installation_tag),
+                                      prefix("${SPICY_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
+                                      prefix("${SPICY_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag)});
 
-    runtime_ld_flags_release =
-        flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
-                 prefix("${SPICY_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag)});
+    runtime_ld_flags_release = flatten({prefix(spicy_config_runtime_cxx_library_dirs, "-L", installation_tag),
+                                        prefix(spicy_config_runtime_cxx_library_dirs, "-Wl,-rpath,", installation_tag),
+                                        prefix("${SPICY_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
+                                        prefix("${SPICY_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag)});
 
     hlto_cxx_flags_debug = runtime_cxx_flags_debug;
     hlto_cxx_flags_release = runtime_cxx_flags_release;


### PR DESCRIPTION
* Add a utility function, `fromOrigin`, in hilti/toolchain that returns a normalized path relative to the current process.
* Change hilti/toolchain/config to use relative paths when reporting
  * install prefix
  * lib directory
  * hiltic
* Change spicy/toolchain/config to use relative paths when reporting
  * spicyc