### PR TITLE
Remove use of `IntrusivePtr` over `const`.

### DIFF
--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -160,9 +160,11 @@ add_subdirectory(bin/spicy-dump)
 add_custom_target(spicy-build ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build
                   COMMENT "Generating spicy-build")
 add_custom_command(
-    OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build POST_BUILD COMMENT "Copying spicy-build"
+    OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/spicy-build POST_BUILD
+    COMMENT "Copying spicy-build"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/bin/spicy-build
-            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/spicy-build)
 
 ## Installation
 


### PR DESCRIPTION
It looks like using a `IntrusivePtr<const T>` interferes with default'ed move constructors and assignment operators so that the non-move versions are called. This can incur additional overhead.

This patch simply gets rid all `IntrusivePtr<const T>` in favor of `IntrusivePtr<T>` which does not seem to show this issue. It might be possible to instead adjust something e.g., `ManagedObject` so `IntrusivePtr` does not regress when holding semantically `const` values though.

For a big internal parser this shows runtime improvements up to 2%.