### PR TITLE
Fix stray Python escape sequence.

### DIFF
--- a/scripts/autogen-type-erased
+++ b/scripts/autogen-type-erased
@@ -134,7 +134,7 @@ def parseMethod(s):
 
     m = Method()
 
-    i = re.search("(.*) *with *default *(\{.*)$", s)
+    i = re.search("(.*) *with *default *({.*)$", s)
 
     if i:
         s = i.group(1)


### PR DESCRIPTION
At least on my platform with python-3.12.2 the previous code produced a warning

    ../scripts/autogen-type-erased:137: SyntaxWarning: invalid escape sequence '\{'
      i = re.search("(.*) *with *default *(\{.*)$", s)