### PR TITLE
Allow unsafe Vector iteration over underlying std::vector.

### DIFF
--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -490,6 +490,9 @@ public:
     auto cbegin() const { return const_iterator(0U, _control); }
     auto cend() const { return const_iterator(size(), _control); }
 
+    auto unsafeBegin() const { return V::cbegin(); }
+    auto unsafeEnd() const { return V::cend(); }
+
     size_type size() const { return V::size(); }
 
     // Methods of `std::vector`.


### PR DESCRIPTION
Iterating over hilti::Vector is quite expensive due to the weak_ptr::lock() calls. For unsafe uses, allow access to the underlying std::vector for faster raw iteration speed.

---

Change on the Zeek side: https://github.com/zeek/zeek/pull/3491