### PR TITLE
Simplify `while` loops over constant conditions.

### DIFF
--- a/tests/Baseline/hilti.optimization.const/noopt.hlt
+++ b/tests/Baseline/hilti.optimization.const/noopt.hlt
@@ -47,4 +47,28 @@ True;
 t ? 1 : 0;
 f ? 0 : 1;
 
+while ( False ) {
+}
+
+
+while ( False ) {
+    False;
+}
+else {
+    True;
+}
+
+
+while ( True ) {
+}
+
+
+while ( True ) {
+    True;
+}
+else {
+    False;
+}
+
+
 }

--- a/tests/Baseline/hilti.optimization.const/opt.hlt
+++ b/tests/Baseline/hilti.optimization.const/opt.hlt
@@ -29,5 +29,17 @@ False;
 True;
 1;
 1;
+{
+    True;
+}
+
+while ( True ) {
+}
+
+
+while ( True ) {
+    True;
+}
+
 
 }

--- a/tests/hilti/optimization/const.hlt
+++ b/tests/hilti/optimization/const.hlt
@@ -52,4 +52,21 @@ f && f;
 t ? 1: 0;
 f ? 0: 1;
 
+# While loops over constants.
+while (False) {}
+
+while (False) {
+    False;
+} else {
+    True;
+}
+
+while (True) {}
+
+while (True) {
+    True;
+} else {
+    False;
+}
+
 }


### PR DESCRIPTION
While loops with constant conditions are unlikely to occur in code generated by us, but could appear in user code. Cleaning them up is simple and cheap, so this patch implements a pass which simplifies them.