### PR TITLE
Vector/Bytes: Lazily allocate shared_ptr _control

### DIFF
--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -267,7 +267,6 @@ public:
     using const_iterator = vector::ConstIterator<T, Allocator>;
 
     using C = std::shared_ptr<Vector*>;
-    C _control = std::make_shared<Vector<T, Allocator>*>(this);
 
     Vector() = default;
 
@@ -325,7 +324,7 @@ public:
         if ( i >= V::size() )
             throw IndexError(fmt("vector index %" PRIu64 " out of range", i));
 
-        return const_iterator(static_cast<size_type>(i), _control);
+        return const_iterator(static_cast<size_type>(i), getControl());
     }
 
     /**
@@ -481,14 +480,14 @@ public:
         return pos;
     }
 
-    auto begin() { return iterator(0U, _control); }
-    auto end() { return iterator(size(), _control); }
+    auto begin() { return iterator(0U, getControl()); }
+    auto end() { return iterator(size(), getControl()); }
 
-    auto begin() const { return const_iterator(0U, _control); }
-    auto end() const { return const_iterator(size(), _control); }
+    auto begin() const { return const_iterator(0U, getControl()); }
+    auto end() const { return const_iterator(size(), getControl()); }
 
-    auto cbegin() const { return const_iterator(0U, _control); }
-    auto cend() const { return const_iterator(size(), _control); }
+    auto cbegin() const { return const_iterator(0U, getControl()); }
+    auto cend() const { return const_iterator(size(), getControl()); }
 
     auto unsafeBegin() const { return V::cbegin(); }
     auto unsafeEnd() const { return V::cend(); }
@@ -509,6 +508,16 @@ public:
     friend bool operator==(const Vector& a, const Vector& b) {
         return static_cast<const V&>(a) == static_cast<const V&>(b);
     }
+
+private:
+    const C& getControl() const {
+        if ( ! _control )
+            _control = std::make_shared<Vector<T, Allocator>*>(const_cast<Vector<T, Allocator>*>(this));
+
+        return _control;
+    }
+
+    mutable C _control;
 };
 
 namespace vector {


### PR DESCRIPTION
Vector and Bytes currently allocate and de-allocated a shared_ptr as a "control block" unconditionally.

This results in an extra malloc and free as well as atomic instructions during destruction. This control block is only required when "safely" iterating, but that may never happen.

Applying this change and testing with a fairly large analyzer, execution time is reduced from 20.6 seconds to ~17.3~ 19.5 seconds, some ~16%~ 5%.

A further step might be to implement a custom control block class to avoid the atomic instructions altogether. Also, the StrongReferene and ValueReference use shared_ptr, showing significantly in profiles. Their usage should likely be revisited, too.

---

mutable and const_cast. Happy to hear how to do that nicer :-)