### PR TITLE
Aggressively implement rule of 5

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,8 @@ Checks: '
   -clang-diagnostic-range-loop-analysis,
   -clang-analyzer-core.StackAddressEscape,
 
+  cppcoreguidelines-special-member-functions,
+
   misc-*,
   -misc-macro-parentheses,
   -misc-non-private-member-variables-in-classes,

--- a/hilti/runtime/include/exception.h
+++ b/hilti/runtime/include/exception.h
@@ -99,6 +99,12 @@ inline std::ostream& operator<<(std::ostream& stream, const Exception& e) { retu
         name(std::string_view desc) : base(Internal(), #name, desc) {}                                                 \
         name(std::string_view desc, std::string_view location) : base(Internal(), #name, desc, location) {}            \
         virtual ~name(); /* required to create vtable, see hilti::rt::Exception */                                     \
+                                                                                                                       \
+        name(const name&) = default;                                                                                   \
+        name(name&&) = default;                                                                                        \
+        name& operator=(const name&) = default;                                                                        \
+        name& operator=(name&&) = default;                                                                             \
+                                                                                                                       \
     protected:                                                                                                         \
         using base::base;                                                                                              \
     }; // namespace hilti::rt

--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -81,6 +81,11 @@ struct StackBuffer {
      */
     StackBuffer(const ::Fiber* fiber) : _fiber(fiber) {}
 
+    StackBuffer(const StackBuffer&) = delete;
+    StackBuffer(StackBuffer&&) = default;
+    StackBuffer& operator=(const StackBuffer&) = delete;
+    StackBuffer& operator=(StackBuffer&&) = default;
+
     /** Destructor. */
     ~StackBuffer();
 

--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -48,6 +48,12 @@ struct FiberContext {
     FiberContext();
     ~FiberContext();
 
+    FiberContext(const FiberContext&) = delete;
+    FiberContext(FiberContext&&) = default;
+
+    FiberContext& operator=(const FiberContext&) = delete;
+    FiberContext& operator=(FiberContext&&) = default;
+
     /** (Pseudo-)fiber representing the main function. */
     std::unique_ptr<detail::Fiber> main;
 

--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -145,11 +145,13 @@ public:
               return hilti::rt::any_cast<F>(f)(h);
           }) {}
 
-    Callback(const Callback&) = default;
+    Callback(const Callback&) = delete;
     Callback(Callback&&) = default;
 
-    Callback& operator=(const Callback&) = default;
+    Callback& operator=(const Callback&) = delete;
     Callback& operator=(Callback&&) = default;
+
+    ~Callback() = default;
 
     hilti::rt::any operator()(resumable::Handle* h) const { return _invoke(_f, h); }
 

--- a/hilti/runtime/include/iterator.h
+++ b/hilti/runtime/include/iterator.h
@@ -18,6 +18,9 @@ public:
 
     Range(const Range&) = delete;
     Range(Range&&) = delete;
+
+    ~Range() = default;
+
     Range& operator=(const Range&) = delete;
     Range& operator=(Range&&) = delete;
 

--- a/hilti/runtime/include/test/utils.h
+++ b/hilti/runtime/include/test/utils.h
@@ -55,6 +55,11 @@ public:
             hilti::rt::filesystem::remove_all(_path, ec); // Swallow any error from removal.
     }
 
+    TemporaryFile(const TemporaryFile&) = delete;
+    TemporaryFile(TemporaryFile&&) = default;
+    TemporaryFile& operator=(const TemporaryFile&) = delete;
+    TemporaryFile& operator=(TemporaryFile&&) = default;
+
 private:
     hilti::rt::filesystem::path _path;
 };
@@ -64,6 +69,11 @@ class CaptureIO {
 public:
     CaptureIO(std::ostream& stream) : _old(stream.rdbuf(_buffer.rdbuf())), _stream(&stream) {}
     ~CaptureIO() { _stream->rdbuf(_old); }
+
+    CaptureIO(const CaptureIO&) = delete;
+    CaptureIO(CaptureIO&&) = default;
+    CaptureIO& operator=(const CaptureIO&) = delete;
+    CaptureIO& operator=(CaptureIO&&) = default;
 
     auto str() const { return _buffer.str(); }
 
@@ -82,6 +92,11 @@ public:
     }
 
     ~TestContext() { context::detail::current() = _prev; }
