### PR TITLE
Reduce string allocations for literals [skip CI]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,14 +37,14 @@ repos:
     stages: ["commit"]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v16.0.6'
+  rev: 'v17.0.6'
   hooks:
   - id: clang-format
     types_or: ["c", "c++"]
     stages: ["commit"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: trailing-whitespace
     exclude: '^tests/Baseline'
@@ -86,7 +86,7 @@ repos:
     stages: ["commit"]
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.16.13
+  rev: v1.16.23
   hooks:
   - id: typos
     exclude: 'tests/.*/regexp/.*'

--- a/hilti/runtime/include/debug-logger.h
+++ b/hilti/runtime/include/debug-logger.h
@@ -24,14 +24,15 @@ public:
     bool isEnabled(std::string_view stream) { return _streams.find(stream) != _streams.end(); }
 
     void indent(std::string_view stream) {
-        if ( isEnabled(stream) )
-            _streams[stream] += 1;
+        if ( auto s = _streams.find(stream); s != _streams.end() ) {
+            auto& indent = s->second;
+            indent += 1;
+        }
     }
 
     void dedent(std::string_view stream) {
-        if ( isEnabled(stream) ) {
-            auto& indent = _streams[stream];
-
+        if ( auto s = _streams.find(stream); s != _streams.end() ) {
+            auto& indent = s->second;
             if ( indent > 0 )
                 indent -= 1;
         }

--- a/hilti/runtime/include/debug-logger.h
+++ b/hilti/runtime/include/debug-logger.h
@@ -6,7 +6,7 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <string>
+#include <string_view>
 
 #include <hilti/rt/filesystem.h>
 #include <hilti/rt/util.h>
@@ -18,17 +18,17 @@ class DebugLogger {
 public:
     DebugLogger(hilti::rt::filesystem::path output);
 
-    void print(const std::string& stream, const std::string& msg);
-    void enable(const std::string& streams);
+    void print(std::string_view stream, std::string_view msg);
+    void enable(std::string_view streams);
 
-    bool isEnabled(const std::string& stream) { return _streams.find(stream) != _streams.end(); }
+    bool isEnabled(std::string_view stream) { return _streams.find(stream) != _streams.end(); }
 
-    void indent(const std::string& stream) {
+    void indent(std::string_view stream) {
         if ( isEnabled(stream) )
             _streams[stream] += 1;
     }
 
-    void dedent(const std::string& stream) {
+    void dedent(std::string_view stream) {
         if ( isEnabled(stream) ) {
             auto& indent = _streams[stream];
 
@@ -41,7 +41,7 @@ private:
     hilti::rt::filesystem::path _path;
     std::ostream* _output = nullptr;
     std::unique_ptr<std::ofstream> _output_file;
-    std::map<std::string, integer::safe<uint64_t>> _streams;
+    std::map<std::string_view, integer::safe<uint64_t>> _streams;
 };
 
 } // namespace hilti::rt::detail

--- a/hilti/runtime/include/exception.h
+++ b/hilti/runtime/include/exception.h
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -25,7 +26,7 @@ public:
     /**
      * @param desc message describing the situation
      */
-    Exception(const std::string& desc) : Exception(Internal(), "Exception", desc) {
+    Exception(std::string_view desc) : Exception(Internal(), "Exception", desc) {
 #ifndef NDEBUG
         _backtrace = Backtrace();
 #endif
@@ -79,11 +80,11 @@ public:
 protected:
     enum Internal {};
 
-    Exception(Internal, const char* type, const std::string& desc);
+    Exception(Internal, const char* type, std::string_view desc);
     Exception(Internal, const char* type, std::string_view desc, std::string_view location);
 
 private:
-    Exception(Internal, const char* type, const std::string& what, std::string_view desc, std::string_view location);
+    Exception(Internal, const char* type, std::string_view what, std::string_view desc, std::string_view location);
 
     std::string _description;
     std::string _location;
@@ -95,7 +96,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Exception& e) { retu
 #define HILTI_EXCEPTION(name, base)                                                                                    \
     class name : public ::hilti::rt::base {                                                                            \
     public:                                                                                                            \
-        name(const std::string& desc) : base(Internal(), #name, desc) {}                                               \
+        name(std::string_view desc) : base(Internal(), #name, desc) {}                                                 \
         name(std::string_view desc, std::string_view location) : base(Internal(), #name, desc, location) {}            \
         virtual ~name(); /* required to create vtable, see hilti::rt::Exception */                                     \
     protected:                                                                                                         \
@@ -105,7 +106,7 @@ inline std::ostream& operator<<(std::ostream& stream, const Exception& e) { retu
 #define HILTI_EXCEPTION_NS(name, ns, base)                                                                             \
     class name : public ns::base {                                                                                     \
     public:                                                                                                            \
-        name(const std::string& desc) : base(Internal(), #name, desc) {}                                               \
+        name(std::string_view desc) : base(Internal(), #name, desc) {}                                                 \
         name(std::string_view desc, std::string_view location) : base(Internal(), #name, desc, location) {}            \
         virtual ~name(); /* required to create vtable, see hilti::rt::Exception */                                     \
     protected:                                                                                                         \
@@ -237,7 +238,7 @@ public:
      * @param desc message describing the situation
      * @param location string indicating the location of the operation that couldn't complete
      */
-    WouldBlock(const std::string& desc, const std::string& location);
+    WouldBlock(std::string_view desc, std::string_view location);
 };
 
 namespace exception {

--- a/hilti/runtime/include/fmt.h
+++ b/hilti/runtime/include/fmt.h
@@ -16,7 +16,8 @@ std::string fmt(const char* fmt, const Args&... args) {
 
 /** sprintf-style string formatting. */
 template<typename... Args>
-std::string fmt(const std::string& s, const Args&... args) {
-    return fmt(s.c_str(), args...);
+std::string fmt(std::string_view s, const Args&... args) {
+    // In generated code `s` is always null-terminated.
+    return fmt(s.data(), args...);
 }
 } // namespace hilti::rt

--- a/hilti/runtime/include/logging.h
+++ b/hilti/runtime/include/logging.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <utility>
 
 #include <hilti/rt/debug-logger.h>
@@ -18,10 +18,10 @@ namespace hilti::rt {
  * anything that can happen during "normal" operation (which is almost
  * everything).
  */
-void fatalError(const std::string& msg) __attribute__((noreturn));
+void fatalError(std::string_view msg) __attribute__((noreturn));
 
 /** Reports a warning. */
-void warning(const std::string& msg);
+void warning(std::string_view msg);
 
 /**
  * Prints a string, or a runtime value, to a specific debug stream. This is a
@@ -42,39 +42,39 @@ namespace debug {
 
 namespace detail {
 /** Prints a debug message to a specific debug stream. */
-inline void print(const std::string& stream, const char* msg) {
+inline void print(std::string_view stream, const char* msg) {
     if ( ::hilti::rt::detail::globalState()->debug_logger )
         ::hilti::rt::detail::globalState()->debug_logger->print(stream, msg);
 }
 
 /** Print a string to a specific debug stream with proper escaping. */
-inline void print(const std::string& stream, const std::string_view& s) {
+inline void print(std::string_view stream, std::string_view s) {
     if ( ::hilti::rt::detail::globalState()->debug_logger )
         ::hilti::rt::detail::globalState()->debug_logger->print(stream, hilti::rt::escapeBytes(s, false));
 }
 
 template<typename T, typename std::enable_if_t<not std::is_convertible<T, std::string_view>::value>* = nullptr>
 /** Prints the string representastion of a HILTI runtime value to a specific debug stream. */
-inline void print(const std::string& stream, const T& t) {
+inline void print(std::string_view stream, const T& t) {
     if ( ::hilti::rt::detail::globalState()->debug_logger )
         ::hilti::rt::detail::globalState()->debug_logger->print(stream, hilti::rt::to_string_for_print(t));
 }
 } // namespace detail
 
 /** Returns true if debug logging is enabled for a given stream. */
-inline bool isEnabled(const std::string& stream) {
+inline bool isEnabled(std::string_view stream) {
     return ::hilti::rt::detail::globalState()->debug_logger &&
            ::hilti::rt::detail::globalState()->debug_logger->isEnabled(stream);
 }
 
 /** Increases the indentation level for a debug stream. */
-inline void indent(const std::string& stream) {
+inline void indent(std::string_view stream) {
     if ( ::hilti::rt::detail::globalState()->debug_logger )
         ::hilti::rt::detail::globalState()->debug_logger->indent(stream);
 }
 
 /** Decreases the indentation level for a debug stream. */
-inline void dedent(const std::string& stream) {
+inline void dedent(const std::string_view stream) {
     if ( ::hilti::rt::detail::globalState()->debug_logger )
         ::hilti::rt::detail::globalState()->debug_logger->dedent(stream);
 }
@@ -103,7 +103,7 @@ inline void setLocation(const char* l = nullptr) { detail::tls_location = l; }
  * arguments if nothing is going to get logged.
  */
 template<typename T>
-inline void print(const std::string& stream, T&& msg) {
+inline void print(std::string_view stream, T&& msg) {
     if ( ::hilti::rt::detail::globalState()->debug_logger &&
          ::hilti::rt::detail::globalState()->debug_logger->isEnabled(stream) )
         ::hilti::rt::debug::detail::print(stream, std::forward<T>(msg));

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -226,6 +226,9 @@ public:
     /** Returns the bytes' data as a string instance. */
     const std::string& str() const& { return *this; }
 
+    /** Returns the bytes' data as a string instance. */
+    std::string str() && { return std::move(*this); }
+
     /** Returns an iterator representing the first byte of the instance. */
     const_iterator begin() const { return const_iterator(0U, _control); }
 

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -251,8 +251,9 @@ public:
      * @param n optional starting point, which must be inside the same instance
      */
     const_iterator find(value_type b, const const_iterator& n = const_iterator()) const {
-        if ( auto i = Base::find(b, (n ? n - begin() : 0)); i != Base::npos )
-            return begin() + i;
+        auto beg = begin();
+        if ( auto i = Base::find(b, (n ? n - beg : 0)); i != Base::npos )
+            return beg + i;
         else
             return end();
     }

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1335,16 +1335,17 @@ public:
     View extract(Byte* dst, uint64_t n) const {
         _ensureValid();
 
+        auto p = unsafeBegin();
+
         // Fast-path for when we're staying inside the initial chunk.
-        if ( auto chunk = _begin.chunk(); chunk && chunk->inRange(_begin.offset() + n) ) {
-            memcpy(dst, chunk->data(_begin.offset()), n);
-            return View(SafeConstIterator(_begin._chain, _begin.offset() + n, chunk), _end);
+        if ( auto chunk = p.chunk(); chunk && chunk->inRange(p.offset() + n) ) {
+            memcpy(dst, chunk->data(p.offset()), n);
+            return View(SafeConstIterator(p + n), _end);
         }
 
         if ( n > size() )
             throw WouldBlock("end of stream view");
 
-        auto p = unsafeBegin();
         for ( uint64_t i = 0; i < n; ++i )
             dst[i] = *p++;
 

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -95,7 +95,7 @@ public:
         : _offset(o), _data(std::make_pair(n, d)) {}
     Chunk(const Offset& o, Vector&& d) : _offset(o), _data(std::move(d)) {}
     Chunk(const Offset& o, const View& d);
-    Chunk(const Offset& o, const std::string& s);
+    Chunk(const Offset& o, std::string_view sv);
 
     template<int N>
     Chunk(Offset o, std::array<Byte, N> d) : Chunk(_fromArray(o, std::move(d))) {}

--- a/hilti/runtime/include/types/string.h
+++ b/hilti/runtime/include/types/string.h
@@ -77,5 +77,13 @@ inline std::string detail::to_string_for_print<std::string_view>(const std::stri
     return escapeUTF8(x, false, false, true);
 }
 
+// Specialization for string literals. Since `to_string_for_print` is not
+// implemented with ADL like e.g., `to_string` provide an overload for string
+// literals. This is needed since we cannot partially specialize
+// `to_string_for_print`.
+template<typename CharT, size_t N>
+inline std::string to_string_for_print(const CharT (&x)[N]) {
+    return x;
+}
 
 } // namespace hilti::rt

--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -76,7 +76,7 @@
 namespace hilti::rt {
 
 /** Reports an internal error and aborts execution. */
-void internalError(const std::string& msg) __attribute__((noreturn));
+void internalError(std::string_view msg) __attribute__((noreturn));
 
 } // namespace hilti::rt
 

--- a/hilti/runtime/src/debug-logger.cc
+++ b/hilti/runtime/src/debug-logger.cc
@@ -15,12 +15,12 @@ using namespace hilti::rt;
 
 detail::DebugLogger::DebugLogger(hilti::rt::filesystem::path output) : _path(std::move(output)) {}
 
-void detail::DebugLogger::enable(const std::string& streams) {
+void detail::DebugLogger::enable(std::string_view streams) {
     for ( auto s : split(streams, ":") )
-        _streams[std::string(trim(s))] = 0;
+        _streams[trim(s)] = 0;
 }
 
-void detail::DebugLogger::print(const std::string& stream, const std::string& msg) {
+void detail::DebugLogger::print(std::string_view stream, std::string_view msg) {
     if ( _path.empty() )
         return;
 

--- a/hilti/runtime/src/exception.cc
+++ b/hilti/runtime/src/exception.cc
@@ -57,9 +57,9 @@ static void printException(const std::string& msg, const Exception& e, std::ostr
         out << "[libhilti]    " << s << "\n";
 }
 
-Exception::Exception(Internal, const char* type, const std::string& what, std::string_view desc,
+Exception::Exception(Internal, const char* type, std::string_view what, std::string_view desc,
                      std::string_view location)
-    : std::runtime_error(what), _description(desc), _location(location) {
+    : std::runtime_error({what.data(), what.size()}), _description(desc), _location(location) {
     if ( isInitialized() )
         profiler::start(std::string("hilti/exception/") + type);
 
@@ -72,7 +72,7 @@ Exception::Exception(Internal, const char* type, const std::string& what, std::s
     }
 }
 
-Exception::Exception(Internal, const char* type, const std::string& desc)
+Exception::Exception(Internal, const char* type, std::string_view desc)
     : Exception(Internal(), type, debug::location() ? fmt("%s (%s)", desc, debug::location()) : desc, desc,
                 debug::location() ? debug::location() : "") {}
 
@@ -85,8 +85,7 @@ Exception::Exception() : std::runtime_error("<no error>") { /* no profiling */
 
 Exception::~Exception() = default;
 
-WouldBlock::WouldBlock(const std::string& desc, const std::string& location)
-    : WouldBlock(fmt("%s (%s)", desc, location)) {}
+WouldBlock::WouldBlock(std::string_view desc, std::string_view location) : WouldBlock(fmt("%s (%s)", desc, location)) {}
 
 exception::DisableAbortOnExceptions::DisableAbortOnExceptions() {
     detail::globalState()->disable_abort_on_exceptions++;

--- a/hilti/runtime/src/logging.cc
+++ b/hilti/runtime/src/logging.cc
@@ -9,21 +9,22 @@ using namespace hilti::rt::detail;
 
 #include <cstdlib>
 #include <iostream>
+#include <string_view>
 
 using namespace hilti::rt;
 
 HILTI_THREAD_LOCAL const char* debug::detail::tls_location = nullptr;
 
-void hilti::rt::internalError(const std::string& msg) {
+void hilti::rt::internalError(std::string_view msg) {
     std::cerr << fmt("[libhilti] Internal error: %s", msg) << std::endl;
     abort_with_backtrace();
 }
 
-void hilti::rt::fatalError(const std::string& msg) {
+void hilti::rt::fatalError(std::string_view msg) {
     std::cerr << fmt("[libhilti] Fatal error: %s", msg) << std::endl;
     // We do a hard abort here, with no cleanup, because  ASAN may have trouble
     // terminating otherwise if the fiber stacks are still hanging out.
     _exit(1);
 }
 
-void hilti::rt::warning(const std::string& msg) { std::cerr << fmt("[libhilti] Warning: %s", msg) << std::endl; }
+void hilti::rt::warning(std::string_view msg) { std::cerr << fmt("[libhilti] Warning: %s", msg) << std::endl; }

--- a/hilti/runtime/src/tests/string.cc
+++ b/hilti/runtime/src/tests/string.cc
@@ -61,4 +61,16 @@ TEST_CASE("upper") {
                          "illegal UTF8 sequence in string", const RuntimeError&);
 }
 
+TEST_CASE("to_string") {
+    CHECK_EQ(to_string(std::string("abc")), "\"abc\"");
+    CHECK_EQ(to_string(std::string_view("abc")), "\"abc\"");
+    CHECK_EQ(to_string("abc"), "\"abc\"");
+}
+
+TEST_CASE("to_string_for_print") {
+    CHECK_EQ(to_string_for_print(std::string("abc")), "abc");
+    CHECK_EQ(to_string_for_print(std::string_view("abc")), "abc");
+    CHECK_EQ(to_string_for_print("abc"), "abc");
+}
+
 TEST_SUITE_END();

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -215,6 +215,7 @@ Result<Bytes> Bytes::match(const RegExp& re, unsigned int group) const {
 }
 
 void Bytes::append(const stream::View& view) {
+    reserve(size() + view.size());
     for ( auto block = view.firstBlock(); block; block = view.nextBlock(block) )
         Base::append(reinterpret_cast<const char*>(block->start), block->size);
 }

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -12,12 +12,15 @@ using namespace hilti::rt;
 using namespace hilti::rt::bytes;
 
 std::tuple<bool, Bytes::const_iterator> Bytes::find(const Bytes& v, const const_iterator& n) const {
+    auto b = begin();
+
     if ( v.isEmpty() )
-        return std::make_tuple(true, n ? n : begin());
+        return std::make_tuple(true, n ? n : b);
 
-    auto first = *v.begin();
+    auto bv = v.begin();
+    auto first = *bv;
 
-    for ( auto i = const_iterator(n ? n : begin()); true; ++i ) {
+    for ( auto i = const_iterator(n ? n : b); true; ++i ) {
         if ( i == end() )
             return std::make_tuple(false, i);
 
@@ -25,7 +28,7 @@ std::tuple<bool, Bytes::const_iterator> Bytes::find(const Bytes& v, const const_
             continue;
 
         auto x = i;
-        auto y = v.begin();
+        auto y = bv;
 
         for ( ;; ) {
             if ( x == end() )
@@ -151,7 +154,7 @@ Bytes Bytes::strip(bytes::Side side) const {
 
 integer::safe<int64_t> Bytes::toInt(uint64_t base) const {
     int64_t x = 0;
-    if ( hilti::rt::atoi_n(begin(), end(), base, &x) == end() )
+    if ( hilti::rt::atoi_n(str().begin(), str().end(), base, &x) == str().end() )
         return x;
 
     throw RuntimeError("cannot parse bytes as signed integer");
@@ -159,7 +162,7 @@ integer::safe<int64_t> Bytes::toInt(uint64_t base) const {
 
 integer::safe<uint64_t> Bytes::toUInt(uint64_t base) const {
     int64_t x = 0;
-    if ( hilti::rt::atoi_n(begin(), end(), base, &x) == end() )
+    if ( hilti::rt::atoi_n(str().begin(), str().end(), base, &x) == str().end() )
         return x;
 
     throw RuntimeError("cannot parse bytes as unsigned integer");
@@ -193,7 +196,7 @@ uint64_t Bytes::toUInt(ByteOrder byte_order) const {
 
     uint64_t i = 0;
 
-    for ( auto c : *this )
+    for ( auto c : str() )
         i = (i << 8U) | static_cast<uint8_t>(c);
 
     if ( byte_order == hilti::rt::ByteOrder::Little )

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -26,8 +26,7 @@ Chunk::Chunk(const Offset& offset, const View& d) : _offset(offset) {
         _data = std::make_pair(d.size(), a);
     }
     else {
-        std::vector<Byte> v;
-        v.resize(d.size());
+        std::vector<Byte> v(d.size());
         d.copyRaw(v.data());
         _data = std::move(v);
     }
@@ -40,8 +39,7 @@ Chunk::Chunk(const Offset& offset, std::string_view s) : _offset(offset) {
         _data = std::make_pair(s.size(), a);
     }
     else {
-        std::vector<Byte> v;
-        v.resize(s.size());
+        std::vector<Byte> v(s.size());
         memcpy(v.data(), s.data(), s.size());
         _data = std::move(v);
     }

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -394,7 +394,7 @@ void Stream::append(Bytes&& data) {
     if ( data.isEmpty() )
         return;
 
-    _chain->append(std::make_unique<Chunk>(0, data.str()));
+    _chain->append(std::make_unique<Chunk>(0, std::move(data).str()));
 }
 
 void Stream::append(const Bytes& data) {

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -33,7 +33,7 @@ Chunk::Chunk(const Offset& offset, const View& d) : _offset(offset) {
     }
 }
 
-Chunk::Chunk(const Offset& offset, const std::string& s) : _offset(offset) {
+Chunk::Chunk(const Offset& offset, std::string_view s) : _offset(offset) {
     if ( s.size() <= SmallBufferSize ) {
         std::array<Byte, SmallBufferSize> a{};
         memcpy(a.data(), s.data(), s.size());
@@ -410,7 +410,7 @@ void Stream::append(const char* data, size_t len) {
         return;
 
     if ( data )
-        _chain->append(std::make_unique<Chunk>(0, std::string(data, len)));
+        _chain->append(std::make_unique<Chunk>(0, std::string_view{data, len}));
     else
         _chain->append(std::make_unique<Chunk>(0, len));
 }

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -328,31 +328,32 @@ void View::copyRaw(Byte* dst) const {
 std::optional<View::Block> View::firstBlock() const {
     _ensureValid();
 
-    if ( unsafeBegin() == unsafeEnd() || ! unsafeBegin().chunk() )
+    auto begin = unsafeBegin();
+    if ( begin == unsafeEnd() || ! begin.chunk() )
         return {};
 
-    const auto* chain = _begin.chain();
+    const auto* chain = begin.chain();
     assert(chain);
 
-    auto chunk = chain->findChunk(_begin.offset(), _begin.chunk());
+    auto chunk = chain->findChunk(begin.offset(), begin.chunk());
     if ( ! chunk )
         throw InvalidIterator("stream iterator outside of valid range");
 
-    auto start = chunk->data() + (_begin.offset() - chunk->offset()).Ref();
+    auto start = chunk->data() + (begin.offset() - chunk->offset()).Ref();
     bool is_last = (chunk->isLast() || (_end && _end->offset() <= chunk->endOffset()));
 
     Size size;
 
     if ( _end && is_last ) {
-        auto offset_end = std::max(std::min(_end->offset(), _begin.chain()->endOffset()), _begin.offset());
-        size = (offset_end - _begin.offset());
+        auto offset_end = std::max(std::min(_end->offset(), chain->endOffset()), begin.offset());
+        size = (offset_end - begin.offset());
     }
     else
         size = chunk->endData() - start;
 
     return View::Block{.start = start,
                        .size = size,
-                       .offset = _begin.offset(),
+                       .offset = begin.offset(),
                        .is_first = true,
                        .is_last = is_last,
                        ._block = is_last ? nullptr : chunk->next()};

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -54,8 +54,8 @@ public:
 
     void addExpression(const Expression& expr) { _block._add(statement::Expression(expr, expr.meta())); }
 
-    void addAssert(Expression cond, std::string msg, Meta m = Meta()) {
-        _block._add(statement::Assert(std::move(cond), builder::string(std::move(msg)), std::move(m)));
+    void addAssert(Expression cond, std::string_view msg, Meta m = Meta()) {
+        _block._add(statement::Assert(std::move(cond), builder::string_literal(msg), std::move(m)));
     }
 
     void addAssign(Expression dst, Expression src, const Meta& m = Meta()) {

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -241,7 +241,7 @@ public:
 
     bool empty() const { return _block.statements().empty() && _tmps.empty(); }
 
-    std::optional<Expression> startProfiler(const std::string& name);
+    std::optional<Expression> startProfiler(std::string_view name);
     void stopProfiler(Expression profiler);
 
 private:

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -103,9 +104,9 @@ public:
     void addThrow(Expression excpt, Meta m = Meta()) { _block._add(statement::Throw(std::move(excpt), std::move(m))); }
     void addRethrow(Meta m = Meta()) { _block._add(statement::Throw(std::move(m))); }
 
-    void addDebugMsg(const std::string& stream, const std::string& fmt, std::vector<Expression> args = {});
-    void addDebugIndent(const std::string& stream);
-    void addDebugDedent(const std::string& stream);
+    void addDebugMsg(std::string_view stream, std::string_view fmt, std::vector<Expression> args = {});
+    void addDebugIndent(std::string_view stream);
+    void addDebugDedent(std::string_view stream);
 
     void addPrint(const std::vector<Expression>& exprs) { addCall("hilti::print", exprs); }
     void addPrint(const Expression& expr) { addCall("hilti::print", {expr}); }

--- a/hilti/toolchain/include/ast/builder/expression.h
+++ b/hilti/toolchain/include/ast/builder/expression.h
@@ -20,9 +20,16 @@ inline Expression id(ID id_, Meta m = Meta()) { return expression::UnresolvedID(
 
 // Ctor expressions
 
-inline Expression string(std::string s, const Meta& m = Meta()) {
+inline Expression string_mut(std::string s, const Meta& m = Meta()) {
     return expression::Ctor(ctor::String(std::move(s), false, m), m);
 }
+
+// clang-format off
+[[deprecated("Use string_mut or string_literal instead")]]
+inline Expression string(std::string s, const Meta& m = Meta()) {
+    return builder::string_mut(std::move(s), m);
+}
+// clang-format on
 
 inline Expression string_literal(std::string_view s) {
     // String literals have no location.
@@ -57,7 +64,7 @@ inline Expression default_(Type t, hilti::node::Range<Expression> type_args, con
 
 
 inline Expression exception(Type t, std::string msg, const Meta& m = Meta()) {
-    return expression::Ctor(ctor::Exception(std::move(t), builder::string(std::move(msg)), m), m);
+    return expression::Ctor(ctor::Exception(std::move(t), builder::string_mut(std::move(msg)), m), m);
 }
 
 inline Expression exception(Type t, Expression msg, const Meta& m = Meta()) {

--- a/hilti/toolchain/include/ast/builder/expression.h
+++ b/hilti/toolchain/include/ast/builder/expression.h
@@ -21,7 +21,12 @@ inline Expression id(ID id_, Meta m = Meta()) { return expression::UnresolvedID(
 // Ctor expressions
 
 inline Expression string(std::string s, const Meta& m = Meta()) {
-    return expression::Ctor(ctor::String(std::move(s), m), m);
+    return expression::Ctor(ctor::String(std::move(s), false, m), m);
+}
+
+inline Expression string_literal(std::string_view s) {
+    // String literals have no location.
+    return expression::Ctor(ctor::String({s.data(), s.size()}, true));
 }
 
 inline Expression bool_(bool b, const Meta& m = Meta()) { return expression::Ctor(ctor::Bool(b, m), m); }
@@ -305,13 +310,9 @@ inline Expression new_(Type t, const std::vector<Expression>& args, const Meta& 
 
 inline Expression expression(Ctor c, Meta m = Meta()) { return expression::Ctor(std::move(c), std::move(m)); }
 
-inline Expression expression(const Location& l) { return expression::Ctor(ctor::String(l), l); }
+inline Expression expression(const Location& l) { return builder::string_literal(std::string(l)); }
 
-inline Expression expression(const Meta& m) {
-    // NOTE: We omit the meta information here since this is how we distinguish
-    // user-provided and generated strings. Meta is generated information.
-    return expression::Ctor(ctor::String(m.location()));
-}
+inline Expression expression(const Meta& m) { return builder::expression(m.location()); }
 
 inline Expression grouping(Expression e, Meta m = Meta()) { return expression::Grouping(std::move(e), std::move(m)); }
 

--- a/hilti/toolchain/include/ast/builder/expression.h
+++ b/hilti/toolchain/include/ast/builder/expression.h
@@ -307,7 +307,11 @@ inline Expression expression(Ctor c, Meta m = Meta()) { return expression::Ctor(
 
 inline Expression expression(const Location& l) { return expression::Ctor(ctor::String(l), l); }
 
-inline Expression expression(const Meta& m) { return expression::Ctor(ctor::String(m.location()), m); }
+inline Expression expression(const Meta& m) {
+    // NOTE: We omit the meta information here since this is how we distinguish
+    // user-provided and generated strings. Meta is generated information.
+    return expression::Ctor(ctor::String(m.location()));
+}
 
 inline Expression grouping(Expression e, Meta m = Meta()) { return expression::Grouping(std::move(e), std::move(m)); }
 

--- a/hilti/toolchain/include/ast/ctors/string.h
+++ b/hilti/toolchain/include/ast/ctors/string.h
@@ -13,9 +13,11 @@ namespace hilti::ctor {
 /** AST node for a string constructor. */
 class String : public NodeBase, public hilti::trait::isCtor {
 public:
-    String(std::string v, const Meta& m = Meta()) : NodeBase(nodes(type::String(m)), m), _value(std::move(v)) {}
+    String(std::string v, bool is_literal = false, const Meta& m = Meta())
+        : NodeBase(nodes(type::String(m)), m), _value(std::move(v)), _is_literal(is_literal) {}
 
-    auto value() const { return _value; }
+    const auto& value() const& { return _value; }
+    bool isLiteral() const { return _is_literal; }
 
     bool operator==(const String& other) const { return value() == other.value(); }
 
@@ -31,10 +33,11 @@ public:
     auto isEqual(const Ctor& other) const { return node::isEqual(this, other); }
 
     /** Implements `Node` interface. */
-    auto properties() const { return node::Properties{{"value", _value}}; }
+    auto properties() const { return node::Properties{{"value", _value}, {"is_literal", _is_literal}}; }
 
 private:
     std::string _value;
+    bool _is_literal = false;
 };
 
 } // namespace hilti::ctor

--- a/hilti/toolchain/src/ast/builder/builder.cc
+++ b/hilti/toolchain/src/ast/builder/builder.cc
@@ -67,7 +67,7 @@ Expression Builder::addTmp(const std::string& prefix, const Type& t, const Expre
     return builder::id(tmp);
 }
 
-void Builder::addDebugMsg(const std::string& stream, const std::string& fmt, std::vector<Expression> args) {
+void Builder::addDebugMsg(std::string_view stream, std::string_view fmt, std::vector<Expression> args) {
     if ( ! context()->options().debug )
         return;
 
@@ -87,7 +87,7 @@ void Builder::addDebugMsg(const std::string& stream, const std::string& fmt, std
     _block._add(statement::Expression(call, call.meta()));
 }
 
-void Builder::addDebugIndent(const std::string& stream) {
+void Builder::addDebugIndent(std::string_view stream) {
     if ( ! context()->options().debug )
         return;
 
@@ -95,7 +95,7 @@ void Builder::addDebugIndent(const std::string& stream) {
     _block._add(statement::Expression(std::move(call)));
 }
 
-void Builder::addDebugDedent(const std::string& stream) {
+void Builder::addDebugDedent(std::string_view stream) {
     if ( ! context()->options().debug )
         return;
 

--- a/hilti/toolchain/src/ast/builder/builder.cc
+++ b/hilti/toolchain/src/ast/builder/builder.cc
@@ -74,14 +74,14 @@ void Builder::addDebugMsg(const std::string& stream, const std::string& fmt, std
     Expression call;
 
     if ( args.empty() )
-        call = builder::call("hilti::debug", {builder::string(stream), builder::string(fmt)});
+        call = builder::call("hilti::debug", {builder::string_literal(stream), builder::string_literal(fmt)});
     else if ( args.size() == 1 ) {
-        auto msg = builder::modulo(builder::string(fmt), std::move(args.front()));
-        call = builder::call("hilti::debug", {builder::string(stream), std::move(msg)});
+        auto msg = builder::modulo(builder::string_literal(fmt), std::move(args.front()));
+        call = builder::call("hilti::debug", {builder::string_literal(stream), std::move(msg)});
     }
     else {
-        auto msg = builder::modulo(builder::string(fmt), builder::tuple(args));
-        call = builder::call("hilti::debug", {builder::string(stream), std::move(msg)});
+        auto msg = builder::modulo(builder::string_literal(fmt), builder::tuple(args));
+        call = builder::call("hilti::debug", {builder::string_literal(stream), std::move(msg)});
     }
 
     _block._add(statement::Expression(call, call.meta()));
@@ -91,7 +91,7 @@ void Builder::addDebugIndent(const std::string& stream) {
     if ( ! context()->options().debug )
         return;
 
-    auto call = builder::call("hilti::debugIndent", {builder::string(stream)});
+    auto call = builder::call("hilti::debugIndent", {builder::string_literal(stream)});
     _block._add(statement::Expression(std::move(call)));
 }
 
@@ -99,11 +99,13 @@ void Builder::addDebugDedent(const std::string& stream) {
     if ( ! context()->options().debug )
         return;
 
-    auto call = builder::call("hilti::debugDedent", {builder::string(stream)});
+    auto call = builder::call("hilti::debugDedent", {builder::string_literal(stream)});
     _block._add(statement::Expression(std::move(call)));
 }
 
-void Builder::setLocation(const Location& l) { _block._add(statement::SetLocation(builder::string(l.render()))); }
+void Builder::setLocation(const Location& l) {
+    _block._add(statement::SetLocation(builder::string_literal(l.render())));
+}
 
 std::optional<Expression> Builder::startProfiler(const std::string& name) {
     if ( ! context()->options().enable_profiling )
@@ -112,7 +114,7 @@ std::optional<Expression> Builder::startProfiler(const std::string& name) {
     // Note the name of the temp must not clash what HILTI's code generator
     // picks for profiler that it instantiates itself. We do not currently keep
     // those namespace separate.
-    return addTmp("prof", builder::call("hilti::profiler_start", {builder::string(name)}));
+    return addTmp("prof", builder::call("hilti::profiler_start", {builder::string_literal(name)}));
 }
 
 void Builder::stopProfiler(Expression profiler) {

--- a/hilti/toolchain/src/ast/builder/builder.cc
+++ b/hilti/toolchain/src/ast/builder/builder.cc
@@ -107,7 +107,7 @@ void Builder::setLocation(const Location& l) {
     _block._add(statement::SetLocation(builder::string_literal(l.render())));
 }
 
-std::optional<Expression> Builder::startProfiler(const std::string& name) {
+std::optional<Expression> Builder::startProfiler(std::string_view name) {
     if ( ! context()->options().enable_profiling )
         return {};
 

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -181,7 +181,12 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
         return fmt("::hilti::rt::Stream(\"%s\"_b)", util::escapeBytesForCxx(n.value()));
     }
 
-    result_t operator()(const ctor::String& n) { return fmt("std::string(\"%s\")", util::escapeUTF8(n.value(), true)); }
+    result_t operator()(const ctor::String& n) {
+        if ( n.isLiteral() )
+            return fmt("std::string_view(\"%s\")", util::escapeUTF8(n.value(), true));
+        else
+            return fmt("std::string(\"%s\")", util::escapeUTF8(n.value(), true));
+    }
 
     result_t operator()(const ctor::Tuple& n) {
         return fmt("std::make_tuple(%s)",

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -820,7 +820,7 @@ member_expr   : local_id                         { $$ = hilti::expression::Membe
 
 ctor          : CBOOL                            { $$ = hilti::ctor::Bool($1, __loc__); }
               | CBYTES                           { $$ = hilti::ctor::Bytes(std::move($1), __loc__); }
-              | CSTRING                          { $$ = hilti::ctor::String($1, __loc__); }
+              | CSTRING                          { $$ = hilti::ctor::String($1, false, __loc__); }
               | CUINTEGER                        { $$ = hilti::ctor::UnsignedInteger($1, 64, __loc__); }
               | '+' CUINTEGER                    { if ( $2 > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) )
                                                     logger().error("integer constant out of range", __loc__.location());

--- a/hilti/toolchain/src/compiler/visitors/normalizer.cc
+++ b/hilti/toolchain/src/compiler/visitors/normalizer.cc
@@ -221,7 +221,7 @@ struct VisitorNormalizer : public visitor::PreOrder<void, VisitorNormalizer> {
         // Normalize values passed as `&cxxname` so they always are interpreted as FQNs by enforcing leading `::`.
         if ( const auto& tag = n.tag(); tag == "&cxxname" && n.hasValue() ) {
             if ( const auto& value = n.valueAsString(); value && ! util::startsWith(*value, "::") ) {
-                auto n = Attribute(tag, builder::string(util::fmt("::%s", *value)));
+                auto n = Attribute(tag, builder::string_literal(util::fmt("::%s", *value)));
                 logChange(p.node, n);
                 p.node = n;
                 modified = true;

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -139,10 +139,10 @@ struct has_on_undelivered {
  * as well.
  */
 struct Parser {
-    Parser(std::string name, bool is_public, Parse1Function parse1, hilti::rt::any parse2, Parse3Function parse3,
+    Parser(std::string_view name, bool is_public, Parse1Function parse1, hilti::rt::any parse2, Parse3Function parse3,
            ContextNewFunction context_new, const hilti::rt::TypeInfo* type, std::string description,
            hilti::rt::Vector<MIMEType> mime_types, hilti::rt::Vector<ParserPort> ports)
-        : name(std::move(name)),
+        : name(name),
           is_public(is_public),
           parse1(parse1),
           parse2(std::move(parse2)),
@@ -155,10 +155,10 @@ struct Parser {
         _initProfiling();
     }
 
-    Parser(std::string name, bool is_public, Parse1Function parse1, hilti::rt::any parse2, Parse3Function parse3,
+    Parser(std::string_view name, bool is_public, Parse1Function parse1, hilti::rt::any parse2, Parse3Function parse3,
            hilti::rt::Null /* null */, const hilti::rt::TypeInfo* type, std::string description,
            hilti::rt::Vector<MIMEType> mime_types, hilti::rt::Vector<ParserPort> ports)
-        : name(std::move(name)),
+        : name(name),
           is_public(is_public),
           parse1(parse1),
           parse2(std::move(parse2)),
@@ -170,19 +170,19 @@ struct Parser {
         _initProfiling();
     }
 
-    Parser(std::string name, bool is_public, hilti::rt::Null /* null */, hilti::rt::any parse2,
+    Parser(std::string_view name, bool is_public, hilti::rt::Null /* null */, hilti::rt::any parse2,
            hilti::rt::Null /* null */, hilti::rt::Null /* null */, const hilti::rt::TypeInfo* type,
            std::string description, hilti::rt::Vector<MIMEType> mime_types, hilti::rt::Vector<ParserPort> ports)
-        : Parser(std::move(name), is_public, nullptr, std::move(parse2), nullptr, nullptr, type, std::move(description),
+        : Parser(name, is_public, nullptr, std::move(parse2), nullptr, nullptr, type, std::move(description),
                  std::move(mime_types), std::move(ports)) {
         _initProfiling();
     }
 
-    Parser(std::string name, bool is_public, hilti::rt::Null /* null */, hilti::rt::any parse2,
+    Parser(std::string_view name, bool is_public, hilti::rt::Null /* null */, hilti::rt::any parse2,
            hilti::rt::Null /* null */, ContextNewFunction context_new, const hilti::rt::TypeInfo* type,
            std::string description, hilti::rt::Vector<MIMEType> mime_types, hilti::rt::Vector<ParserPort> ports)
-        : Parser(std::move(name), is_public, nullptr, std::move(parse2), nullptr, context_new, type,
-                 std::move(description), std::move(mime_types), std::move(ports)) {
+        : Parser(name, is_public, nullptr, std::move(parse2), nullptr, context_new, type, std::move(description),
+                 std::move(mime_types), std::move(ports)) {
         _initProfiling();
     }
 
@@ -206,7 +206,7 @@ struct Parser {
     }
 
     /** Short descriptive name. */
-    std::string name;
+    std::string_view name;
 
     /** Whether this parser is public. */
     bool is_public;
@@ -250,9 +250,9 @@ struct Parser {
 
     /** Pre-computed profiler tags used by the runtime driver. */
     struct {
-        std::string prepare_block;
-        std::string prepare_input;
-        std::string prepare_stream;
+        std::string prepare_block = "spicy/prepare/block/";
+        std::string prepare_input = "spicy/prepare/input/";
+        std::string prepare_stream = "spicy/prepare/stream/";
 
         operator bool() const {
             // ensure initialization code has run

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -405,11 +405,11 @@ inline void registerParser(::spicy::rt::Parser& p, // NOLINT(google-runtime-refe
  * Prints the current parser state, as passed in through arguments, to the
  * spicy-verbose debug stream.
  */
-void printParserState(const std::string& unit_id, const hilti::rt::ValueReference<hilti::rt::Stream>& data,
+void printParserState(std::string_view unit_id, const hilti::rt::ValueReference<hilti::rt::Stream>& data,
                       const std::optional<hilti::rt::stream::SafeConstIterator>& begin,
                       const hilti::rt::stream::View& cur, int64_t lahead,
-                      const hilti::rt::stream::SafeConstIterator& lahead_end, const std::string& literal_mode,
-                      bool trim, const std::optional<hilti::rt::RecoverableFailure>& error);
+                      const hilti::rt::stream::SafeConstIterator& lahead_end, std::string_view literal_mode, bool trim,
+                      const std::optional<hilti::rt::RecoverableFailure>& error);
 
 /**
  * Used by generated parsers to wait until a minimum amount of input becomes

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -316,7 +317,7 @@ inline auto parsers() {
  */
 class ParseError : public hilti::rt::RecoverableFailure {
 public:
-    ParseError(const std::string& msg, const std::string& location = "") : RecoverableFailure(msg, location) {}
+    ParseError(std::string_view msg, std::string_view location = "") : RecoverableFailure(msg, location) {}
 
     ParseError(const hilti::rt::result::Error& e) : RecoverableFailure(e.description()) {}
 
@@ -336,7 +337,7 @@ public:
 
 class MissingData : public ParseError {
 public:
-    MissingData(const std::string& location = "") : ParseError("missing data", location) {}
+    MissingData(std::string_view location = "") : ParseError("missing data", location) {}
     ~MissingData() override; /* required to create vtable, see hilti::rt::Exception */
 };
 
@@ -452,8 +453,8 @@ extern void waitForEod(hilti::rt::ValueReference<hilti::rt::Stream>& data, // NO
  * has been reached
  */
 extern void waitForInput(hilti::rt::ValueReference<hilti::rt::Stream>& data, // NOLINT(google-runtime-references)
-                         const hilti::rt::stream::View& cur, uint64_t min, const std::string& error_msg,
-                         const std::string& location,
+                         const hilti::rt::stream::View& cur, uint64_t min, std::string_view error_msg,
+                         std::string_view location,
                          hilti::rt::StrongReference<spicy::rt::filter::detail::Filters> filters);
 
 /**
@@ -484,7 +485,7 @@ extern bool waitForInputOrEod(hilti::rt::ValueReference<hilti::rt::Stream>& data
  * has been reached
  */
 extern void waitForInput(hilti::rt::ValueReference<hilti::rt::Stream>& data, // NOLINT(google-runtime-references)
-                         const hilti::rt::stream::View& cur, const std::string& error_msg, const std::string& location,
+                         const hilti::rt::stream::View& cur, std::string_view error_msg, std::string_view location,
                          const hilti::rt::StrongReference<spicy::rt::filter::detail::Filters>& filters);
 
 /**

--- a/spicy/runtime/include/sink.h
+++ b/spicy/runtime/include/sink.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -341,9 +342,9 @@ private:
     void _reportUndeliveredUpTo(uint64_t rupper) const;
 
     // Output reassembler state for debugging.
-    void _debugReassembler(const std::string& msg, const std::optional<hilti::rt::Bytes>& data, uint64_t seq,
+    void _debugReassembler(std::string_view msg, const std::optional<hilti::rt::Bytes>& data, uint64_t seq,
                            uint64_t len) const;
-    void _debugReassemblerBuffer(const std::string& msg) const;
+    void _debugReassemblerBuffer(std::string_view msg) const;
     void _debugDeliver(const hilti::rt::Bytes& data) const;
 
     // States for connected units.

--- a/spicy/runtime/include/sink.h
+++ b/spicy/runtime/include/sink.h
@@ -179,7 +179,7 @@ public:
      * @param mt MIME type to connect units for
      * @param scope identifier for the desired scope
      */
-    void connect_mime_type(const MIMEType& mt, const std::string& scope);
+    void connect_mime_type(const MIMEType& mt, std::string_view scope);
 
     /**
      * Connects new instances of all units to the sink that support a given
@@ -191,7 +191,7 @@ public:
      * @param scope identifier for the desired scope
      * @throws ``mime::InvalidType`` if the type cannot be parsed
      */
-    void connect_mime_type(const std::string& mt, const std::string& scope) { connect_mime_type(MIMEType(mt), scope); }
+    void connect_mime_type(const std::string& mt, std::string_view scope) { connect_mime_type(MIMEType(mt), scope); }
 
     /**
      * Connects new instances of all units to the sink that support a given
@@ -203,7 +203,7 @@ public:
      * @param scope identifier for the desired scope
      * @throws ``mime::InvalidType`` if the type cannot be parsed
      */
-    void connect_mime_type(const hilti::rt::Bytes& mt, const std::string& scope) {
+    void connect_mime_type(const hilti::rt::Bytes& mt, std::string_view scope) {
         connect_mime_type(MIMEType(mt.str()), scope);
     }
 

--- a/spicy/runtime/src/init.cc
+++ b/spicy/runtime/src/init.cc
@@ -38,7 +38,7 @@ void spicy::rt::init() {
                 default_parser = std::nullopt;
         }
 
-        globalState()->parsers_by_name[p->name].emplace_back(p);
+        globalState()->parsers_by_name[{p->name.data(), p->name.size()}].emplace_back(p);
 
         for ( const auto& x : p->ports ) {
             auto idx = std::string(x.port);

--- a/spicy/runtime/src/parser.cc
+++ b/spicy/runtime/src/parser.cc
@@ -22,9 +22,9 @@ HILTI_EXCEPTION_IMPL(ParseError)
 void spicy::rt::Parser::_initProfiling() {
     // Cache profiler tags to avoid recomputing them frequently.
     assert(! name.empty());
-    profiler_tags.prepare_block = "spicy/prepare/block/" + name;
-    profiler_tags.prepare_input = "spicy/prepare/input/" + name;
-    profiler_tags.prepare_stream = "spicy/prepare/stream/" + name;
+    profiler_tags.prepare_block.append(name);
+    profiler_tags.prepare_input.append(name);
+    profiler_tags.prepare_stream.append(name);
 }
 
 void spicy::rt::accept_input() {

--- a/spicy/runtime/src/parser.cc
+++ b/spicy/runtime/src/parser.cc
@@ -105,14 +105,14 @@ void detail::waitForEod(hilti::rt::ValueReference<hilti::rt::Stream>& data, cons
 }
 
 void detail::waitForInput(hilti::rt::ValueReference<hilti::rt::Stream>& data, const hilti::rt::stream::View& cur,
-                          uint64_t min, const std::string& error_msg, const std::string& location,
+                          uint64_t min, std::string_view error_msg, std::string_view location,
                           hilti::rt::StrongReference<spicy::rt::filter::detail::Filters>
                               filters) { // NOLINT(performance-unnecessary-value-param)
     while ( min > cur.size() )
         if ( ! waitForInputOrEod(data, cur, filters) ) {
             SPICY_RT_DEBUG_VERBOSE(
                 hilti::rt::fmt("insufficient input at end of data for stream %p (which is not ok here)", data.get()));
-            throw ParseError(error_msg, location);
+            throw ParseError(std::string(error_msg), std::string(location));
         }
 }
 
@@ -156,12 +156,12 @@ bool detail::waitForInputOrEod(hilti::rt::ValueReference<hilti::rt::Stream>& dat
 }
 
 void detail::waitForInput(hilti::rt::ValueReference<hilti::rt::Stream>& data, const hilti::rt::stream::View& cur,
-                          const std::string& error_msg, const std::string& location,
+                          std::string_view error_msg, std::string_view location,
                           const hilti::rt::StrongReference<spicy::rt::filter::detail::Filters>& filters) {
     if ( ! waitForInputOrEod(data, cur, filters) ) {
         SPICY_RT_DEBUG_VERBOSE(
             hilti::rt::fmt("insufficient input at end of data for stream %p (which is not ok here)", data.get()));
-        throw ParseError(error_msg, location);
+        throw ParseError(std::string(error_msg), std::string(location));
     }
 }
 

--- a/spicy/runtime/src/parser.cc
+++ b/spicy/runtime/src/parser.cc
@@ -52,10 +52,10 @@ static bool _haveEod(const hilti::rt::ValueReference<hilti::rt::Stream>& data, c
         return false;
 }
 
-void detail::printParserState(const std::string& unit_id, const hilti::rt::ValueReference<hilti::rt::Stream>& data,
+void detail::printParserState(std::string_view unit_id, const hilti::rt::ValueReference<hilti::rt::Stream>& data,
                               const std::optional<hilti::rt::stream::SafeConstIterator>& begin,
                               const hilti::rt::stream::View& cur, int64_t lahead,
-                              const hilti::rt::stream::SafeConstIterator& lahead_end, const std::string& literal_mode,
+                              const hilti::rt::stream::SafeConstIterator& lahead_end, std::string_view literal_mode,
                               bool trim, const std::optional<hilti::rt::RecoverableFailure>& error) {
     auto msg = [&]() {
         auto str = [&](const hilti::rt::stream::SafeConstIterator& begin,

--- a/spicy/runtime/src/sink.cc
+++ b/spicy/runtime/src/sink.cc
@@ -337,7 +337,7 @@ void Sink::_reportUndeliveredUpTo(uint64_t rupper) const {
     }
 }
 
-void Sink::_debugReassembler(const std::string& msg, const std::optional<hilti::rt::Bytes>& data, uint64_t rseq,
+void Sink::_debugReassembler(std::string_view msg, const std::optional<hilti::rt::Bytes>& data, uint64_t rseq,
                              uint64_t len) const {
     if ( ! debug::wantVerbose() )
         return;
@@ -355,7 +355,7 @@ void Sink::_debugReassembler(const std::string& msg, const std::optional<hilti::
             fmt("reassembler/%p: %s rseq=% " PRIu64 " upper=%" PRIu64 " <gap>", this, msg, rseq, rseq + len));
 }
 
-void Sink::_debugReassemblerBuffer(const std::string& msg) const {
+void Sink::_debugReassemblerBuffer(std::string_view msg) const {
     if ( ! debug::wantVerbose() )
         return;
 

--- a/spicy/runtime/src/sink.cc
+++ b/spicy/runtime/src/sink.cc
@@ -375,7 +375,7 @@ void Sink::_debugReassemblerBuffer(std::string_view msg) const {
         _debugReassembler(fmt("  * chunk %d:", i), c.data, c.rseq, (c.rupper - c.rseq));
 }
 
-void Sink::connect_mime_type(const MIMEType& mt, const std::string& scope) {
+void Sink::connect_mime_type(const MIMEType& mt, std::string_view scope) {
     auto connect_matching = [&](auto mt) {
         if ( const auto& x = detail::globalState()->parsers_by_mime_type.find(mt.asKey());
              x != detail::globalState()->parsers_by_mime_type.end() ) {

--- a/spicy/runtime/src/tests/init.cc
+++ b/spicy/runtime/src/tests/init.cc
@@ -52,12 +52,12 @@ TEST_CASE("init") {
         REQUIRE_NE(gs, nullptr);
         CHECK_EQ(gs->default_parser, &parser);
 
-        CHECK_EQ(gs->parsers_by_name,
-                 std::map<std::string, std::vector<const Parser*>>({{parser.name, {&parser}},
-                                                                    {"4040/tcp", {&parser}},
-                                                                    {"4040/tcp%orig", {&parser}},
-                                                                    {"4040/tcp%resp", {&parser}},
-                                                                    {parser.mime_types.at(0), {&parser}}}));
+        CHECK_EQ(gs->parsers_by_name, std::map<std::string, std::vector<const Parser*>>(
+                                          {{{parser.name.data(), parser.name.size()}, {&parser}},
+                                           {"4040/tcp", {&parser}},
+                                           {"4040/tcp%orig", {&parser}},
+                                           {"4040/tcp%resp", {&parser}},
+                                           {parser.mime_types.at(0), {&parser}}}));
         CHECK_EQ(gs->parsers_by_mime_type,
                  std::map<std::string, std::vector<const Parser*>>({{parser.mime_types.at(0), {&parser}}}));
     }
@@ -82,12 +82,12 @@ TEST_CASE("init") {
 
         CAPTURE(gs->parsers.size());
         CAPTURE(gs->parsers_by_name.size());
-        CHECK_EQ(gs->parsers_by_name,
-                 std::map<std::string, std::vector<const Parser*>>({{parser1.name, {&parser1}},
-                                                                    {"4040/tcp%orig", {&parser1}},
-                                                                    {parser1.mime_types.at(0), {&parser1}},
-                                                                    {parser2.name, {&parser2}},
-                                                                    {"4040/tcp%resp", {&parser2}}}));
+        CHECK_EQ(gs->parsers_by_name, std::map<std::string, std::vector<const Parser*>>(
+                                          {{{parser1.name.data(), parser1.name.size()}, {&parser1}},
+                                           {"4040/tcp%orig", {&parser1}},
+                                           {parser1.mime_types.at(0), {&parser1}},
+                                           {{parser2.name.data(), parser2.name.size()}, {&parser2}},
+                                           {"4040/tcp%resp", {&parser2}}}));
         CHECK_EQ(gs->parsers_by_mime_type,
                  std::map<std::string, std::vector<const Parser*>>(
                      {{parser1.mime_types.at(0), {&parser1}}, {parser2.mime_types.at(0).mainType(), {&parser2}}}));
@@ -113,12 +113,12 @@ TEST_CASE("init") {
 
         CAPTURE(gs->parsers.size());
         CAPTURE(gs->parsers_by_name.size());
-        CHECK_EQ(gs->parsers_by_name,
-                 std::map<std::string, std::vector<const Parser*>>({{parser1.name, {&parser1}},
-                                                                    {"4040/tcp%orig", {&parser1}},
-                                                                    {parser1.mime_types.at(0), {&parser1}},
-                                                                    {parser2.name, {&parser2}},
-                                                                    {"4040/tcp%resp", {&parser2}}}));
+        CHECK_EQ(gs->parsers_by_name, std::map<std::string, std::vector<const Parser*>>(
+                                          {{{parser1.name.data(), parser1.name.size()}, {&parser1}},
+                                           {"4040/tcp%orig", {&parser1}},
+                                           {parser1.mime_types.at(0), {&parser1}},
+                                           {{parser2.name.data(), parser2.name.size()}, {&parser2}},
+                                           {"4040/tcp%resp", {&parser2}}}));
         CHECK_EQ(gs->parsers_by_mime_type,
                  std::map<std::string, std::vector<const Parser*>>(
                      {{parser1.mime_types.at(0), {&parser1}}, {parser2.mime_types.at(0).mainType(), {&parser2}}}));

--- a/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
@@ -315,7 +315,7 @@ public:
      * @param error_msg message to report with parse error if end-of-data is reached
      * @param location location associated with the operation.
      */
-    void waitForInput(const Expression& min, const std::string& error_msg, const Meta& location);
+    void waitForInput(const Expression& min, std::string_view error_msg, const Meta& location);
 
     /**
      * Generates code that ensures that either a minimum amount of data is
@@ -337,7 +337,7 @@ public:
      * @param error_msg message to report with parse error if end-of-data is reached
      * @param location location associated with the operation
      */
-    void waitForInput(const std::string& error_msg, const Meta& location);
+    void waitForInput(std::string_view error_msg, const Meta& location);
 
     /**
      * Generates code that waits for either more input becoming available or

--- a/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/parser-builder.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -402,13 +403,13 @@ public:
     void consumeLookAhead(std::optional<Expression> dst = {});
 
     /** Generates code that triggers a parse error exception. */
-    void parseError(const std::string& error_msg, const Meta& location);
+    void parseError(std::string_view error_msg, const Meta& location);
 
     /** Generates code that triggers a parse error exception. */
     void parseError(const Expression& error_msg, const Meta& location);
 
     /** Generates code that triggers a parse error exception. */
-    void parseError(const std::string& fmt, const std::vector<Expression>& args, const Meta& location);
+    void parseError(std::string_view fmt, const std::vector<Expression>& args, const Meta& location);
 
     /** Called when a field has been updated. */
     void newValueForField(const production::Meta& meta, const Expression& value, const Expression& dd);

--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -343,7 +343,7 @@ struct VisitorPass2 : public hilti::visitor::PreOrder<void, VisitorPass2> {
 
         switch ( exprs.size() ) {
             case 0: {
-                auto call = builder::call("hilti::print", {builder::string("")});
+                auto call = builder::call("hilti::print", {builder::string_literal("")});
                 replaceNode(&p, hilti::statement::Expression(call, p.node.location()));
                 break;
             }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -2369,7 +2369,7 @@ Expression ParserBuilder::atEod() {
     return builder::call("spicy_rt::atEod", {state().data, state().cur, _filters(state())});
 }
 
-void ParserBuilder::waitForInput(const std::string& error_msg, const Meta& location) {
+void ParserBuilder::waitForInput(std::string_view error_msg, const Meta& location) {
     builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, builder::string_literal(error_msg),
                                                   builder::expression(location), _filters(state())});
 }
@@ -2378,7 +2378,7 @@ Expression ParserBuilder::waitForInputOrEod(const Expression& min) {
     return builder::call("spicy_rt::waitForInputOrEod", {state().data, state().cur, min, _filters(state())});
 }
 
-void ParserBuilder::waitForInput(const Expression& min, const std::string& error_msg, const Meta& location) {
+void ParserBuilder::waitForInput(const Expression& min, std::string_view error_msg, const Meta& location) {
     builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, min, builder::string_literal(error_msg),
                                                   builder::expression(location), _filters(state())});
 }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -1844,7 +1844,7 @@ hilti::type::Function ParserBuilder::parseMethodFunctionType(std::optional<type:
 
     auto params = std::vector<type::function::Parameter>{
         builder::parameter("__data", type::ValueReference(type::Stream()), declaration::parameter::Kind::InOut),
-        builder::parameter("__begin", type::Optional(type::stream::Iterator()), declaration::parameter::Kind::Copy),
+        builder::parameter("__begin", type::Optional(type::stream::Iterator()), declaration::parameter::Kind::In),
         builder::parameter("__cur", type::stream::View(), declaration::parameter::Kind::Copy),
         builder::parameter("__trim", type::Bool(), declaration::parameter::Kind::Copy),
         builder::parameter("__lah", look_ahead::Type, declaration::parameter::Kind::Copy),

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -64,8 +64,9 @@ ParserState::ParserState(const type::Unit& unit, const Grammar& grammar, Express
       cur(std::move(cur)) {}
 
 void ParserState::printDebug(const std::shared_ptr<builder::Builder>& builder) const {
-    builder->addCall("spicy_rt::printParserState", {builder::string(unit_id), data, begin, cur, lahead, lahead_end,
-                                                    builder::string(to_string(literal_mode)), trim, error});
+    builder->addCall("spicy_rt::printParserState",
+                     {builder::string_literal(unit_id.str()), data, begin, cur, lahead, lahead_end,
+                      builder::string_literal(to_string(literal_mode)), trim, error});
 }
 
 namespace spicy::detail::codegen {
@@ -157,7 +158,7 @@ struct ProductionVisitor
         if ( pb->options().debug ) {
             pb->state().printDebug(builder());
             builder()->addDebugMsg("spicy-verbose", fmt("- parsing production: %s", hilti::util::trim(std::string(p))));
-            builder()->addCall("hilti::debugIndent", {builder::string("spicy-verbose")});
+            builder()->addCall("hilti::debugIndent", {builder::string_literal("spicy-verbose")});
         }
     }
 
@@ -165,7 +166,7 @@ struct ProductionVisitor
         HILTI_DEBUG(spicy::logging::debug::ParserBuilder, fmt("- end production"));
 
         if ( pb->options().debug )
-            builder()->addCall("hilti::debugDedent", {builder::string("spicy-verbose")});
+            builder()->addCall("hilti::debugDedent", {builder::string_literal("spicy-verbose")});
 
         builder()->addComment(fmt("End parsing production: %s", hilti::util::trim(std::string(p))),
                               hilti::statement::comment::Separator::After);
@@ -259,7 +260,7 @@ struct ProductionVisitor
                         }
 
                         builder()->addDebugMsg("spicy", msg);
-                        builder()->addCall("hilti::debugIndent", {builder::string("spicy")});
+                        builder()->addCall("hilti::debugIndent", {builder::string_literal("spicy")});
                     }
 
                     if ( unit ) {
@@ -378,7 +379,7 @@ struct ProductionVisitor
                             fmt("ParserBuilder: non-atomic production %s not handled (%s)", p.typename_(), p));
 
                     if ( unit ) {
-                        builder()->addCall("hilti::debugDedent", {builder::string("spicy")});
+                        builder()->addCall("hilti::debugDedent", {builder::string_literal("spicy")});
                         popState();
                     }
 
@@ -1365,9 +1366,9 @@ struct ProductionVisitor
     }
 
     void operator()(const production::Enclosure& p) {
-        builder()->addCall("hilti::debugIndent", {builder::string("spicy")});
+        builder()->addCall("hilti::debugIndent", {builder::string_literal("spicy")});
         parseProduction(p.child());
-        builder()->addCall("hilti::debugDedent", {builder::string("spicy")});
+        builder()->addCall("hilti::debugDedent", {builder::string_literal("spicy")});
     }
 
     void operator()(const production::ForEach& p) {
@@ -1391,7 +1392,7 @@ struct ProductionVisitor
     void operator()(const production::Resolved& p) { parseProduction(grammar.resolved(p)); }
 
     void operator()(const production::Switch& p) {
-        builder()->addCall("hilti::debugIndent", {builder::string("spicy")});
+        builder()->addCall("hilti::debugIndent", {builder::string_literal("spicy")});
 
         if ( const auto& a = AttributeSet::find(p.attributes(), "&parse-from") )
             redirectInputToBytesValue(*a->valueAsExpression());
@@ -1444,7 +1445,7 @@ struct ProductionVisitor
         if ( AttributeSet::find(p.attributes(), "&parse-from") || AttributeSet::find(p.attributes(), "&parse-at") )
             popState();
 
-        builder()->addCall("hilti::debugDedent", {builder::string("spicy")});
+        builder()->addCall("hilti::debugDedent", {builder::string_literal("spicy")});
     }
 
     void operator()(const production::Unit& p) {
@@ -1884,9 +1885,9 @@ hilti::type::Struct ParserBuilder::addParserMethods(hilti::type::Struct s, const
          builder::parameter("cur", type::Optional(type::stream::View()), builder::optional(type::stream::View())),
          builder::parameter("context", type::Optional(builder::typeByID("spicy_rt::UnitContext")))};
 
-    auto attr_ext_overload =
-        AttributeSet({Attribute("&needed-by-feature", builder::string("is_filter")),
-                      Attribute("&needed-by-feature", builder::string("supports_sinks")), Attribute("&static")});
+    auto attr_ext_overload = AttributeSet({Attribute("&needed-by-feature", builder::string_literal("is_filter")),
+                                           Attribute("&needed-by-feature", builder::string_literal("supports_sinks")),
+                                           Attribute("&static")});
 
     auto f_ext_overload1_result = type::stream::View();
     auto f_ext_overload1 = builder::function(id_ext_overload1, f_ext_overload1_result, params,
@@ -2369,7 +2370,7 @@ Expression ParserBuilder::atEod() {
 }
 
 void ParserBuilder::waitForInput(const std::string& error_msg, const Meta& location) {
-    builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, builder::string(error_msg),
+    builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, builder::string_literal(error_msg),
                                                   builder::expression(location), _filters(state())});
 }
 
@@ -2378,7 +2379,7 @@ Expression ParserBuilder::waitForInputOrEod(const Expression& min) {
 }
 
 void ParserBuilder::waitForInput(const Expression& min, const std::string& error_msg, const Meta& location) {
-    builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, min, builder::string(error_msg),
+    builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, min, builder::string_literal(error_msg),
                                                   builder::expression(location), _filters(state())});
 }
 
@@ -2391,11 +2392,11 @@ void ParserBuilder::parseError(const Expression& error_msg, const Meta& location
 }
 
 void ParserBuilder::parseError(const std::string& error_msg, const Meta& location) {
-    parseError(builder::string(error_msg), location);
+    parseError(builder::string_literal(error_msg), location);
 }
 
 void ParserBuilder::parseError(const std::string& fmt, const std::vector<Expression>& args, const Meta& location) {
-    parseError(builder::modulo(builder::string(fmt), builder::tuple(args)), location);
+    parseError(builder::modulo(builder::string_literal(fmt), builder::tuple(args)), location);
 }
 
 void ParserBuilder::advanceToNextData() {

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -2391,11 +2391,11 @@ void ParserBuilder::parseError(const Expression& error_msg, const Meta& location
     builder()->addThrow(builder::exception(builder::typeByID("spicy_rt::ParseError"), error_msg, location), location);
 }
 
-void ParserBuilder::parseError(const std::string& error_msg, const Meta& location) {
+void ParserBuilder::parseError(std::string_view error_msg, const Meta& location) {
     parseError(builder::string_literal(error_msg), location);
 }
 
-void ParserBuilder::parseError(const std::string& fmt, const std::vector<Expression>& args, const Meta& location) {
+void ParserBuilder::parseError(std::string_view fmt, const std::vector<Expression>& args, const Meta& location) {
     parseError(builder::modulo(builder::string_literal(fmt), builder::tuple(args)), location);
 }
 

--- a/spicy/toolchain/src/compiler/codegen/unit-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/unit-builder.cc
@@ -341,7 +341,11 @@ Type CodeGen::compileUnit(const type::Unit& unit, bool declare_only) {
                               {ID("parse3"), parse3},
                               {ID("context_new"), context_new},
                               {ID("type_info"), builder::typeinfo(builder::id(*unit.id()))},
-                              {ID("description"), (description ? *description->expression() : builder::string(""))},
+                              // We emit different string types for generated and user-provided strings. The distinction
+                              // is whether they have a location, so set a dummy location so both branches behave
+                              // identically.
+                              {ID("description"), (description ? *description->expression() :
+                                                                 builder::string("", Meta(Location("<unset>"))))},
                               {ID("mime_types"),
                                builder::vector(builder::typeByID("spicy_rt::MIMEType"), std::move(mime_types))},
                               {ID("ports"),

--- a/spicy/toolchain/src/compiler/codegen/unit-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/unit-builder.cc
@@ -343,7 +343,7 @@ Type CodeGen::compileUnit(const type::Unit& unit, bool declare_only) {
                               {ID("parse3"), parse3},
                               {ID("context_new"), context_new},
                               {ID("type_info"), builder::typeinfo(builder::id(*unit.id()))},
-                              {ID("description"), (description ? *description->expression() : builder::string(""))},
+                              {ID("description"), (description ? *description->expression() : builder::string_mut(""))},
                               {ID("mime_types"),
                                builder::vector(builder::typeByID("spicy_rt::MIMEType"), std::move(mime_types))},
                               {ID("ports"),

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -1007,7 +1007,7 @@ ctor          : CADDRESS                         { $$ = hilti::ctor::Address(hil
               | CBYTES                           { $$ = hilti::ctor::Bytes(std::move($1), __loc__); }
               | CPORT                            { $$ = hilti::ctor::Port(hilti::ctor::Port::Value($1), __loc__); }
               | CNULL                            { $$ = hilti::ctor::Null(__loc__); }
-              | CSTRING                          { $$ = hilti::ctor::String($1, __loc__); }
+              | CSTRING                          { $$ = hilti::ctor::String($1, false, __loc__); }
               | CUINTEGER                        { $$ = hilti::ctor::UnsignedInteger($1, 64, __loc__); }
               | '+' CUINTEGER                    { if ( $2 > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) )
                                                     hilti::logger().error("integer constant out of range", __loc__.location());

--- a/tests/Baseline/hilti.ast.coercion/output
+++ b/tests/Baseline/hilti.ast.coercion/output
@@ -52,7 +52,7 @@
 [debug/ast-final]       - ID <name="D"> (coercion.hlt:10:15) [@i:XXX]
 [debug/ast-final]       - type::String (coercion.hlt:10:8) (const) (resolved) [@t:XXX]
 [debug/ast-final]       - expression::Ctor (coercion.hlt:10:19) (const) (resolved) [@e:XXX]
-[debug/ast-final]         - ctor::String <value="42"> (coercion.hlt:10:19) [@c:XXX]
+[debug/ast-final]         - ctor::String <is_literal="false" value="42"> (coercion.hlt:10:19) [@c:XXX]
 [debug/ast-final]           - type::String (coercion.hlt:10:19) (const) (resolved) [@t:XXX]
 [debug/ast-final]     - declaration::Function %5 <linkage="private" parent_type="%???"> (coercion.hlt:10:24-14:2) [canon-id: Foo::x] [@d:XXX]
 [debug/ast-final]       - Function <cc="<standard>"> (coercion.hlt:12:9-14:2) [@f:XXX]
@@ -140,7 +140,7 @@
 [debug/ast-final]               - ctor::UnsignedInteger <value="2" width="64"> (coercion.hlt:28:45) [@c:XXX]
 [debug/ast-final]                 - type::UnsignedInteger <width="64"> (coercion.hlt:28:45) (const) (resolved) [@t:XXX]
 [debug/ast-final]             - expression::Ctor (coercion.hlt:28:48) (const) (resolved) [@e:XXX]
-[debug/ast-final]               - ctor::String <value="xyz"> (coercion.hlt:28:48) [@c:XXX]
+[debug/ast-final]               - ctor::String <is_literal="false" value="xyz"> (coercion.hlt:28:48) [@c:XXX]
 [debug/ast-final]                 - type::String (coercion.hlt:28:48) (const) (resolved) [@t:XXX]
 [debug/ast-final]           - ctor::Tuple (coercion.hlt:28:41) [@c:XXX]
 [debug/ast-final]             - type::Tuple <wildcard="false"> (coercion.hlt:28:41) (const) (resolved) [@t:XXX]
@@ -166,7 +166,7 @@
 [debug/ast-final]                 - ctor::SignedInteger <value="2" width="32"> (coercion.hlt:28:45) [@c:XXX]
 [debug/ast-final]                   - type::SignedInteger <width="32"> (coercion.hlt:28:45) (const) (resolved) [@t:XXX]
 [debug/ast-final]             - expression::Ctor (coercion.hlt:28:48) (const) (resolved) [@e:XXX]
-[debug/ast-final]               - ctor::String <value="xyz"> (coercion.hlt:28:48) [@c:XXX]
+[debug/ast-final]               - ctor::String <is_literal="false" value="xyz"> (coercion.hlt:28:48) [@c:XXX]
 [debug/ast-final]                 - type::String (coercion.hlt:28:48) (const) (resolved) [@t:XXX]
 module Foo {
 

--- a/tests/Baseline/spicy.optimization.default-parser-functions/noopt.hlt
+++ b/tests/Baseline/spicy.optimization.default-parser-functions/noopt.hlt
@@ -24,11 +24,11 @@ type P0 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<P0> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P0_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P0_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type P1 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -50,11 +50,11 @@ public type P1 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<P1> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type P2 = struct {
     uint<8> x &optional;
@@ -80,11 +80,11 @@ public type P2 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<P2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@P0%uses_offset = True;
@@ -106,7 +106,7 @@ const bool __feat%foo@@P2%supports_filters = True;
 const bool __feat%foo@@P2%supports_sinks = True;
 const bool __feat%foo@@P2%synchronization = True;
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P0::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P0::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:12:11"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -213,7 +213,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P0::__parse_foo_P0_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P0::__parse_foo_P0_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:12:11"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -339,7 +339,7 @@ init function void __register_foo_P0() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:14:18"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -446,7 +446,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_foo_P1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_foo_P1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:14:18"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -574,7 +574,7 @@ method hook void foo::P2::__on_y(uint<8> __dd) {
 method hook void foo::P2::__on_0x25_error(string __except) {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:16:18-21:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -681,7 +681,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_foo_P2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_foo_P2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:16:18-21:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     # "<...>/default-parser-functions.spicy:17:8"

--- a/tests/Baseline/spicy.optimization.default-parser-functions/opt.hlt
+++ b/tests/Baseline/spicy.optimization.default-parser-functions/opt.hlt
@@ -7,11 +7,11 @@ import hilti;
 public type P1 = struct {
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<P1> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type P2 = struct {
     uint<8> x &optional;
@@ -20,11 +20,11 @@ public type P2 = struct {
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
     hook void __on_y(uint<8> __dd);
     hook void __on_0x25_error(string __except) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<P2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_P2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@P0%uses_offset = False;
@@ -49,7 +49,7 @@ const bool __feat%foo@@P2%synchronization = False;
 init function void __register_foo_P0() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:14:18"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -78,7 +78,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_foo_P1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P1::__parse_foo_P1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:14:18"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -157,7 +157,7 @@ method hook void foo::P2::__on_y(uint<8> __dd) {
 method hook void foo::P2::__on_0x25_error(string __except) {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:16:18-21:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -186,7 +186,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_foo_P2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::P2::__parse_foo_P2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/default-parser-functions.spicy:16:18-21:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     # "<...>/default-parser-functions.spicy:17:8"

--- a/tests/Baseline/spicy.optimization.feature_requirements/noopt.hlt
+++ b/tests/Baseline/spicy.optimization.feature_requirements/noopt.hlt
@@ -24,11 +24,11 @@ type X0 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X0> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X0_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X0_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type X1 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -50,11 +50,11 @@ type X1 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X1> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type X2 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -76,11 +76,11 @@ type X2 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type X3 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -103,11 +103,11 @@ type X3 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X3> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type X4 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -130,11 +130,11 @@ type X4 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X4> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type X5 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -156,11 +156,11 @@ public type X5 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X5> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type X6 = struct {
     strong_ref<spicy_rt::Sink> data &default=new spicy_rt::Sink() &internal &needed-by-feature="supports_sinks";
@@ -183,11 +183,11 @@ type X6 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X6> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@X0%uses_offset = True;
@@ -237,7 +237,7 @@ method hook void foo::X0::__on_0x25_init() {
     self.__offset;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X0::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X0::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:13:11-15:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -344,7 +344,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X0::__parse_foo_X0_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X0::__parse_foo_X0_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:13:11-15:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -474,7 +474,7 @@ method hook void foo::X1::__on_0x25_init() {
     (*(self.__begin));
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X1::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X1::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:18:11-20:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -581,7 +581,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X1::__parse_foo_X1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X1::__parse_foo_X1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:18:11-20:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -707,7 +707,7 @@ init function void __register_foo_X1() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:23:11"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -814,7 +814,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X2::__parse_foo_X2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X2::__parse_foo_X2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:23:11"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -940,7 +940,7 @@ init function void __register_foo_X2() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X3::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X3::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:26:11-28:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1051,7 +1051,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X3::__parse_foo_X3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X3::__parse_foo_X3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:26:11-28:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1181,7 +1181,7 @@ init function void __register_foo_X3() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:32:11-34:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1292,7 +1292,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_foo_X4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_foo_X4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:32:11-34:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1426,7 +1426,7 @@ method hook void foo::X5::__on_0x25_init() {
     spicy_rt::filter_connect(self, new X4());
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:36:18-40:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1533,7 +1533,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_foo_X5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_foo_X5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:36:18-40:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1659,7 +1659,7 @@ method hook void foo::X6::__on_0x25_init() {
     (*(*self).data).write(b"", Null, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:43:11-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1767,7 +1767,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_foo_X6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_foo_X6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:43:11-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 

--- a/tests/Baseline/spicy.optimization.feature_requirements/opt.hlt
+++ b/tests/Baseline/spicy.optimization.feature_requirements/opt.hlt
@@ -25,11 +25,11 @@ type X4 = struct {
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &needed-by-feature="supports_sinks" &needed-by-feature="is_filter";
     weak_ref<spicy_rt::Forward> __forward &internal &needed-by-feature="is_filter";
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X4> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 # Type X5 supports the following features:
 #     - supports_filters
@@ -38,11 +38,11 @@ public type X5 = struct {
     strong_ref<spicy_rt::Filters> __filters &internal &needed-by-feature="supports_filters";
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
     hook void __on_0x25_init() ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X5> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 # Type X6 supports the following features:
 #     - supports_sinks
@@ -52,11 +52,11 @@ type X6 = struct {
     spicy_rt::SinkState __sink &internal &needed-by-feature="supports_sinks";
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
     hook void __on_0x25_init() ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<X6> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_X6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@X0%uses_offset = True;
@@ -122,7 +122,7 @@ init function void __register_foo_X2() {
 init function void __register_foo_X3() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:32:11-34:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -154,7 +154,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_foo_X4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X4::__parse_foo_X4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:32:11-34:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -237,7 +237,7 @@ method hook void foo::X5::__on_0x25_init() {
     spicy_rt::filter_connect(self, new X4());
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:36:18-40:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -283,7 +283,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_foo_X5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X5::__parse_foo_X5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:36:18-40:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -363,7 +363,7 @@ method hook void foo::X6::__on_0x25_init() {
     (*(*self).data).write(b"", Null, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:43:11-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -393,7 +393,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_foo_X6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::X6::__parse_foo_X6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/feature_requirements.spicy:43:11-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;

--- a/tests/Baseline/spicy.optimization.unused-functions/noopt.hlt
+++ b/tests/Baseline/spicy.optimization.unused-functions/noopt.hlt
@@ -24,11 +24,11 @@ type A = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<A> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_A_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_A_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type B = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -50,11 +50,11 @@ public type B = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<B> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_B_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_B_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type C = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -76,11 +76,11 @@ type C = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<C> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_C_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_C_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type D = struct {
     value_ref<C> anon &optional &anonymous &no-emit;
@@ -103,11 +103,11 @@ public type D = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<D> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_D_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_D_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type F = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -130,11 +130,11 @@ type F = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<F> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_F_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_F_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@A%uses_offset = True;
@@ -174,7 +174,7 @@ function void f1() {
 public function void f2() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::A::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::A::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:18:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -281,7 +281,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::A::__parse_foo_A_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::A::__parse_foo_A_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:18:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -407,7 +407,7 @@ init function void __register_foo_A() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:21:17"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -514,7 +514,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_foo_B_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_foo_B_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:21:17"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -636,7 +636,7 @@ init function void __register_foo_B() {
     spicy_rt::registerParser(foo::B::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:24:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -743,7 +743,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_foo_C_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_foo_C_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:24:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -869,7 +869,7 @@ init function void __register_foo_C() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:25:17-27:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -976,7 +976,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_foo_D_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_foo_D_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:25:17-27:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     local value_ref<C> __transient_anon;
@@ -1113,7 +1113,7 @@ init function void __register_foo_D() {
     spicy_rt::registerParser(foo::D::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::F::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::F::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:30:10-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1224,7 +1224,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::F::__parse_foo_F_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::F::__parse_foo_F_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:30:10-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 

--- a/tests/Baseline/spicy.optimization.unused-functions/opt.hlt
+++ b/tests/Baseline/spicy.optimization.unused-functions/opt.hlt
@@ -7,26 +7,26 @@ import hilti;
 public type B = struct {
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<B> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_B_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_B_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type C = struct {
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_C_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_C_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type D = struct {
     value_ref<C> anon &optional &anonymous &no-emit;
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<D> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_D_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_D_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 
 const bool __feat%foo@@A%uses_offset = False;
@@ -63,7 +63,7 @@ const bool __feat%foo@@F%synchronization = False;
 init function void __register_foo_A() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:21:17"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -92,7 +92,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_foo_B_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::B::__parse_foo_B_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:21:17"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -165,7 +165,7 @@ init function void __register_foo_B() {
     spicy_rt::registerParser(foo::B::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:24:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -194,7 +194,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_foo_C_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::C::__parse_foo_C_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:24:10"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -208,7 +208,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
 init function void __register_foo_C() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:25:17-27:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -237,7 +237,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_foo_D_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::D::__parse_foo_D_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-functions.spicy:25:17-27:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     local value_ref<C> __transient_anon;

--- a/tests/Baseline/spicy.optimization.unused-types/noopt.hlt
+++ b/tests/Baseline/spicy.optimization.unused-types/noopt.hlt
@@ -24,11 +24,11 @@ type Priv1 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv1> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type Pub2 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -50,11 +50,11 @@ public type Pub2 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Pub2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv2 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -76,11 +76,11 @@ type Priv2 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv3 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -102,11 +102,11 @@ type Priv3 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv3> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv4 = struct {
     value_ref<Priv2> anon &optional &anonymous &no-emit;
@@ -131,11 +131,11 @@ type Priv4 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv4> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv5 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -157,11 +157,11 @@ type Priv5 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv5> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv6 = struct {
     optional<iterator<stream>> __begin &internal &needed-by-feature="uses_random_access";
@@ -183,11 +183,11 @@ type Priv6 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv6> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type Pub3 = struct {
     value_ref<Priv5> anon_2 &optional &anonymous &no-emit;
@@ -212,11 +212,11 @@ public type Pub3 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Pub3> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv7 = enum { A = 0, B = 1, C = 2 };
 public type Pub4 = enum { A = 0, B = 1, C = 2 };
@@ -244,11 +244,11 @@ public type Priv10 = struct {
     hook void __on_0x25_overlap(uint<64> seq, bytes old, bytes new_) ;
     hook void __on_0x25_skipped(uint<64> seq) ;
     hook void __on_0x25_undelivered(uint<64> seq, bytes data) ;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv10> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv10_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv10_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv11 = enum { A = 0, B = 1, C = 2 };
 type Priv12 = enum { A = 0, B = 1, C = 2 };
@@ -311,7 +311,7 @@ const bool __feat%foo@@Priv10%synchronization = True;
 global Priv11 en;
 global Priv12 em = Priv12::A;
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv1::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv1::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:13:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -418,7 +418,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv1::__parse_foo_Priv1_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv1::__parse_foo_Priv1_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:13:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -544,7 +544,7 @@ init function void __register_foo_Priv1() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:16:20"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -651,7 +651,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_foo_Pub2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_foo_Pub2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:16:20"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -773,7 +773,7 @@ init function void __register_foo_Pub2() {
     spicy_rt::registerParser(foo::Pub2::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:19:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -880,7 +880,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv2::__parse_foo_Priv2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv2::__parse_foo_Priv2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:19:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1006,7 +1006,7 @@ init function void __register_foo_Priv2() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv3::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv3::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:20:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1113,7 +1113,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv3::__parse_foo_Priv3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv3::__parse_foo_Priv3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:20:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1239,7 +1239,7 @@ init function void __register_foo_Priv3() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv4::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv4::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:21:14-24:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1346,7 +1346,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv4::__parse_foo_Priv4_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv4::__parse_foo_Priv4_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:21:14-24:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     local value_ref<Priv2> __transient_anon;
@@ -1518,7 +1518,7 @@ init function void __register_foo_Priv4() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:27:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1625,7 +1625,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_foo_Priv5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_foo_Priv5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:27:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1751,7 +1751,7 @@ init function void __register_foo_Priv5() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:28:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -1858,7 +1858,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_foo_Priv6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_foo_Priv6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:28:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 
@@ -1984,7 +1984,7 @@ init function void __register_foo_Priv6() {
 
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:29:20-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -2091,7 +2091,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_foo_Pub3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_foo_Pub3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:29:20-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     local value_ref<Priv5> __transient_anon_2;
@@ -2259,7 +2259,7 @@ init function void __register_foo_Pub3() {
     spicy_rt::registerParser(foo::Pub3::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:43:22-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -2366,7 +2366,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_foo_Priv10_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_foo_Priv10_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:43:22-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
 

--- a/tests/Baseline/spicy.optimization.unused-types/opt.hlt
+++ b/tests/Baseline/spicy.optimization.unused-types/opt.hlt
@@ -7,32 +7,32 @@ import hilti;
 public type Pub2 = struct {
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Pub2> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv5 = struct {
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv6 = struct {
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type Pub3 = struct {
     value_ref<Priv5> anon_2 &optional &anonymous &no-emit;
     value_ref<Priv6> x &optional;
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Pub3> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Pub3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 public type Pub4 = enum { A = 0, B = 1, C = 2 };
 type Priv8 = enum { A = 0, B = 1, C = 2 };
@@ -42,11 +42,11 @@ public type Priv10 = struct {
     Priv9 em;
     spicy_rt::Parser __parser &static &internal &needed-by-feature="supports_filters" &always-emit;
     optional<hilti::RecoverableFailure> __error &always-emit &internal;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
     method extern view<stream> parse1(inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse2(inout value_ref<Priv10> unit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method extern view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> gunit, inout value_ref<stream> data, optional<view<stream>> cur = Null, optional<spicy_rt::UnitContext> context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
-    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv10_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
+    method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo_Priv10_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
 type Priv11 = enum { A = 0, B = 1, C = 2 };
 type Priv12 = enum { A = 0, B = 1, C = 2 };
@@ -112,7 +112,7 @@ global Priv12 em = Priv12::A;
 init function void __register_foo_Priv1() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:16:20"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -141,7 +141,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_foo_Pub2_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub2::__parse_foo_Pub2_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:16:20"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -223,7 +223,7 @@ init function void __register_foo_Priv3() {
 init function void __register_foo_Priv4() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:27:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -252,7 +252,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_foo_Priv5_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv5::__parse_foo_Priv5_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:27:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -266,7 +266,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
 init function void __register_foo_Priv5() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:28:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -295,7 +295,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_foo_Priv6_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv6::__parse_foo_Priv6_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:28:14"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;
@@ -309,7 +309,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
 init function void __register_foo_Priv6() {
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:29:20-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -338,7 +338,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_foo_Pub3_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Pub3::__parse_foo_Pub3_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:29:20-32:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     local value_ref<Priv5> __transient_anon_2;
@@ -429,7 +429,7 @@ init function void __register_foo_Pub3() {
     spicy_rt::registerParser(foo::Pub3::__parser, $scope, Null);
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_stage1(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_stage1(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:43:22-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     try {
@@ -458,7 +458,7 @@ method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::Rec
     return __result;
 }
 
-method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_foo_Priv10_stage2(inout value_ref<stream> __data, copy optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
+method method tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> foo::Priv10::__parse_foo_Priv10_stage2(inout value_ref<stream> __data, optional<iterator<stream>> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error) {
     # "<...>/unused-types.spicy:43:22-46:2"
     local tuple<view<stream>, int<64>, iterator<stream>, optional<hilti::RecoverableFailure>> __result;
     (*self).__error = __error;


### PR DESCRIPTION
With this PR the benchmark from #1589 shows identical performance for both cases for me. Overall runtime seems to improve as well.

Before:

```console
$ hyperfine --export-markdown results.md -w3 'cat test-data.txt | ./build/bin/spicy-driver t.hlto' 'cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto'
Benchmark 1: cat test-data.txt | ./build/bin/spicy-driver t.hlto
  Time (mean ± σ):      1.713 s ±  0.018 s    [User: 1.699 s, System: 0.031 s]
  Range (min … max):    1.695 s …  1.738 s    10 runs
 
Benchmark 2: cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto
  Time (mean ± σ):      2.166 s ±  0.014 s    [User: 2.141 s, System: 0.041 s]
  Range (min … max):    2.147 s …  2.191 s    10 runs
 
Summary
  cat test-data.txt | ./build/bin/spicy-driver t.hlto ran
    1.26 ± 0.02 times faster than cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto
```

After:

```console
$ hyperfine --export-markdown results.md -w3 'cat test-data.txt | ./build/bin/spicy-driver t.hlto' 'cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto'
Benchmark 1: cat test-data.txt | ./build/bin/spicy-driver t.hlto
  Time (mean ± σ):      1.218 s ±  0.008 s    [User: 1.204 s, System: 0.029 s]
  Range (min … max):    1.209 s …  1.232 s    10 runs
 
Benchmark 2: cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto
  Time (mean ± σ):      1.219 s ±  0.005 s    [User: 1.202 s, System: 0.031 s]
  Range (min … max):    1.215 s …  1.231 s    10 runs
 
Summary
  cat test-data.txt | ./build/bin/spicy-driver t.hlto ran
    1.00 ± 0.01 times faster than cat test-data.txt | ./build/bin/spicy-driver t-compiled-with-realpath.hlto
```

Closes #1589.
Closes #1591.