### PR TITLE
Remove check of Zeek docs in Cirrus cron config [skip CI]

### DIFF
--- a/ci/run-ci
+++ b/ci/run-ci
@@ -303,14 +303,6 @@ function run_test_common {
     # the remote is temporarily unavailable.
     (cd "${root}"/doc && make BUILDDIR="${build}" DESTDIR="${artifacts}"/doc check) || true
 
-    # Only check Zeek docs from cron builds triggered via Cirrus. This
-    # surfaces errors, but avoids failing builds because e.g., vendored docs
-    # and unversioned external dependencies get out of sync.
-    if [ -n "${CIRRUS_CRON}" ]; then
-        log_stage "Check Zeek docs ..."
-        (cd "${root}"/doc && make check-zeek-docs) || rc=1
-    fi
-
     return ${rc}
 }
 


### PR DESCRIPTION
This is a follow-up to 2b92da596631ff1a29b7deac05e00faaad9305f3.