+
+    TestContext(const TestContext&) = delete;
+    TestContext(TestContext&&) = default;
+    TestContext& operator=(const TestContext&) = delete;
+    TestContext& operator=(TestContext&&) = default;
 
 private:
     Context* _prev = nullptr;

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -188,6 +188,8 @@ public:
     Bytes(const Bytes& xs) : Base(xs) {}
     Bytes(Bytes&& xs) noexcept : Base(std::move(xs)) {}
 
+    ~Bytes() = default;
+
     /** Replaces the contents of this `Bytes` with another `Bytes`.
      *
      * This function invalidates all iterators.

--- a/hilti/runtime/include/types/reference.h
+++ b/hilti/runtime/include/types/reference.h
@@ -392,6 +392,8 @@ public:
     /** Move constructor. */
     StrongReference(StrongReference&& other) noexcept : Base(std::move(other)) {}
 
+    ~StrongReference() = default;
+
     /**
      * Returns true if the reference does not refer any value.
      */

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -366,6 +366,8 @@ public:
     /** Constructor. */
     SafeConstIterator() = default;
 
+    ~SafeConstIterator() = default;
+
     SafeConstIterator(const SafeConstIterator&) = default;
     SafeConstIterator(SafeConstIterator&&) = default;
 

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -225,7 +225,8 @@ public:
     using UnsafeConstIterator = stream::detail::UnsafeConstIterator;
     using Size = stream::Size;
 
-    Chain() {}
+    Chain() = default;
+    ~Chain() = default;
 
     /** Moves a chunk and all its successors into a new chain. */
     Chain(std::unique_ptr<Chunk> head) : _head(std::move(head)), _tail(_head->last()) { _head->setChain(this); }

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1020,6 +1020,8 @@ public:
     /** Constructor. */
     View() = default;
 
+    ~View() = default;
+
     View(const View&) = default;
     View(View&&) = default;
 

--- a/hilti/runtime/src/tests/exception.cc
+++ b/hilti/runtime/src/tests/exception.cc
@@ -30,6 +30,11 @@ public:
         debug::setLocation(nullptr);
     }
 
+    TestLocation(const TestLocation&) = delete;
+    TestLocation(TestLocation&&) = delete;
+    TestLocation& operator=(const TestLocation&) = delete;
+    TestLocation& operator=(TestLocation&&) = delete;
+
 private:
     std::string _location;
     Context* _prev = nullptr;

--- a/hilti/runtime/src/tests/hilti.cc
+++ b/hilti/runtime/src/tests/hilti.cc
@@ -23,6 +23,11 @@ public:
 
     ~TestCout() { configuration::detail::__configuration = std::move(_prev); }
 
+    TestCout(const TestCout&) = delete;
+    TestCout(TestCout&&) = delete;
+    TestCout& operator=(const TestCout&) = delete;
+    TestCout& operator=(TestCout&&) = delete;
+
     auto str() const { return _cout.str(); }
 
 private:

--- a/hilti/runtime/src/tests/intrusive-ptr.cc
+++ b/hilti/runtime/src/tests/intrusive-ptr.cc
@@ -25,6 +25,11 @@ public:
     Managed() { ++instances; }
     ~Managed() { --instances; }
     static inline int instances = 0;
+
+    Managed(const Managed&) = delete;
+    Managed(Managed&&) = default;
+    Managed& operator=(const Managed&) = delete;
+    Managed& operator=(Managed&&) = default;
 };
 
 using ManagedPtr = IntrusivePtr<Managed>;
@@ -49,6 +54,11 @@ struct TestObject : intrusive_ptr::ManagedObject {
     static uint64_t instances;
     TestObject() { ++instances; }
     TestObject(int _i) : i(_i) { ++instances; }
+
+    TestObject(const TestObject&) = delete;
+    TestObject(TestObject&&) = default;
+    TestObject& operator=(const TestObject&) = delete;
+    TestObject& operator=(TestObject&&) = default;
 
     ~TestObject() { --instances; }
 

--- a/hilti/runtime/src/tests/library.cc
+++ b/hilti/runtime/src/tests/library.cc
@@ -55,6 +55,11 @@ public:
         }
     }
 
