### PR TITLE
Replace recursive deletion with explicit loop to avoid stack overflow.

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -118,7 +118,7 @@ public:
         return *this;
     }
 
-    ~Chunk() = default;
+    ~Chunk();
 
     Offset offset() const { return _offset; }
     Offset endOffset() const { return _offset + size(); }

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -9,6 +9,15 @@ using namespace hilti::rt;
 using namespace hilti::rt::stream;
 using namespace hilti::rt::stream::detail;
 
+Chunk::~Chunk() {
+    // The default dtr would turn deletion the list behind `_next` into a
+    // recursive list traversal. For very long lists this could lead to stack
+    // overflows. Traverse the list in a loop instead. This is adapted from
+    // https://stackoverflow.com/questions/35535312/stack-overflow-with-unique-ptr-linked-list#answer-35535907.
+    for ( auto current = std::move(_next); current; current = std::move(current->_next) )
+        ; // Nothing.
+}
+
 Chunk::Chunk(const Offset& offset, const View& d) : _offset(offset) {
     if ( d.size() <= SmallBufferSize ) {
         std::array<Byte, SmallBufferSize> a{};


### PR DESCRIPTION
Closes #1550.