### PR TITLE
Drop overzealous validator.

### DIFF
--- a/spicy/toolchain/src/compiler/visitors/validator.cc
+++ b/spicy/toolchain/src/compiler/visitors/validator.cc
@@ -1,6 +1,5 @@
 // Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
-#include <algorithm>
 #include <utility>
 
 #include <spicy/rt/mime.h>
@@ -697,9 +696,8 @@ struct VisitorPost : public hilti::visitor::PreOrder<void, VisitorPost>, public 
     }
 
     void operator()(const spicy::type::unit::item::Field& f, position_t p) {
-        auto count_attr = AttributeSet::find(f.attributes(), "&count");
-        auto repeat = f.repeatCount();
-        auto is_sub_item = p.parent().isA<spicy::type::unit::item::Field>();
+        const auto count_attr = AttributeSet::find(f.attributes(), "&count");
+        const auto repeat = f.repeatCount();
 
         if ( f.isSkip() ) {
             if ( ! f.sinks().empty() )
@@ -721,11 +719,6 @@ struct VisitorPost : public hilti::visitor::PreOrder<void, VisitorPost>, public 
         else {
             if ( f.originalType().isA<type::RegExp>() ) {
                 error("need regexp constant for parsing a field", p);
-                return;
-            }
-
-            if ( f.originalType().isA<type::Vector>() && is_sub_item ) {
-                error("use [] syntax to parse vectors", p);
                 return;
             }
 


### PR DESCRIPTION
This validator was intended to reject incorrect parsing of vectors but instead ending up rejecting all vector parsing if the vector elements itself produced vectors. Since this code has no test and it seems to have no clear purpose this patch drops this validation.

Closes #1522.