### PR TITLE
Avoid potentially inefficient data access in `View::extract`.

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -837,6 +837,9 @@ private:
     }
 
     void _increment(const integer::safe<uint64_t>& n) {
+        if ( n == 0 )
+            return;
+
         _offset += n;
 
         if ( _chunk && _offset < _chunk->endOffset() )
@@ -846,6 +849,9 @@ private:
     }
 
     void _decrement(const integer::safe<uint64_t>& n) {
+        if ( n == 0 )
+            return;
+
         _offset -= n;
 
         if ( _chunk && _offset > _chunk->offset() )

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -1002,6 +1002,32 @@ TEST_CASE("View") {
             Byte dst[1] = {'0'};
             CHECK_THROWS_WITH_AS(Stream().view().extract(dst, sizeof(dst)), "end of stream view", const WouldBlock&);
         }
+
+        SUBCASE("gaps") {
+            auto s = Stream();
+            SUBCASE("just gap") {
+                s.append(nullptr, 3); // Gap.
+                Byte dst[3] = {};
+                REQUIRE_EQ(sizeof(dst), s.size());
+                CHECK_THROWS_WITH_AS(s.view().extract(dst, sizeof(dst)), "data is missing", const MissingData&);
+            }
+
+            SUBCASE("begin in gap") {
+                s.append(nullptr, 2); // Gap.
+                s.append("A");
+                Byte dst[3] = {};
+                REQUIRE_EQ(sizeof(dst), s.size());
+                CHECK_THROWS_WITH_AS(s.view().extract(dst, sizeof(dst)), "data is missing", const MissingData&);
+            }
+
+            SUBCASE("end in gap") {
+                s.append("A");
+                s.append(nullptr, 2); // Gap.
+                Byte dst[3] = {};
+                REQUIRE_EQ(sizeof(dst), s.size());
+                CHECK_THROWS_WITH_AS(s.view().extract(dst, sizeof(dst)), "data is missing", const MissingData&);
+            }
+        }
     }
 
     SUBCASE("sub") {

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -1028,6 +1028,25 @@ TEST_CASE("View") {
                 CHECK_THROWS_WITH_AS(s.view().extract(dst, sizeof(dst)), "data is missing", const MissingData&);
             }
         }
+
+        SUBCASE("from expanding View") {
+            auto s = Stream();
+            auto v = s.view();
+
+            Byte dst[3] = {};
+
+            CHECK_THROWS_WITH_AS(v.extract(dst, sizeof(dst)), "end of stream view", const WouldBlock&);
+
+            s.append("A");
+            CHECK_THROWS_WITH_AS(v.extract(dst, sizeof(dst)), "end of stream view", const WouldBlock&);
+
+            s.append("B");
+            CHECK_THROWS_WITH_AS(v.extract(dst, sizeof(dst)), "end of stream view", const WouldBlock&);
+
+            s.append("C");
+            CHECK_EQ(v.extract(dst, sizeof(dst)), ""_b);
+            CHECK_EQ(vec(dst), std::vector<Byte>{'A', 'B', 'C'});
+        }
     }
 
     SUBCASE("sub") {


### PR DESCRIPTION
While we already had a fast path to extract data out of `View`s consisting of a single chunk we still would use a potentially inefficient approach when extracting from `View`s over multiple chunks.

This patch uses the same optimized handling for both cases.

Closes #1628.