### PR TITLE
Fix type of generated code for `string::size`.

### DIFF
--- a/hilti/runtime/include/types/string.h
+++ b/hilti/runtime/include/types/string.h
@@ -6,6 +6,7 @@
 #include <string_view>
 
 #include <hilti/rt/extension-points.h>
+#include <hilti/rt/safe-int.h>
 #include <hilti/rt/util.h>
 
 namespace hilti::rt {
@@ -27,7 +28,7 @@ HILTI_RT_ENUM_WITH_DEFAULT(DecodeErrorStrategy, IGNORE,
  * @return the length of the input string
  * @throws RuntimeError if the input is not a valid UTF8 string
  */
-size_t size(const std::string& s, DecodeErrorStrategy errors = DecodeErrorStrategy::REPLACE);
+integer::safe<uint64_t> size(const std::string& s, DecodeErrorStrategy errors = DecodeErrorStrategy::REPLACE);
 
 /**
  * Computes a lower-case version of an UTF8 string.

--- a/hilti/runtime/src/types/string.cc
+++ b/hilti/runtime/src/types/string.cc
@@ -7,11 +7,11 @@
 
 using namespace hilti::rt;
 
-size_t string::size(const std::string& s, DecodeErrorStrategy errors) {
+integer::safe<uint64_t> string::size(const std::string& s, DecodeErrorStrategy errors) {
     auto p = reinterpret_cast<const unsigned char*>(s.data());
     auto e = p + s.size();
 
-    size_t len = 0;
+    uint64_t len = 0;
 
     while ( p < e ) {
         utf8proc_int32_t cp;

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -728,7 +728,7 @@ struct Visitor : hilti::visitor::PreOrder<cxx::Expression, Visitor> {
 
     result_t operator()(const operator_::string::Sum& n) { return binary(n, "+"); }
     result_t operator()(const operator_::string::SumAssign& n) { return binary(n, "+="); }
-    result_t operator()(const operator_::string::Size& n) { return fmt("%s.size()", op0(n)); }
+    result_t operator()(const operator_::string::Size& n) { return fmt("::hilti::rt::string::size(%s)", op0(n)); }
     result_t operator()(const operator_::string::Equal& n) { return binary(n, "=="); }
     result_t operator()(const operator_::string::Unequal& n) { return binary(n, "!="); }
 

--- a/tests/hilti/types/string/operators.hlt
+++ b/tests/hilti/types/string/operators.hlt
@@ -2,6 +2,8 @@
 
 module Foo {
 
+import hilti;
+
 global x1 = "abc";
 x1 = x1 + "123";
 assert x1 == "abc123";
@@ -17,5 +19,9 @@ assert !( "abc" == "123" );
 
 assert !( "abc" != "abc" );
 assert "abc" != "123";
+
+assert |"𝔘𝔫𝔦𝔠𝔬𝔡𝔢"| == 7; # 7 codepoints but 28 bytes long.
+assert |"abc"| == 3;
+hilti::print(|"abc"|); # Validates that size operator returns a valid, printable runtime type.
 
 }


### PR DESCRIPTION
While we defined `string`'s size operator to return an `uint64` and documented that it returns the length in codepoints, not bytes, we still generated C++ code which worked on the underlying bytes (i.e., it directly invoked `std::string::size` instead of using `hilti::rt::string::size`).