### PR TITLE
Display floats in scientific notation in profiler report.

### DIFF
--- a/hilti/runtime/src/profiler.cc
+++ b/hilti/runtime/src/profiler.cc
@@ -89,7 +89,7 @@ std::optional<Measurement> profiler::get(const std::string& name) {
 
 void profiler::report() {
     static const auto fmt_header = "#%-49s %10s %10s %10s %10s\n";
-    static const auto fmt_data = "%-50s %10" PRIu64 " %10" PRIu64 " %10.2f %10.2f \n";
+    static const auto fmt_data = "%-50s %10" PRIu64 " %10" PRIu64 " %10.2e %10.2e\n";
 
     const auto& profilers = rt::detail::globalState()->profilers;
 

--- a/tests/Baseline/hilti.rt.profiler/output
+++ b/tests/Baseline/hilti.rt.profiler/output
@@ -2,4 +2,4 @@
 #name count avg-% total-%
 hilti/func/Foo::fibo 192
 hilti/func/Foo::y 95
-hilti/total 1 100.00 100.00
+hilti/total 1 1.00e+02 1.00e+02

--- a/tests/Baseline/spicy.rt.profiler/prof.log
+++ b/tests/Baseline/spicy.rt.profiler/prof.log
@@ -11,7 +11,7 @@ hilti/func/Mini::Test::__parse_stage1 1
 hilti/func/Mini::Test::parse3 1
 hilti/func/Mini::__register_Mini_Sub 1
 hilti/func/Mini::__register_Mini_Test 1
-hilti/total 1 100.00 100.00
+hilti/total 1 1.00e+02 1.00e+02
 spicy/prepare/input/Mini::Test 1
 spicy/unit/Mini::Sub 1
 spicy/unit/Mini::Sub::f2 1
@@ -30,7 +30,7 @@ hilti/func/Mini::Test::__parse_stage1 4
 hilti/func/Mini::Test::parse1 4
 hilti/func/Mini::__register_Mini_Sub 1
 hilti/func/Mini::__register_Mini_Test 1
-hilti/total 1 100.00 100.00
+hilti/total 1 1.00e+02 1.00e+02
 spicy/prepare/block/Mini::Test 3
 spicy/prepare/stream/Mini::Test 3
 spicy/unit/Mini::Sub 4


### PR DESCRIPTION
We previously would display floats as decimals with two decimals in the profiler report. While this makes it easy to get a quick overview of the magnitude from directly looking at the logs, in real parsers many more components might be involved which each only contribute less than 1%; such contributions are currently displayed as 0.00.

This patch switches display of floating point numbers in the profiler report to use scientific notation so we do not loose information for small fractions.