### PR TITLE
Explicitly set ASM compiler.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -7,11 +7,19 @@ add_subdirectory(doctest)
 
 add_subdirectory(justrx)
 
+
+# Use the configured C compiler as ASM compiler as well. This prevents that we
+# e.g., use a Clang as C compiler, but e.g., GCC as assembler which leads to
+# incompatible flags like `-Weverything` being passed to GCC from e.g.,
+# `3rdparty/fiber`.
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+
 # The GNU toolchain by default assumes that any assembly files (of which the
 # fiber library contains at least one) need an executable stack; explictly
 # disable that since we do not need executable stacks and some package linters
 # call this out as needlessly insecure.
 set(CMAKE_ASM_FLAGS ${CMAKE_ASM_FLAGS} -Wa,--noexecstack)
+
 set(FIBER_SHARED OFF)
 set(FIBER_OBJECT ON)
 add_subdirectory(fiber)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.15.0)
 
-project(spicy LANGUAGES ASM C CXX)
+project(spicy LANGUAGES C CXX)
 
 set(flex_minimum_version "2.5.37")
 set(bison_minimum_version "3.0")


### PR DESCRIPTION
When not setting an ASM compiler we might end up configuring Clang as C compiler, but GCC as ASM compiler. The code in `3rdparty/fiber` then causes Clang-only flags like `-Weverything` to be passed to GCC (which does not understand it).

The way we need to do this is subtle. We need to rely on `3rdparty/fiber` to explicitly `enable_language(ASM)` and not set it as a project language to work around `find_package(BISON)` breaking if `CMAKE_ASM_COMPILER` is set. By removing ASM from project languages and setting the ASM config after Bison was found, but before we configure `3rdparty/fiber` things seem to work as intended.