### PR TITLE
Attempt to make copying into `Stream`s more lazy

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -118,17 +118,7 @@ public:
     bool isGap() const { return _gap_size > 0; };
     bool inRange(const Offset& offset) const { return offset >= _offset && offset < endOffset(); }
     bool isLazy() const { return ! _non_owning_data.empty(); };
-    void makeOwning(Offset begin, Offset end) {
-        if ( isGap() || ! isLazy() )
-            return;
-
-        auto a = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
-        auto b = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
-
-        assert(_data.empty());
-        _data = std::string{_non_owning_data.data() + (offset().Ref() - a), b - a};
-        _non_owning_data = "";
-    }
+    void makeOwning(Offset begin, Offset end);
 
     const Byte* data() const {
         if ( isGap() )

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -118,7 +118,18 @@ public:
     bool isGap() const { return _gap_size > 0; };
     bool inRange(const Offset& offset) const { return offset >= _offset && offset < endOffset(); }
     bool isLazy() const { return ! _non_owning_data.empty(); };
-    void makeOwning(Offset begin, Offset end);
+    void makeOwning(Offset begin, Offset end) {
+        if ( isGap() || ! isLazy() )
+            return;
+
+        begin = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
+        end = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
+
+        assert(_data.empty());
+        _data = std::string{_non_owning_data.data() + (begin.Ref() - offset().Ref()), end.Ref() - begin.Ref()};
+        _offset = begin;
+        _non_owning_data = "";
+    }
 
     const Byte* data() const {
         if ( isGap() )

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -118,12 +118,15 @@ public:
     bool isGap() const { return _gap_size > 0; };
     bool inRange(const Offset& offset) const { return offset >= _offset && offset < endOffset(); }
     bool isLazy() const { return ! _non_owning_data.empty(); };
-    void makeOwning() {
-        if ( isGap() )
+    void makeOwning(Offset begin, Offset end) {
+        if ( isGap() || ! isLazy() )
             return;
 
+        auto a = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
+        auto b = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
+
         assert(_data.empty());
-        _data = std::string{_non_owning_data.data(), _non_owning_data.size()};
+        _data = std::string{_non_owning_data.data() + (offset().Ref() - a), b - a};
         _non_owning_data = "";
     }
 

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -269,9 +269,8 @@ TEST_CASE("append") {
 
     SUBCASE("FIXME(bbannier)") {
         {
-            auto lazy = stream::detail::AppendLazy(&s);
             const char* data = "456";
-            lazy.append(data);
+            auto _ = stream::detail::AppendLazy(&s, data);
             CHECK_EQ(s, "123456"_b);
             CHECK_EQ(s.numberOfChunks(), 2);
 
@@ -289,8 +288,7 @@ TEST_CASE("append") {
 
         {
             auto data = std::string("abc");
-            auto lazy = stream::detail::AppendLazy(&s);
-            lazy.append(data);
+            auto _ = stream::detail::AppendLazy(&s, data);
             CHECK_EQ(s, "456abc"_b);
             CHECK_EQ(s.numberOfChunks(), 2);
         }

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -266,6 +266,35 @@ TEST_CASE("append") {
         CHECK_NOTHROW(s.append(data, 0));
         CHECK_THROWS_WITH_AS(s.append(data, strlen(data)), "stream object can no longer be modified", const Frozen&);
     }
+
+    SUBCASE("FIXME(bbannier)") {
+        const char* data = "456";
+        auto o = s.append_lazy(data);
+        CHECK_EQ(s, "123456"_b);
+        CHECK_EQ(s.numberOfChunks(), 2);
+
+        s.trim(s.begin() + 2);
+        CHECK_EQ(s, "3456"_b);
+        CHECK_EQ(s.numberOfChunks(), 2);
+
+        s.trim(s.begin() + 1);
+        CHECK_EQ(s, "456"_b);
+        CHECK_EQ(s.numberOfChunks(), 1);
+
+        s.commit_chunk_at(o);
+        CHECK_EQ(s, "456"_b);
+        CHECK_EQ(s.numberOfChunks(), 1);
+
+        {
+            auto data = std::string("abc");
+            auto o = s.append_lazy(data);
+            CHECK_EQ(s, "456abc"_b);
+            CHECK_EQ(s.numberOfChunks(), 2);
+            s.commit_chunk_at(o);
+        }
+        CHECK_EQ(s, "456abc"_b);
+        CHECK_EQ(s.numberOfChunks(), 2);
+    }
 }
 
 TEST_CASE("iteration") {

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -268,29 +268,31 @@ TEST_CASE("append") {
     }
 
     SUBCASE("FIXME(bbannier)") {
-        const char* data = "456";
-        auto o = s.append_lazy(data);
-        CHECK_EQ(s, "123456"_b);
-        CHECK_EQ(s.numberOfChunks(), 2);
+        {
+            auto lazy = stream::detail::AppendLazy(&s);
+            const char* data = "456";
+            lazy.append(data);
+            CHECK_EQ(s, "123456"_b);
+            CHECK_EQ(s.numberOfChunks(), 2);
 
-        s.trim(s.begin() + 2);
-        CHECK_EQ(s, "3456"_b);
-        CHECK_EQ(s.numberOfChunks(), 2);
+            s.trim(s.begin() + 2);
+            CHECK_EQ(s, "3456"_b);
+            CHECK_EQ(s.numberOfChunks(), 2);
 
-        s.trim(s.begin() + 1);
-        CHECK_EQ(s, "456"_b);
-        CHECK_EQ(s.numberOfChunks(), 1);
+            s.trim(s.begin() + 1);
+            CHECK_EQ(s, "456"_b);
+            CHECK_EQ(s.numberOfChunks(), 1);
+        }
 
-        s.commit_chunk_at(o);
         CHECK_EQ(s, "456"_b);
         CHECK_EQ(s.numberOfChunks(), 1);
 
         {
             auto data = std::string("abc");
-            auto o = s.append_lazy(data);
+            auto lazy = stream::detail::AppendLazy(&s);
+            lazy.append(data);
             CHECK_EQ(s, "456abc"_b);
             CHECK_EQ(s.numberOfChunks(), 2);
-            s.commit_chunk_at(o);
         }
         CHECK_EQ(s, "456abc"_b);
         CHECK_EQ(s.numberOfChunks(), 2);

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -410,11 +410,12 @@ void Chunk::makeOwning(Offset begin, Offset end) {
     if ( isGap() || ! isLazy() )
         return;
 
-    auto a = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
-    auto b = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
+    begin = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
+    end = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
 
     assert(_data.empty());
-    _data = std::string{_non_owning_data.data() + (offset().Ref() - a), b - a};
+    _data = std::string{_non_owning_data.data() + (begin.Ref() - offset().Ref()), end.Ref() - begin.Ref()};
+    _offset = begin;
     _non_owning_data = "";
 }
 

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -407,8 +407,9 @@ Offset Stream::append_lazy(std::string_view data) {
 }
 
 void Stream::commit_chunk_at(Offset offset) {
-    if ( auto chunk = this->_chain->findChunk(offset) )
-        chunk->makeOwning();
+    if ( auto chunk = this->_chain->findChunk(offset) ) {
+        chunk->makeOwning(_chain->offset(), _chain->endOffset());
+    }
 }
 
 std::string stream::View::dataForPrint() const {

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -406,6 +406,18 @@ Offset Stream::append_lazy(std::string_view data) {
     return o;
 }
 
+void Chunk::makeOwning(Offset begin, Offset end) {
+    if ( isGap() || ! isLazy() )
+        return;
+
+    auto a = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
+    auto b = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
+
+    assert(_data.empty());
+    _data = std::string{_non_owning_data.data() + (offset().Ref() - a), b - a};
+    _non_owning_data = "";
+}
+
 void Stream::commit_chunk_at(Offset offset) {
     if ( auto chunk = this->_chain->findChunk(offset) ) {
         chunk->makeOwning(_chain->offset(), _chain->endOffset());

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -406,19 +406,6 @@ Offset Stream::append_lazy(std::string_view data) {
     return o;
 }
 
-void Chunk::makeOwning(Offset begin, Offset end) {
-    if ( isGap() || ! isLazy() )
-        return;
-
-    begin = inRange(begin) ? std::max(begin.Ref(), offset().Ref()) : offset().Ref();
-    end = inRange(end) ? std::min(end.Ref(), endOffset().Ref()) : endOffset().Ref();
-
-    assert(_data.empty());
-    _data = std::string{_non_owning_data.data() + (begin.Ref() - offset().Ref()), end.Ref() - begin.Ref()};
-    _offset = begin;
-    _non_owning_data = "";
-}
-
 void Stream::commit_chunk_at(Offset offset) {
     if ( auto chunk = this->_chain->findChunk(offset) ) {
         chunk->makeOwning(_chain->offset(), _chain->endOffset());

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
+#include <memory>
+
 #include <hilti/rt/exception.h>
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/types/bytes.h>
@@ -392,6 +394,21 @@ void Stream::append(const char* data, size_t len) {
         _chain->append(std::make_unique<Chunk>(0, std::string{data, len}));
     else
         _chain->append(std::make_unique<Chunk>(0, len));
+}
+
+Offset Stream::append_lazy(std::string_view data) {
+    auto o = _chain->endOffset();
+    if ( data.empty() )
+        return o;
+
+    _chain->append(std::make_unique<Chunk>(0, data));
+
+    return o;
+}
+
+void Stream::commit_chunk_at(Offset offset) {
+    if ( auto chunk = this->_chain->findChunk(offset) )
+        chunk->makeOwning();
 }
 
 std::string stream::View::dataForPrint() const {

--- a/spicy/runtime/src/driver.cc
+++ b/spicy/runtime/src/driver.cc
@@ -322,13 +322,11 @@ driver::ParsingState::State driver::ParsingState::_process(size_t size, const ch
                     // Resume parsing.
                     assert(_input && _resumable);
 
-                    hilti::rt::stream::Offset offset;
+                    std::optional<hilti::rt::stream::detail::AppendLazy> lazy;
 
-                    if ( size )
-                    // (*_input)->append(data, size);
-                    {
+                    if ( size ) {
                         if ( data )
-                            offset = (*_input)->append_lazy(std::string_view{data, size});
+                            lazy = hilti::rt::stream::detail::AppendLazy(_input->get(), std::string_view{data, size});
                         else
                             (*_input)->append(data, size);
                     }
@@ -342,9 +340,6 @@ driver::ParsingState::State driver::ParsingState::_process(size_t size, const ch
 
                     hilti::rt::profiler::stop(profiler);
                     _resumable->resume();
-
-                    if ( data && size )
-                        (*_input)->commit_chunk_at(offset);
                 }
 
                 if ( *_resumable ) {

--- a/spicy/runtime/src/driver.cc
+++ b/spicy/runtime/src/driver.cc
@@ -322,8 +322,16 @@ driver::ParsingState::State driver::ParsingState::_process(size_t size, const ch
                     // Resume parsing.
                     assert(_input && _resumable);
 
+                    hilti::rt::stream::Offset offset;
+
                     if ( size )
-                        (*_input)->append(data, size);
+                    // (*_input)->append(data, size);
+                    {
+                        if ( data )
+                            offset = (*_input)->append_lazy(std::string_view{data, size});
+                        else
+                            (*_input)->append(data, size);
+                    }
 
                     if ( eod ) {
                         DRIVER_DEBUG("end of data");
@@ -334,6 +342,9 @@ driver::ParsingState::State driver::ParsingState::_process(size_t size, const ch
 
                     hilti::rt::profiler::stop(profiler);
                     _resumable->resume();
+
+                    if ( data && size )
+                        (*_input)->commit_chunk_at(offset);
                 }
 
                 if ( *_resumable ) {


### PR DESCRIPTION
Spicy-generated parser operate on `Stream`s, so in order to parse anything we always need to append input data to the `Stream` a parser operates on. `Stream`s consist of `Chunk`s which own their data, so this always involves a deep copy of the data.

This PR attempts to make this more lazy to explore whether we can get rid of associated overhead. For that I introduced a `Chunk` behavior where it does not own the data; to make this safe (e.g., since the input data might at some point disappear) users of this API need to explicitly make such `Chunk`s owning before their data goes out of scope. For now I encapsulated this in a RAII class which performs this operation when it goes out of scope.

Benchmarking this with a large internal parser the changes here actually make performance _worse_ (by about (3.5±1.2)%), so I am opening this more for reference. The added overhead seems to be due to many `Chunk` methods now having to also check whether a `Chunk` is not owning (previously: only check for gap chunk or not); it probably is worthwhile checking whether e.g., introducing dedicated `Chunk` classes for owning, non-owning, and gaps perform any better.