### PR TITLE
Fix bitfield's lack of declaring its C++-side type dependencies.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -32,6 +32,13 @@ struct VisitorDeclaration : hilti::visitor::PreOrder<cxx::declaration::Type, Vis
     auto typeID(const Node& n) { return n.as<Type>().typeID(); }
     auto cxxID(const Node& n) { return n.as<Type>().cxxID(); }
 
+    result_t operator()(const type::Bitfield& n) {
+        for ( const auto& b : n.bits(true) )
+            addDependency(b.itemType());
+
+        return {};
+    }
+
     result_t operator()(const type::Struct& n, const position_t p) {
         assert(typeID(p.node));
 

--- a/tests/spicy/types/bitfield/convert-with-enum.spicy
+++ b/tests/spicy/types/bitfield/convert-with-enum.spicy
@@ -1,0 +1,16 @@
+# @TEST-EXEC: spicyc -j %INPUT
+#
+# @TEST-DOC: Make sure this compiles. Regression test for #1568.
+
+module Test;
+
+import spicy;
+
+type X = enum { A = 1, B = 2 };
+
+public type Foo = unit {
+    f: bitfield(8) {
+        x1: 0..3 &convert=X($$);
+        x2: 4..7 &convert=X($$);
+    } { print self.f.x1, self.f.x2; }
+};


### PR DESCRIPTION
Closes #1568.
