### PR TITLE
`context()` constness fix

### DIFF
--- a/spicy/toolchain/include/ast/types/unit.h
+++ b/spicy/toolchain/include/ast/types/unit.h
@@ -33,8 +33,8 @@ public:
         return child<hilti::declaration::Expression>(0);
     }
 
-    /** Returns the type set through ``%context`, if available. */
-    UnqualifiedTypePtr contextType() const;
+    /** Returns the type set through ``%context`, if available and resolved already. */
+    UnqualifiedTypePtr contextType() const { return child<UnqualifiedType>(2); }
 
     /**
      * Returns the item of a given name if it exists. This descends
@@ -100,6 +100,7 @@ public:
     }
 
     void setAttributes(ASTContext* ctx, const AttributeSetPtr& attrs) { setChild(ctx, 1, attrs); }
+    void setContextType(ASTContext* ctx, const UnqualifiedTypePtr& type) { setChild(ctx, 2, type); }
     void setGrammar(std::shared_ptr<spicy::detail::codegen::Grammar> g) { _grammar = std::move(g); }
     void setPublic(bool p) { _public = p; }
 
@@ -125,15 +126,16 @@ public:
         for ( auto&& p : params )
             p->setIsTypeParameter();
 
-        auto t = std::shared_ptr<Unit>(new Unit(ctx, node::flatten(nullptr, attrs, params, std::move(items)), meta));
+        auto t = std::shared_ptr<Unit>(
+            new Unit(ctx, node::flatten(nullptr, attrs, nullptr, params, std::move(items)), meta));
+
         t->_setSelf(ctx);
         return t;
     }
 
     static auto create(ASTContext* ctx, hilti::type::Wildcard _, const Meta& meta = {}) {
-        auto t =
-            std::shared_ptr<Unit>(new Unit(ctx, hilti::type::Wildcard(), {nullptr, AttributeSet::create(ctx)}, meta));
-        return t;
+        return std::shared_ptr<Unit>(
+            new Unit(ctx, hilti::type::Wildcard(), {nullptr, AttributeSet::create(ctx), nullptr}, meta));
     }
 
 protected:

--- a/spicy/toolchain/src/ast/operators/unit.cc
+++ b/spicy/toolchain/src/ast/operators/unit.cc
@@ -72,16 +72,16 @@ QualifiedTypePtr itemType(hilti::Builder* builder, const Expressions& operands) 
         return builder->qualifiedType(builder->typeAuto(), hilti::Constness::Const);
 }
 
-QualifiedTypePtr contextResult(hilti::Builder* builder, const Expressions& operands) {
+QualifiedTypePtr contextResult(hilti::Builder* builder, const Expressions& operands, hilti::Constness constness) {
     if ( operands.empty() )
-        return builder->qualifiedType(builder->typeDocOnly("<context>&"), hilti::Constness::Const);
+        return builder->qualifiedType(builder->typeDocOnly("<context>&"), constness);
 
     if ( const auto& ctype = operands[0]->type()->type()->as<type::Unit>()->contextType() )
         return builder->qualifiedType(builder->typeStrongReference(
                                           builder->qualifiedType(ctype, hilti::Constness::Mutable)),
-                                      hilti::Constness::Const);
+                                      constness);
 
-    return builder->qualifiedType(builder->typeVoid(), hilti::Constness::Const);
+    return builder->qualifiedType(builder->typeVoid(), constness);
 }
 
 
@@ -473,7 +473,7 @@ Returns a reference to the ``%context`` instance associated with the unit.
     }
 
     QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return contextResult(builder, operands);
+        return contextResult(builder, operands, hilti::Constness::Const);
     }
 
     HILTI_OPERATOR(spicy, unit::ContextConst);
@@ -497,7 +497,7 @@ Returns a reference to the ``%context`` instance associated with the unit.
     }
 
     QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return contextResult(builder, operands);
+        return contextResult(builder, operands, hilti::Constness::Mutable);
     }
 
     HILTI_OPERATOR(spicy, unit::ContextNonConst);

--- a/spicy/toolchain/src/ast/types/unit.cc
+++ b/spicy/toolchain/src/ast/types/unit.cc
@@ -33,14 +33,6 @@ static NodePtr itemByNameBackend(const std::shared_ptr<spicy::type::unit::Item>&
     return {};
 }
 
-UnqualifiedTypePtr Unit::contextType() const {
-    if ( auto context = propertyItem("%context") )
-        if ( auto ty = context->expression()->type()->type()->tryAs<hilti::type::Type_>() )
-            return ty->typeValue()->type();
-
-    return {};
-}
-
 unit::item::PropertyPtr Unit::propertyItem(const std::string& name) const {
     for ( const auto& i : items<unit::item::Property>() ) {
         if ( i->id() == name )
@@ -70,6 +62,9 @@ bool Unit::isResolved(node::CycleDetector* cd) const {
         return false;
 
     for ( const auto& c : children() ) {
+        if ( ! c )
+            continue;
+
         if ( auto i = c->template tryAs<unit::Item>(); i && ! i->isResolved(cd) )
             return false;
 

--- a/spicy/toolchain/src/compiler/resolver.cc
+++ b/spicy/toolchain/src/compiler/resolver.cc
@@ -451,8 +451,16 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     void operator()(type::Unit* n) final {
-        if ( ! n->typeID() )
-            return;
+        if ( ! n->contextType() ) {
+            if ( auto ctx = n->propertyItem("%context") ) {
+                if ( auto expr = ctx->expression(); expr && expr->isResolved() ) {
+                    if ( auto ty = expr->type()->type()->tryAs<hilti::type::Type_>() ) {
+                        recordChange(n, "set unit's context type");
+                        n->setContextType(context(), ty->typeValue()->type());
+                    }
+                }
+            }
+        }
 
         if ( n->inheritScope() ) {
             recordChange(n, "set no-inherit");

--- a/tests/spicy/types/unit/context-unit-func-param.spicy
+++ b/tests/spicy/types/unit/context-unit-func-param.spicy
@@ -1,0 +1,18 @@
+# @TEST-EXEC: spicyc -p %INPUT
+#
+# @TEST-DOC: Regression test for https://github.com/corelight/zeek-spicy-openvpn/issues/11; we used to have a constness bug here
+
+module zeek_spicy_openvpn;
+
+type Context = tuple<initialized: bool>;
+
+public type OpenVPNRecords = unit {
+	%context = Context;
+};
+
+function initialize_connection(inout ctx: zeek_spicy_openvpn::Context) {
+}
+
+on zeek_spicy_openvpn::OpenVPNRecords::%init {
+    initialize_connection(self.context());
+}


### PR DESCRIPTION
- **Infer constness of `<unit>.context()` from that of `<unit>`.**
- **Move inferring of a unit's context type into the resolver.**