+    Env(const Env&) = delete;
+    Env(Env&&) = default;
+    Env& operator=(const Env&) = delete;
+    Env& operator=(Env&&) = default;
+
 private:
     std::pair<std::string, std::optional<std::string>> _prev;
 };

--- a/hilti/runtime/src/tests/logging.cc
+++ b/hilti/runtime/src/tests/logging.cc
@@ -27,6 +27,11 @@ public:
         std::swap(_prev, detail::globalState()->debug_logger);
     }
 
+    TestLogger(const TestLogger&) = delete;
+    TestLogger(TestLogger&&) = default;
+    TestLogger& operator=(const TestLogger&) = delete;
+    TestLogger& operator=(TestLogger&&) = default;
+
     ~TestLogger() { detail::globalState()->debug_logger = std::move(_prev); }
 
     auto lines() const { return _file.lines(); }

--- a/hilti/runtime/src/tests/main.cc
+++ b/hilti/runtime/src/tests/main.cc
@@ -7,6 +7,11 @@
 
 struct RuntimeWrapper {
     ~RuntimeWrapper() { hilti::rt::done(); }
+    RuntimeWrapper() = default;
+    RuntimeWrapper(const RuntimeWrapper&) = delete;
+    RuntimeWrapper(RuntimeWrapper&&) = default;
+    RuntimeWrapper& operator=(const RuntimeWrapper&) = delete;
+    RuntimeWrapper& operator=(RuntimeWrapper&&) = default;
 };
 
 int main(int argc, char** argv) {

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -134,6 +134,10 @@ TEST_CASE("createTemporaryFile") {
 
         struct Cleanup {
             Cleanup(hilti::rt::filesystem::path& tmp) : _tmp(tmp) {}
+            Cleanup(const Cleanup&) = delete;
+            Cleanup(Cleanup&&) = default;
+            Cleanup& operator=(const Cleanup&) = delete;
+            Cleanup& operator=(Cleanup&&) = delete;
             ~Cleanup() {
                 std::error_code ec;
                 if ( hilti::rt::filesystem::exists(_tmp, ec) )

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -56,6 +56,10 @@ public:
     Pimpl(const Pimpl& other) : _acc(other._acc), _first(other._first), _re(other._re) {
         jrx_match_state_copy(&other._ms, &_ms);
     }
+
+    Pimpl(Pimpl&&) = default;
+    Pimpl& operator=(const Pimpl&) = default;
+    Pimpl& operator=(Pimpl&&) = default;
 };
 
 regexp::MatchState::MatchState(const RegExp& re) {

--- a/hilti/toolchain/include/ast/operator.h
+++ b/hilti/toolchain/include/ast/operator.h
@@ -192,6 +192,8 @@ struct Operand {
     Operand(Operand&&) = default;
     Operand(const Operand&) = default;
 
+    ~Operand() = default;
+
     Operand& operator=(Operand&&) = default;
     Operand& operator=(const Operand&) = default;
 

--- a/hilti/toolchain/include/base/visitor.h
+++ b/hilti/toolchain/include/base/visitor.h
@@ -260,6 +260,11 @@ public:
     Visitor() = default;
     virtual ~Visitor() = default;
 
+    Visitor(const Visitor&) = default;
+    Visitor(Visitor&&) noexcept = default;
+    Visitor& operator=(const Visitor&) = default;
+    Visitor& operator=(Visitor&&) noexcept = default;
+
     virtual void preDispatch(const Erased& /* n */, int /* level */){};
 
     /** Execute matching dispatch methods for a single node.  */

--- a/hilti/toolchain/include/compiler/context.h
+++ b/hilti/toolchain/include/compiler/context.h
@@ -145,6 +145,11 @@ public:
     /** Destructor. */
     ~Context();
 
+    Context(const Context&) = default;
+    Context(Context&&) = default;
+    Context& operator=(const Context&) = default;
+    Context& operator=(Context&&) = default;
+
     /** Returns the context's compiler options. */
     const Options& options() const { return _options; }
 

--- a/hilti/toolchain/include/compiler/detail/cxx/elements.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/elements.h
@@ -120,6 +120,8 @@ struct Local {
     Local(const Local&) = default;
     Local& operator=(Local&&) = default;
     Local& operator=(const Local&) = default;
+    ~Local() = default;
+
     Local(cxx::ID _id = {}, cxx::Type _type = {}, std::vector<cxx::Expression> _args = {},
           std::optional<cxx::Expression> _init = {}, Linkage _linkage = {})
         : id(std::move(_id)),

--- a/hilti/toolchain/include/compiler/optimizer.h
+++ b/hilti/toolchain/include/compiler/optimizer.h
@@ -14,7 +14,11 @@ namespace hilti {
 struct Optimizer {
 public:
     Optimizer(const std::vector<std::shared_ptr<Unit>>& units) : _units(units) {}
-    ~Optimizer() {}
+    Optimizer(const Optimizer&) = default;
+    Optimizer(Optimizer&&) = default;
+    Optimizer& operator=(const Optimizer&) = delete;
+    Optimizer& operator=(Optimizer&&) = delete;
+    ~Optimizer() = default;
 
     void run();
 

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -48,6 +48,13 @@ using MetaData = detail::cxx::linker::MetaData;
  */
 class Unit {
 public:
+    Unit() = default;
+    Unit(const Unit&) = default;
+    Unit(Unit&&) = default;
+
+    Unit& operator=(const Unit&) = default;
+    Unit& operator=(Unit&&) = default;
+
     /** Destructor. */
     ~Unit();
 

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -34,6 +34,11 @@ struct GlobalsVisitor : hilti::visitor::PreOrder<void, GlobalsVisitor> {
     GlobalsVisitor(const GlobalsVisitor&) = delete;
     GlobalsVisitor(GlobalsVisitor&&) noexcept = delete;
 
+    GlobalsVisitor& operator=(const GlobalsVisitor&) = delete;
+    GlobalsVisitor& operator=(GlobalsVisitor&&) noexcept = delete;
+
+    ~GlobalsVisitor() override = default;
+
     CodeGen* cg;
     bool include_implementation;
 

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -98,6 +98,12 @@ public:
         }
     }
 
+    FileGuard() = default;
+    FileGuard(const FileGuard&) = delete;
+    FileGuard(FileGuard&&) = delete;
+    FileGuard& operator=(const FileGuard&) = delete;
+    FileGuard& operator=(FileGuard&&) = delete;
+
 private:
     std::vector<hilti::rt::filesystem::path> _paths;
 };

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -91,6 +91,12 @@ public:
     virtual void collect(Node&) {}
     virtual bool prune_uses(Node&) { return false; }
     virtual bool prune_decls(Node&) { return false; }
+
+    OptimizerVisitor() = default;
+    OptimizerVisitor(const OptimizerVisitor&) = default;
+    OptimizerVisitor(OptimizerVisitor&&) = default;
+    OptimizerVisitor& operator=(const OptimizerVisitor&) = default;
+    OptimizerVisitor& operator=(OptimizerVisitor&&) = default;
 };
 
 struct FunctionVisitor : OptimizerVisitor, visitor::PreOrder<bool, FunctionVisitor> {

--- a/hilti/toolchain/tests/main.cc
+++ b/hilti/toolchain/tests/main.cc
@@ -7,6 +7,12 @@
 
 struct RuntimeWrapper {
     ~RuntimeWrapper() { hilti::rt::done(); }
+
+    RuntimeWrapper() = default;
+    RuntimeWrapper(const RuntimeWrapper&) = delete;
+    RuntimeWrapper(RuntimeWrapper&&) = delete;
+    RuntimeWrapper& operator=(const RuntimeWrapper&) = delete;
+    RuntimeWrapper& operator=(RuntimeWrapper&&) = delete;
 };
 
 int main(int argc, char** argv) {

--- a/spicy/runtime/include/filter.h
+++ b/spicy/runtime/include/filter.h
@@ -32,6 +32,11 @@ struct OneFilter {
               hilti::rt::Resumable _resumable)
         : parse(std::move(_parse)), input(std::move(_input)), resumable(std::move(_resumable)) {}
 
+    ~OneFilter() = default;
+
+    OneFilter& operator=(const OneFilter&) = delete;
+    OneFilter& operator=(OneFilter&&) = default;
+
     Parse1Function parse;
     hilti::rt::ValueReference<hilti::rt::Stream> input;
     hilti::rt::Resumable resumable;

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -322,6 +322,11 @@ public:
     ParseError(const hilti::rt::result::Error& e) : RecoverableFailure(e.description()) {}
 
     ~ParseError() override; /* required to create vtable, see hilti::rt::Exception */
+
+    ParseError(const ParseError&) = default;
+    ParseError(ParseError&&) = default;
+    ParseError& operator=(const ParseError&) = default;
+    ParseError& operator=(ParseError&&) = default;
 };
 
 /**

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -338,12 +338,22 @@ class Backtrack : public ParseError {
 public:
     Backtrack() : ParseError("backtracking outside of &try scope") {}
     ~Backtrack() override;
+
+    Backtrack(const Backtrack&) = default;
+    Backtrack(Backtrack&&) = default;
+    Backtrack& operator=(const Backtrack&) = default;
+    Backtrack& operator=(Backtrack&&) = default;
 };
 
 class MissingData : public ParseError {
 public:
     MissingData(std::string_view location = "") : ParseError("missing data", location) {}
     ~MissingData() override; /* required to create vtable, see hilti::rt::Exception */
+
+    MissingData(const MissingData&) = default;
+    MissingData(MissingData&&) = default;
+    MissingData& operator=(const MissingData&) = default;
+    MissingData& operator=(MissingData&&) = default;
 };
 
 /**

--- a/spicy/runtime/src/tests/global-state.cc
+++ b/spicy/runtime/src/tests/global-state.cc
@@ -19,6 +19,11 @@ public:
         detail::__global_state = _prev;
     }
 
+    TestState(const TestState&) = delete;
+    TestState(TestState&&) = default;
+    TestState& operator=(const TestState&) = delete;
+    TestState& operator=(TestState&&) = default;
+
 private:
     detail::GlobalState* _prev{nullptr};
 };

--- a/spicy/runtime/src/tests/main.cc
+++ b/spicy/runtime/src/tests/main.cc
@@ -12,6 +12,12 @@ struct RuntimeWrapper {
         spicy::rt::done();
         hilti::rt::done();
     }
+
+    RuntimeWrapper() = default;
+    RuntimeWrapper(const RuntimeWrapper&) = delete;
+    RuntimeWrapper(RuntimeWrapper&&) = delete;
+    RuntimeWrapper& operator=(const RuntimeWrapper&) = delete;
+    RuntimeWrapper& operator=(RuntimeWrapper&&) = delete;
 };
 
 int main(int argc, char** argv) {

--- a/spicy/runtime/src/tests/parser.cc
+++ b/spicy/runtime/src/tests/parser.cc
@@ -119,6 +119,17 @@ struct UnitWithSinkSupport : std::enable_shared_from_this<UnitWithSinkSupport> {
         // Not implemented.
         return *this;
     }
+
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment, cert-oop54-cpp)
+    UnitWithSinkSupport& operator=(UnitWithSinkSupport&&) noexcept {
+        // Not implemented.
+        return *this;
+    }
+
+    UnitWithSinkSupport() = default;
+    UnitWithSinkSupport(const UnitWithSinkSupport&) = default;
+    UnitWithSinkSupport(UnitWithSinkSupport&&) = default;
+    ~UnitWithSinkSupport() = default;
 };
 
 Parser UnitWithSinkSupport::__parser{};

--- a/spicy/toolchain/tests/main.cc
+++ b/spicy/toolchain/tests/main.cc
@@ -12,6 +12,12 @@ struct RuntimeWrapper {
         spicy::rt::done();
         hilti::rt::done();
     }
+
+    RuntimeWrapper() = default;
+    RuntimeWrapper(const RuntimeWrapper&) = delete;
+    RuntimeWrapper(RuntimeWrapper&&) = delete;
+    RuntimeWrapper& operator=(const RuntimeWrapper&) = delete;
+    RuntimeWrapper& operator=(RuntimeWrapper&&) = delete;
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This is a follow-up to #1620 where we found that missing move constructors where potentially leaving measurable performance gains on the table. In this patch I aggressively implement [rule of 5](https://en.cppreference.com/w/cpp/language/rule_of_three). While #1620 was a clear win the results for that patches in this PR are less conclusive, and I might even see counterintuitive degraded performance by e.g., 0af525230627b8c08f75741e55978f3d19d9c298 (using a huge internal grammar, but also using gcc-9.4.0).