### PR TITLE
Remove trimming inside individual chunks

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -189,8 +189,6 @@ protected:
     // only from chain so that it can track any changes.
     friend class Chain;
 
-    void trim(const Offset& o);
-
     // Update offset for current chunk and all others linked from it.
     void setOffset(Offset o) {
         auto c = this;


### PR DESCRIPTION
Trimming `Chunk`s (always from the left) causes a lot of internal work with only limited benefit since we manage visbility with `stream::View`s on top of `Chunk`s anyway.

This patch removes trimming inside `Chunk`s so now any trimming only removes `Chunk`s from `Chain`s, but does not internally change individual `Chunk`s anymore. This might lead to slighly increased memory use, but callers usually have that data in memory anyway.

Closes #1571.