### PR TITLE
Fix potential infinite loop when trimming data before stream.

### DIFF
--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -738,6 +738,33 @@ TEST_CASE("Trim to beyond end") {
     CHECK_EQ(x.view().end().offset(), 10);
 }
 
+TEST_CASE("Trim noop") {
+    auto x = Stream("1"_b);
+    auto i = x.begin(); // Into first chunk.
+
+    x.append("2"_b);
+    REQUIRE_EQ(x.numberOfChunks(), 2);
+
+    auto j = x.begin() + x.size() - 1; // Into second chunk.
+
+    x.trim(j); // Drops the first chunk.
+    CHECK_EQ(x.numberOfChunks(), 1);
+
+    // Trimming away data before the range of the stream should be a noop.
+    x.trim(i);
+    CHECK_EQ(x.numberOfChunks(), 1);
+}
+
+TEST_CASE("Trim empty") {
+    auto x = Stream();
+    REQUIRE_EQ(x.numberOfChunks(), 0);
+
+    auto i = x.begin();
+
+    x.trim(i);
+    CHECK_EQ(x.numberOfChunks(), 0);
+}
+
 TEST_CASE("Block iteration") {
     auto content = [](auto b, auto s) -> bool { return memcmp(b->start, s, strlen(s)) == 0; };
 


### PR DESCRIPTION
Previously we would trigger an infinite loop if one tried to trim before the head chunk of a stream. In praxis this seem to have been no issue due to #1549 and us emitting way less calls to trim than possible.

This patch adds an explicit check whether we need to trim anything, and exits the low-level function early for such cases.

Closes #1554.