### PR TITLE
Add `+=` operator for `string`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -630,9 +630,9 @@ freebsd13_task:
     path: build/spicy*.tar.gz
     type: application/gzip
 
-freebsd12_task:
+freebsd14_task:
   freebsd_instance:
-    image_family: freebsd-12-4
+    image_family: freebsd-14-0
     cpu: 8
     memory: 8GB
 

--- a/doc/autogen/types/string.rst
+++ b/doc/autogen/types/string.rst
@@ -23,6 +23,10 @@
 
     Returns the concatenation of two strings.
 
+.. spicy:operator:: string::SumAssign string t:string <sp> op:+= <sp> t:string
+
+    Appends the second string to the first.
+
 .. spicy:operator:: string::Unequal bool t:string <sp> op:!= <sp> t:string
 
     Compares two strings lexicographically.

--- a/hilti/toolchain/include/ast/operators/string.h
+++ b/hilti/toolchain/include/ast/operators/string.h
@@ -21,6 +21,8 @@ STANDARD_OPERATOR_1(string, Size, type::UnsignedInteger(64), type::String(),
                     "Returns the number of characters the string contains.");
 STANDARD_OPERATOR_2(string, Sum, type::String(), type::String(), type::String(),
                     "Returns the concatenation of two strings.");
+STANDARD_OPERATOR_2(string, SumAssign, type::String(), type::String(), type::String(),
+                    "Appends the second string to the first.");
 
 BEGIN_METHOD(string, Encode)
     const auto& signature() const {

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -727,6 +727,7 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
     // String
 
     result_t operator()(const operator_::string::Sum& n) { return binary(n, "+"); }
+    result_t operator()(const operator_::string::SumAssign& n) { return binary(n, "+="); }
     result_t operator()(const operator_::string::Size& n) { return fmt("%s.size()", op0(n)); }
     result_t operator()(const operator_::string::Equal& n) { return binary(n, "=="); }
     result_t operator()(const operator_::string::Unequal& n) { return binary(n, "!="); }

--- a/tests/hilti/types/string/operators.hlt
+++ b/tests/hilti/types/string/operators.hlt
@@ -1,0 +1,21 @@
+# @TEST-EXEC: ${HILTIC} -dj %INPUT
+
+module Foo {
+
+global x1 = "abc";
+x1 = x1 + "123";
+assert x1 == "abc123";
+
+global x2 = "abc";
+x2 += "123";
+assert x2 == "abc123";
+
+assert |"abc"| == 3;
+
+assert "abc" == "abc";
+assert !( "abc" == "123" );
+
+assert !( "abc" != "abc" );
+assert "abc" != "123";
+
+}


### PR DESCRIPTION
This allows appending to a `string` without having to allocate a new string. This might perform better most of the time.

Closes #1500.