### PR TITLE
RFC: Switch to use of individual stacks for fiber execution.

### DIFF
--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -21,8 +21,8 @@ using namespace hilti::rt;
 
 #ifndef HILTI_HAVE_ASAN
 // Defaults for normal operation.
-static const auto DefaultFiberType = detail::Fiber::Type::SharedStack; // share stack by default
-static const auto AlwaysUseStackSwitchTrampoline = false;              // use switch trampoline only with shared stacks
+static const auto DefaultFiberType = detail::Fiber::Type::IndividualStack; // individual stack by default
+static const auto AlwaysUseStackSwitchTrampoline = false; // use switch trampoline only with shared stacks
 static const auto FiberGuardFlags = FIBER_FLAG_GUARD_LO | FIBER_FLAG_GUARD_HI;
 
 #define ASAN_NO_OPTIMIZE // just leave empty


### PR DESCRIPTION
We would previously use shared stacks to minimize memory overhead from pessimisitcally giving each fiber enough stack space if they were running on individual fibers. This causes overhead since when a fiber suspends or resumes it stack needs to be saved and restored (at least: memcpy of the whole used stack).

On many (most?) systems the `malloc` used by our fiber dependency to allocate memory for fiber stacks is lazy though so the overhead is not really a concern there (we might increase the virtual, but not the resident memory). I see a lazy `malloc` on macos-13, and this also seems to be the default on Linux^[1]. This means that we can avoid the overhead from `memcpy` on these systems.

This patch switches fibers to use individual stacks instead.

---
^[1]: https://www.kernel.org/doc/Documentation/vm/overcommit-accounting