### PR TITLE
Misc performance improvements

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1337,7 +1337,9 @@ public:
     detail::UnsafeConstIterator unsafeBegin() const { return detail::UnsafeConstIterator(_begin); }
 
     /** Returns an unsafe iterator representing the end of the instance. */
-    detail::UnsafeConstIterator unsafeEnd() const { return detail::UnsafeConstIterator(end()); }
+    detail::UnsafeConstIterator unsafeEnd() const {
+        return _end ? detail::UnsafeConstIterator(*_end) : _begin.chain()->unsafeEnd();
+    }
 
     /** Returns an safe iterator pointint to the beginning of the view. */
     const SafeConstIterator& begin() const { return _begin; }

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1011,8 +1011,11 @@ public:
     /** Constructor. */
     View() = default;
 
-    /** Destructor. */
-    ~View() = default;
+    View(const View&) = default;
+    View(View&&) = default;
+
+    View& operator=(const View&) = default;
+    View& operator=(View&&) = default;
 
     /** Constructor for static view bracketed through two iterators. */
     explicit View(SafeConstIterator begin, SafeConstIterator end) : _begin(std::move(begin)), _end(std::move(end)) {

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -365,6 +365,12 @@ public:
     /** Constructor. */
     SafeConstIterator() = default;
 
+    SafeConstIterator(const SafeConstIterator&) = default;
+    SafeConstIterator(SafeConstIterator&&) = default;
+
+    SafeConstIterator& operator=(const SafeConstIterator&) = default;
+    SafeConstIterator& operator=(SafeConstIterator&&) = default;
+
     /** Constructor. */
     explicit SafeConstIterator(const UnsafeConstIterator& i);
 


### PR DESCRIPTION
The main changes in this patch are adding of move constructors for types used heavily in generated code (in C++17 if a type declares any constructor no implicit move constructor is generated anymore). This cuts about 4% from the runtime for a huge internal parser we have. Changes here are motivated by benchmark results and I didn't attempt a sweeping audit.