### PR TITLE
Allow for unresolved types for set `in` operator.

### DIFF
--- a/hilti/toolchain/src/compiler/visitors/coercer.cc
+++ b/hilti/toolchain/src/compiler/visitors/coercer.cc
@@ -401,7 +401,11 @@ struct Visitor : public visitor::PreOrder<void, Visitor> {
     // passed `set` and perform the coercion automatically when resolving the
     // function call.
     void operator()(const operator_::set::In& n, position_t p) {
-        if ( auto x = coerceTo(&p.node, n.op0(), n.op1().type().as<type::Set>().elementType(), true, false) ) {
+        auto op1 = n.op1().type().tryAs<type::Set>();
+        if ( ! op1 )
+            return;
+
+        if ( auto x = coerceTo(&p.node, n.op0(), op1->elementType(), true, false) ) {
             logChange(p.node, *x, "call argument");
             p.node.as<operator_::set::In>().setOp0(*x);
             modified = true;

--- a/tests/spicy/types/set/const-set.spicy
+++ b/tests/spicy/types/set/const-set.spicy
@@ -1,0 +1,10 @@
+# @TEST-DOC: Checks that `in` works with `const` sets; regression test for #1605.
+#
+# @TEST-EXEC: spicyc -dj %INPUT
+
+module foo;
+
+const xs = set("a");
+
+assert "a" in xs;
+assert "b" !in xs;


### PR DESCRIPTION
Closes #1605.