### PR TITLE
Pass over Python scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     stages: ["commit"]
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.16.23
+  rev: v1.19.0
   hooks:
   - id: typos
     exclude: 'tests/.*/regexp/.*'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     stages: ["commit"]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v17.0.6'
+  rev: 'v18.1.1'
   hooks:
   - id: clang-format
     types_or: ["c", "c++"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,5 +97,6 @@ repos:
   hooks:
   - id: ruff
     args: [ --fix ]
+  - id: ruff-format
 
 exclude: 3rdparty/|doc/(autogen|.*examples)/|/Baseline/|(\.svg$)|(\.dat$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,4 +91,11 @@ repos:
   - id: typos
     exclude: 'tests/.*/regexp/.*'
 
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.3.2
+  hooks:
+  - id: ruff
+    args: [ --fix ]
+
 exclude: 3rdparty/|doc/(autogen|.*examples)/|/Baseline/|(\.svg$)|(\.dat$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,4 +99,10 @@ repos:
     args: [ --fix ]
   - id: ruff-format
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.10.1
+  hooks:
+  - id: pyupgrade
+    args: ["--py37-plus"]
+
 exclude: 3rdparty/|doc/(autogen|.*examples)/|/Baseline/|(\.svg$)|(\.dat$)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,56 +18,74 @@ import os
 import sys
 import subprocess
 
-sys.path.insert(0, os.path.abspath('scripts'))
+sys.path.insert(0, os.path.abspath("scripts"))
 
 # -- Project information -----------------------------------------------------
 
-project = u'Spicy'
-copyright = u'2023 by the Zeek Project'
-author = u'Zeek Project'
+project = "Spicy"
+copyright = "2023 by the Zeek Project"
+author = "Zeek Project"
 
-version = open('../VERSION').readline()
+version = open("../VERSION").readline()
 release = "1.9.0"  # most recent release version
 
 # -- General configuration ---------------------------------------------------
 
-needs_sphinx = '1.8'
+needs_sphinx = "1.8"
 
-extensions = [
-    'sphinx.ext.todo',
-    'sphinx.ext.extlinks',
-    'spicy',
-    'spicy-pygments'
+extensions = ["sphinx.ext.todo", "sphinx.ext.extlinks", "spicy", "spicy-pygments"]
+
+exclude_patterns = [
+    "_build",
+    "autogen",
+    "Thumbs.db",
+    ".DS_Store",
+    "3rdparty/*",
+    "_old-content",
 ]
 
-exclude_patterns = [u'_build', 'autogen', 'Thumbs.db',
-                    '.DS_Store', '3rdparty/*', "_old-content"]
+templates_path = ["_templates"]
 
-templates_path = ['_templates']
-
-source_suffix = '.rst'
-master_doc = 'index'
-pygments_style = 'sphinx'
-highlight_language = 'none'
+source_suffix = ".rst"
+master_doc = "index"
+pygments_style = "sphinx"
+highlight_language = "none"
 
 # Todo extension
 todo_include_todos = True
 
 # Extlinks extension
 extlinks = {
-    "repo":  ("https://github.com/zeek/spicy/blob/v%s/%%s" % release, "#%s"),
+    "repo": ("https://github.com/zeek/spicy/blob/v%s/%%s" % release, "#%s"),
     "issue": ("https://github.com/zeek/spicy/issues/%s", "#%s"),
-    "pr":    ("https://github.com/zeek/spicy/pulls/%s", "#%s"),
-
-    "zeek":  ("https://docs.zeek.org/en/master/%s", "%s"),
-
+    "pr": ("https://github.com/zeek/spicy/pulls/%s", "#%s"),
+    "zeek": ("https://docs.zeek.org/en/master/%s", "%s"),
     # Links to binary builds.
-    "package-dev-tgz": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/build/spicy-dev.tar.gz", "%s"),
-    "package-dev-rpm": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.rpm", "%s"),
-    "package-dev-deb": ("https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.deb", "%s"),
-    "package-release-tgz": ("https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.tar.gz" % release, "%s"),
-    "package-release-rpm": ("https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.rpm" % release, "%s"),
-    "package-release-deb": ("https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.deb" % release, "%s"),
+    "package-dev-tgz": (
+        "https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/build/spicy-dev.tar.gz",
+        "%s",
+    ),
+    "package-dev-rpm": (
+        "https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.rpm",
+        "%s",
+    ),
+    "package-dev-deb": (
+        "https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/%s/packages/spicy-dev.deb",
+        "%s",
+    ),
+    "package-release-tgz": (
+        "https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.tar.gz"
+        % release,
+        "%s",
+    ),
+    "package-release-rpm": (
+        "https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.rpm" % release,
+        "%s",
+    ),
+    "package-release-deb": (
+        "https://github.com/zeek/spicy/releases/download/v%s/spicy_%%s.deb" % release,
+        "%s",
+    ),
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -76,22 +94,20 @@ html_theme = "sphinx_rtd_theme"
 html_logo = "_static/spicy-logo.png"
 html_favicon = "_static/spicy-favicon.ico"
 html_title = "Spicy v" + version
-html_static_path = ['_static', 'doxygen-output']
+html_static_path = ["_static", "doxygen-output"]
 
-html_theme_options = {
-    "style_external_links": True
-}
+html_theme_options = {"style_external_links": True}
 
 linkcheck_ignore = [
-    r'https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/.*',
-    r'http://download.zeek.org',
-    r'https://download.zeek.org',
+    r"https://api.cirrus-ci.com/v1/artifact/github/zeek/spicy/.*",
+    r"http://download.zeek.org",
+    r"https://download.zeek.org",
     # Certificate potentially cannot be validated.
-    r'https://www.icir.org/hilti',
+    r"https://www.icir.org/hilti",
 ]
 
-read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
 if read_the_docs_build:
     # Generate Doxygen output if we are building in readthedocs. Outside of
     # readthedocs this is done by `docs/Makefile`.
-    subprocess.run(['doxygen'], shell=True)
+    subprocess.run(["doxygen"], shell=True)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 #
 # Configuration file for the Sphinx documentation builder.

--- a/doc/scripts/spicy-doc-to-rst
+++ b/doc/scripts/spicy-doc-to-rst
@@ -24,23 +24,21 @@ def fatalError(message: str):
 
 def call(name):
     def _(op):
-        return "{}({})".format(name, op.operands[0].rst(in_operator=True, markup=False))
+        return f"{name}({op.operands[0].rst(in_operator=True, markup=False)})"
 
     return _
 
 
 def keyword(name):
     def _(op):
-        return "{} <sp> {}".format(name, op.operands[0].rst(in_operator=True))
+        return f"{name} <sp> {op.operands[0].rst(in_operator=True)}"
 
     return _
 
 
 def unary(prefix, postfix=""):
     def _(op):
-        return "op:{} {} op:{}".format(
-            prefix, op.operands[0].rst(in_operator=True), postfix
-        )
+        return f"op:{prefix} {op.operands[0].rst(in_operator=True)} op:{postfix}"
 
     return _
 
@@ -54,7 +52,7 @@ def binary(token):
         if op.commutative and op1 != op2:
             commutative = " $commutative$"
 
-        return "{} <sp> op:{} <sp> {}{}".format(op1, token, op2, commutative)
+        return f"{op1} <sp> op:{token} <sp> {op2}{commutative}"
 
     return _
 
@@ -156,7 +154,7 @@ def namespace(ns):
 
 
 def rstHeading(title, level):
-    return "{}\n{}\n".format(title, "==-~"[level] * len(title))
+    return f"{title}\n{"==-~"[level] * len(title)}\n"
 
 
 def fmtDoc(doc):
@@ -207,18 +205,16 @@ class Operand:
             type = fmtType(self.type)
 
         if not in_operator:
-            default = " = {}".format(self.default) if self.default else ""
-            x = "{id}: {type}{default}".format(
-                id=self.id, type=type, default=default
-            ).strip()
+            default = f" = {self.default}" if self.default else ""
+            x = f"{self.id}: {type}{default}".strip()
         else:
             if markup:
-                x = "t:{type}".format(type=type)
+                x = f"t:{type}"
             else:
-                x = "{type}".format(type=type)
+                x = f"{type}"
 
-        x = "{}{}".format(prefix, x)
-        return "[ {} ]".format(x) if self.optional else x
+        x = f"{prefix}{x}"
+        return f"[ {x} ]" if self.optional else x
 
 
 class Operator:
@@ -236,9 +232,7 @@ class Operator:
             sig = Operators[self.kind](self)
         except KeyError:
             print(
-                "error: " "operator {} not supported by spicy-doc-to-rst yet".format(
-                    self.kind
-                ),
+                "error: " f"operator {self.kind} not supported by spicy-doc-to-rst yet",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -331,7 +325,7 @@ if not args.dir and not args.types:
 try:
     meta = json.load(sys.stdin)
 except ValueError as e:
-    fatalError("cannot parse input: {}".format(e))
+    fatalError(f"cannot parse input: {e}")
 
 operators: Dict[str, List[Operator]] = {}
 methods: Dict[str, List[Method]] = {}
@@ -408,7 +402,7 @@ for ns in sorted(keys):
 
     x1 = sorted(methods.get(ns, []))
     if x1:
-        print(".. rubric:: %sMethods\n" % prefix, file=out)
+        print(f".. rubric:: {prefix}Methods\n", file=out)
 
         for method in sorted(x1):
             print_unique(method.rst())
@@ -416,7 +410,7 @@ for ns in sorted(keys):
     x2 = sorted(operators.get(ns, []))
 
     if x2:
-        print(".. rubric:: %sOperators\n" % prefix, file=out)
+        print(f".. rubric:: {prefix}Operators\n", file=out)
 
         for operator in sorted(x2):
             print_unique(operator.rst())

--- a/doc/scripts/spicy-doc-to-rst
+++ b/doc/scripts/spicy-doc-to-rst
@@ -24,24 +24,24 @@ def fatalError(message: str):
 
 def call(name):
     def _(op):
-        return "{}({})".format(
-            name,
-            op.operands[0].rst(in_operator=True, markup=False))
+        return "{}({})".format(name, op.operands[0].rst(in_operator=True, markup=False))
+
     return _
 
 
 def keyword(name):
     def _(op):
         return "{} <sp> {}".format(name, op.operands[0].rst(in_operator=True))
+
     return _
 
 
 def unary(prefix, postfix=""):
     def _(op):
         return "op:{} {} op:{}".format(
-            prefix,
-            op.operands[0].rst(in_operator=True),
-            postfix)
+            prefix, op.operands[0].rst(in_operator=True), postfix
+        )
+
     return _
 
 
@@ -62,7 +62,7 @@ def binary(token):
 Operators = {
     "Add": lambda op: "add <sp> {}[{}]".format(
         op.operands[0].rst(in_operator=True),
-        op.operands[1].rst(in_operator=True, markup=False)
+        op.operands[1].rst(in_operator=True, markup=False),
     ),
     "Begin": call("begin"),
     "BitAnd": binary("&"),
@@ -70,22 +70,19 @@ Operators = {
     "BitXor": binary("^"),
     "End": call("end"),
     "Call": lambda op: "{}({})".format(
-        op.operands[0].rst(in_operator=True,
-                           markup=False),
-        ", ".join(arg.rst(in_operator=True, markup=False)
-                  for arg in op.operands[1:])),
-    "Cast": lambda op: "cast<{}>({})".format(
-        TypedType.sub("\\1", op.operands[1].rst(
-            in_operator=True, markup=False)),
-        op.operands[0].rst(in_operator=True, markup=False)),
-    "CustomAssign": lambda op: "{} = {}".format(
-        op.operands[0].rst(in_operator=True),
-        op.operands[1].rst(in_operator=True)
+        op.operands[0].rst(in_operator=True, markup=False),
+        ", ".join(arg.rst(in_operator=True, markup=False) for arg in op.operands[1:]),
     ),
-
+    "Cast": lambda op: "cast<{}>({})".format(
+        TypedType.sub("\\1", op.operands[1].rst(in_operator=True, markup=False)),
+        op.operands[0].rst(in_operator=True, markup=False),
+    ),
+    "CustomAssign": lambda op: "{} = {}".format(
+        op.operands[0].rst(in_operator=True), op.operands[1].rst(in_operator=True)
+    ),
     "Delete": lambda op: "delete <sp> {}[{}]".format(
         op.operands[0].rst(in_operator=True),
-        op.operands[1].rst(in_operator=True, markup=False)
+        op.operands[1].rst(in_operator=True, markup=False),
     ),
     "Deref": unary("*"),
     "DecrPostfix": unary("", "--"),
@@ -105,11 +102,13 @@ Operators = {
     "Member": binary("."),
     "Index": lambda op: "{}[{}]".format(
         op.operands[0].rst(in_operator=True),
-        op.operands[1].rst(in_operator=True, markup=False)),
+        op.operands[1].rst(in_operator=True, markup=False),
+    ),
     "IndexAssign": lambda op: "{}[{}] = {}".format(
         op.operands[0].rst(in_operator=True),
         op.operands[1].rst(in_operator=True, markup=False),
-        op.operands[2].rst(in_operator=True, markup=False)),
+        op.operands[2].rst(in_operator=True, markup=False),
+    ),
     "IncrPostfix": unary("", "++"),
     "IncrPrefix": unary("++"),
     "LogicalAnd": binary("&&"),
@@ -126,7 +125,7 @@ Operators = {
     "Unpack": keyword("unpack"),
     "Unset": lambda op: "unset <sp> {}.{}".format(
         op.operands[0].rst(in_operator=True),
-        op.operands[1].rst(in_operator=True, markup=False)
+        op.operands[1].rst(in_operator=True, markup=False),
     ),
     "SignNeg": unary("-"),
     "Size": unary("|", "|"),
@@ -140,7 +139,7 @@ Operators = {
 NamespaceMappings = {
     "signed_integer": "integer",
     "unsigned_integer": "integer",
-    "struct_": "struct"
+    "struct_": "struct",
 }
 
 TypeMappings = {
@@ -149,7 +148,7 @@ TypeMappings = {
 }
 
 LibraryType = re.compile(r'__library_type\("(.*)"\)')
-TypedType: Pattern = re.compile(r'type<(.*)>')
+TypedType: Pattern = re.compile(r"type<(.*)>")
 
 
 def namespace(ns):
@@ -210,7 +209,8 @@ class Operand:
         if not in_operator:
             default = " = {}".format(self.default) if self.default else ""
             x = "{id}: {type}{default}".format(
-                id=self.id, type=type, default=default).strip()
+                id=self.id, type=type, default=default
+            ).strip()
         else:
             if markup:
                 x = "t:{type}".format(type=type)
@@ -236,19 +236,21 @@ class Operator:
             sig = Operators[self.kind](self)
         except KeyError:
             print(
-                "error: "
-                "operator {} not supported by spicy-doc-to-rst yet".format(
-                    self.kind), file=sys.stderr)
+                "error: " "operator {} not supported by spicy-doc-to-rst yet".format(
+                    self.kind
+                ),
+                file=sys.stderr,
+            )
             sys.exit(1)
 
         result = fmtType(self.rtype)
-        return ".. spicy:operator:: "\
-            "{ns}::{kind} {result} {sig}\n\n{doc}".format(
-                ns=self.namespace,
-                kind=self.kind,
-                result=result,
-                sig=sig,
-                doc=fmtDoc(self.doc))
+        return ".. spicy:operator:: " "{ns}::{kind} {result} {sig}\n\n{doc}".format(
+            ns=self.namespace,
+            kind=self.kind,
+            result=result,
+            sig=sig,
+            doc=fmtDoc(self.doc),
+        )
 
     def __lt__(self, other):
         # Sort by string representation to make sure
@@ -279,7 +281,8 @@ class Method:
         const = self.self.const == "const"
         self_ = fmtType(self.self.type)
         result = fmtType(self.rtype)
-        sig = ".. spicy:method:: "\
+        sig = (
+            ".. spicy:method:: "
             "{ns}::{id} {self} {id} {const} {result} ({args})\n\n{doc}".format(
                 ns=self.namespace,
                 result=result,
@@ -287,7 +290,9 @@ class Method:
                 const=const,
                 id=self.id,
                 args=args,
-                doc=fmtDoc(self.doc))
+                doc=fmtDoc(self.doc),
+            )
+        )
         return sig
 
     def __lt__(self, other):
@@ -295,16 +300,28 @@ class Method:
         # the rendered output has a fixed order.
         return self.rst() < other.rst()
 
+
 # Main
 
 
 parser = argparse.ArgumentParser(
-    description="Converts the output of spicy-doc on stdin into reST")
-parser.add_argument("-d", action="store", dest="dir", metavar="DIR",
-                    help="create output for all types in given directory")
-parser.add_argument("-t", action="store", dest="types", metavar="TYPES",
-                    help="create output for specified, comma-separated types;"
-                    "without -d, output goes to stdout")
+    description="Converts the output of spicy-doc on stdin into reST"
+)
+parser.add_argument(
+    "-d",
+    action="store",
+    dest="dir",
+    metavar="DIR",
+    help="create output for all types in given directory",
+)
+parser.add_argument(
+    "-t",
+    action="store",
+    dest="types",
+    metavar="TYPES",
+    help="create output for specified, comma-separated types;"
+    "without -d, output goes to stdout",
+)
 args = parser.parse_args()
 
 if not args.dir and not args.types:
@@ -330,9 +347,9 @@ for op in meta:
         x2 += [m2]
 
         # If we have a `in` operator automatically generate docs for `!in`.
-        if m2.kind == 'In':
+        if m2.kind == "In":
             m3 = copy.copy(m2)
-            m3.kind = 'InInv'
+            m3.kind = "InInv"
             m3.doc = "Performs the inverse of the corresponding ``in`` operation."
             x2 = operators.setdefault(m3.namespace, [])
             x2 += [m3]

--- a/doc/scripts/spicy-pygments.py
+++ b/doc/scripts/spicy-pygments.py
@@ -1,16 +1,25 @@
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
 from pygments.lexer import RegexLexer, include, words, bygroups
-from pygments.token import Comment, Keyword, Name, Number, Operator, Punctuation, String, Text
+from pygments.token import (
+    Comment,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Text,
+)
 from sphinx.highlighting import lexers
 
 
 def setup(app):
-    lexers['spicy'] = SpicyLexer()
-    lexers['spicy-evt'] = SpicyEvtLexer()
+    lexers["spicy"] = SpicyLexer()
+    lexers["spicy-evt"] = SpicyEvtLexer()
     return {
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }
 
 
@@ -18,186 +27,279 @@ class SpicyLexer(RegexLexer):
     """
     For `Spicy <https://github.com/zeek/spicy>`_ grammars.
     """
-    name = 'Spicy'
-    aliases = ['spicy']
-    filenames = ['*.spicy']
 
-    _hex = r'[0-9a-fA-F]'
-    _float = r'((\d*\.?\d+)|(\d+\.?\d*))([eE][-+]?\d+)?'
-    _h = r'[A-Za-z0-9][-A-Za-z0-9]*'
-    _id = r'[a-zA-Z_][a-zA-Z_0-9]*'
+    name = "Spicy"
+    aliases = ["spicy"]
+    filenames = ["*.spicy"]
+
+    _hex = r"[0-9a-fA-F]"
+    _float = r"((\d*\.?\d+)|(\d+\.?\d*))([eE][-+]?\d+)?"
+    _h = r"[A-Za-z0-9][-A-Za-z0-9]*"
+    _id = r"[a-zA-Z_][a-zA-Z_0-9]*"
 
     tokens = {
-        'root': [
-            include('whitespace'),
-            include('comments'),
-            include('directives'),
-            include('attributes'),
-            include('hooks'),
-            include('properties'),
-            include('types'),
-            include('modules'),
-            include('keywords'),
-            include('literals'),
-            include('operators'),
-            include('punctuation'),
-            include('function-call'),
-            include('identifiers'),
+        "root": [
+            include("whitespace"),
+            include("comments"),
+            include("directives"),
+            include("attributes"),
+            include("hooks"),
+            include("properties"),
+            include("types"),
+            include("modules"),
+            include("keywords"),
+            include("literals"),
+            include("operators"),
+            include("punctuation"),
+            include("function-call"),
+            include("identifiers"),
         ],
-
-        'whitespace': [
-            (r'\n', Text),
-            (r'\s+', Text),
-            (r'\\\n', Text),
+        "whitespace": [
+            (r"\n", Text),
+            (r"\s+", Text),
+            (r"\\\n", Text),
         ],
-
-        'comments': [
-            (r'#.*$', Comment),
+        "comments": [
+            (r"#.*$", Comment),
         ],
-
-        'directives': [(r'(@(if|else|endif))\b', Comment.Preproc)],
-
-        'attributes': [
-            (words(('bit-order', 'byte-order', 'chunked', 'convert', 'count',
-                    'cxxname', 'default', 'eod', 'internal', 'ipv4', 'ipv6',
-                    'length', 'max-size', 'no-emit', 'nosub', 'on-heap', 'optional',
-                    'originator', 'parse-at', 'parse-from', 'priority',
-                    'requires', 'responder', 'size', 'static', 'synchronize',
-                    'transient', 'try', 'type', 'until', 'until-including',
-                    'while', 'have_prototype'),
-                prefix=r'&', suffix=r'\b'),
-             Keyword.Pseudo),
+        "directives": [(r"(@(if|else|endif))\b", Comment.Preproc)],
+        "attributes": [
+            (
+                words(
+                    (
+                        "bit-order",
+                        "byte-order",
+                        "chunked",
+                        "convert",
+                        "count",
+                        "cxxname",
+                        "default",
+                        "eod",
+                        "internal",
+                        "ipv4",
+                        "ipv6",
+                        "length",
+                        "max-size",
+                        "no-emit",
+                        "nosub",
+                        "on-heap",
+                        "optional",
+                        "originator",
+                        "parse-at",
+                        "parse-from",
+                        "priority",
+                        "requires",
+                        "responder",
+                        "size",
+                        "static",
+                        "synchronize",
+                        "transient",
+                        "try",
+                        "type",
+                        "until",
+                        "until-including",
+                        "while",
+                        "have_prototype",
+                    ),
+                    prefix=r"&",
+                    suffix=r"\b",
+                ),
+                Keyword.Pseudo,
+            ),
         ],
-
-        'hooks': [
-            (fr'(on)(\s+)(({_id}::)+%?{_id}(\.{_id})*)',
-                bygroups(Keyword, Text, Name.Function)),
-            (fr'(on)(\s+)(%?{_id}(\.{_id})*)',
-                bygroups(Keyword, Text, Name.Function)),
+        "hooks": [
+            (
+                rf"(on)(\s+)(({_id}::)+%?{_id}(\.{_id})*)",
+                bygroups(Keyword, Text, Name.Function),
+            ),
+            (rf"(on)(\s+)(%?{_id}(\.{_id})*)", bygroups(Keyword, Text, Name.Function)),
         ],
-
-        'properties': [
+        "properties": [
             # Like an ID, but allow hyphenation ('-')
-            (r'%[a-zA-Z_][a-zA-Z_0-9-]*', Name.Attribute),
+            (r"%[a-zA-Z_][a-zA-Z_0-9-]*", Name.Attribute),
         ],
-
-        'types': [
-            (words(('any', 'addr', 'bitfield', 'bool', 'bytes',
-                    '__library_type', 'iterator', 'const_iterator', 'int8',
-                    'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32',
-                    'uint64', 'enum', 'interval', 'interval_ns', 'list', 'map',
-                    'optional', 'port', 'real', 'regexp', 'set', 'sink',
-                    'stream', 'view', 'string', 'time', 'time_ns', 'tuple',
-                    'unit', 'vector', 'void', 'function', 'struct'
+        "types": [
+            (
+                words(
+                    (
+                        "any",
+                        "addr",
+                        "bitfield",
+                        "bool",
+                        "bytes",
+                        "__library_type",
+                        "iterator",
+                        "const_iterator",
+                        "int8",
+                        "int16",
+                        "int32",
+                        "int64",
+                        "uint8",
+                        "uint16",
+                        "uint32",
+                        "uint64",
+                        "enum",
+                        "interval",
+                        "interval_ns",
+                        "list",
+                        "map",
+                        "optional",
+                        "port",
+                        "real",
+                        "regexp",
+                        "set",
+                        "sink",
+                        "stream",
+                        "view",
+                        "string",
+                        "time",
+                        "time_ns",
+                        "tuple",
+                        "unit",
+                        "vector",
+                        "void",
+                        "function",
+                        "struct",
                     ),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword.Type),
-
-            (fr'\b(type)(\s+)((?:{_id})(?:::(?:{_id}))*)\b',
-                bygroups(Keyword, Text, Name.Class)),
+                    prefix=r"\b",
+                    suffix=r"\b",
+                ),
+                Keyword.Type,
+            ),
+            (
+                rf"\b(type)(\s+)((?:{_id})(?:::(?:{_id}))*)\b",
+                bygroups(Keyword, Text, Name.Class),
+            ),
         ],
-
-        'modules': [
-            (fr'\b(import)(\s+)({_id})(\s+)(from)(\s+)(\S+)\b',
-                bygroups(Keyword.Namespace, Text, Name.Namespace, Text,
-                         Keyword.Namespace, Text, Name.Namespace)),
-
-            (fr'\b(module|import)(\s+)({_id})\b',
-                bygroups(Keyword.Namespace, Text, Name.Namespace)),
+        "modules": [
+            (
+                rf"\b(import)(\s+)({_id})(\s+)(from)(\s+)(\S+)\b",
+                bygroups(
+                    Keyword.Namespace,
+                    Text,
+                    Name.Namespace,
+                    Text,
+                    Keyword.Namespace,
+                    Text,
+                    Name.Namespace,
+                ),
+            ),
+            (
+                rf"\b(module|import)(\s+)({_id})\b",
+                bygroups(Keyword.Namespace, Text, Name.Namespace),
+            ),
         ],
-
-        'keywords': [
-            (words(('global', 'const', 'local', 'var',
-                    'public', 'private',
-                    'inout'
+        "keywords": [
+            (
+                words(
+                    ("global", "const", "local", "var", "public", "private", "inout"),
+                    prefix=r"\b",
+                    suffix=r"\b",
+                ),
+                Keyword.Declaration,
+            ),
+            (
+                words(
+                    (
+                        "print",
+                        "add",
+                        "delete",
+                        "stop",
+                        "unset",
+                        "assert",
+                        "assert-exception",
+                        "new",
+                        "cast",
+                        "begin",
+                        "end",
+                        "type",
+                        "attribute",
+                        "on",
+                        "priority",
+                        "if",
+                        "else",
+                        "switch",
+                        "case",
+                        "default",
+                        "try",
+                        "catch",
+                        "break",
+                        "return",
+                        "continue",
+                        "while",
+                        "for",
+                        "foreach",
+                        "module",
+                        "import",
+                        "export",
+                        "from",
                     ),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword.Declaration),
-
-
-            (words(('print',
-                    'add', 'delete', 'stop', 'unset',
-                    'assert', 'assert-exception',
-                    'new', 'cast', 'begin', 'end',
-                    'type', 'attribute',
-                    'on', 'priority',
-                    'if', 'else',
-                    'switch', 'case', 'default',
-                    'try', 'catch',
-                    'break', 'return', 'continue',
-                    'while', 'for', 'foreach',
-                    'module', 'import', 'export', 'from'
-                    ),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword),
+                    prefix=r"\b",
+                    suffix=r"\b",
+                ),
+                Keyword,
+            ),
         ],
-
-        'literals': [
-            (r'b?"', String, 'string'),
-
+        "literals": [
+            (r'b?"', String, "string"),
             # Not the greatest match for patterns, but generally helps
             # disambiguate between start of a pattern and just a division
             # operator.
-            (r'/(?=.*/)', String.Regex, 'regex'),
-
-            (r'\b(True|False|None|Null)\b', Keyword.Constant),
-
+            (r"/(?=.*/)", String.Regex, "regex"),
+            (r"\b(True|False|None|Null)\b", Keyword.Constant),
             # Port
-            (r'\b\d{1,5}/(udp|tcp)\b', Number),
-
+            (r"\b\d{1,5}/(udp|tcp)\b", Number),
             # IPv4 Address
-            (r'\b(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\b', Number),
-
+            (
+                r"\b(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\b",
+                Number,
+            ),
             # IPv6 Address (not 100% correct: that takes more effort)
-            (r'\[([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?((25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2}))?\]', Number),
-
+            (
+                r"\[([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?((25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2})\.(25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[0-9]{1,2}))?\]",
+                Number,
+            ),
             # Numeric
-            (fr'\b0[xX]{_hex}+\b', Number.Hex),
-            (fr'\b{_float}\b', Number.Float),
-            (r'\b(\d+)\b', Number.Integer),
+            (rf"\b0[xX]{_hex}+\b", Number.Hex),
+            (rf"\b{_float}\b", Number.Float),
+            (r"\b(\d+)\b", Number.Integer),
         ],
-
-        'operators': [
-            (r'[$][$]', Name.Builtin.Pseudo), # just-parsed-element
-            (r'[$]\d+', Name.Builtin.Pseudo), # capture-group
-            (r'\b(in)\b', Operator.Word),
-            (r'[-+*=&|<>.]{2}', Operator),
-            (r'[-+*/=!><]=', Operator),
-            (r'[?][.]', Operator),
-            (r'[.][?]', Operator),
-            (r'[-][>]', Operator),
-            (r'[!][<>]', Operator),
-            (r'[!%*/+<=>~|&^-]', Operator),
+        "operators": [
+            (r"[$][$]", Name.Builtin.Pseudo),  # just-parsed-element
+            (r"[$]\d+", Name.Builtin.Pseudo),  # capture-group
+            (r"\b(in)\b", Operator.Word),
+            (r"[-+*=&|<>.]{2}", Operator),
+            (r"[-+*/=!><]=", Operator),
+            (r"[?][.]", Operator),
+            (r"[.][?]", Operator),
+            (r"[-][>]", Operator),
+            (r"[!][<>]", Operator),
+            (r"[!%*/+<=>~|&^-]", Operator),
             # Technically, colons are often used for punctuation/sepration.
             # E.g. field name/type separation.
-            (r'[?:]', Operator),
+            (r"[?:]", Operator),
         ],
-
-        'punctuation': [
-            (r'[{}()\[\],;:.]', Punctuation),
+        "punctuation": [
+            (r"[{}()\[\],;:.]", Punctuation),
         ],
-
-        'function-call': [
-            (fr'\b((?:{_id})(?:::(?:{_id}))*)(?=\s*\()', Name.Function),
+        "function-call": [
+            (rf"\b((?:{_id})(?:::(?:{_id}))*)(?=\s*\()", Name.Function),
         ],
-
-        'identifiers': [
-            (r'\b(self)\b', Name.Builtin.Pseudo),
-            (r'([a-zA-Z_]\w*)(::)', bygroups(Name, Punctuation)),
-            (r'[a-zA-Z_]\w*', Name),
+        "identifiers": [
+            (r"\b(self)\b", Name.Builtin.Pseudo),
+            (r"([a-zA-Z_]\w*)(::)", bygroups(Name, Punctuation)),
+            (r"[a-zA-Z_]\w*", Name),
         ],
-
-        'string': [
-            (r'\\.', String.Escape),
-            (r'%-?[0-9]*(\.[0-9]+)?[DTdxsefg]', String.Escape),
-            (r'"', String, '#pop'),
-            (r'.', String),
+        "string": [
+            (r"\\.", String.Escape),
+            (r"%-?[0-9]*(\.[0-9]+)?[DTdxsefg]", String.Escape),
+            (r'"', String, "#pop"),
+            (r".", String),
         ],
-
-        'regex': [
-            (r'\\.', String.Escape),
-            (r'/', String.Regex, '#pop'),
-            (r'.', String.Regex),
+        "regex": [
+            (r"\\.", String.Escape),
+            (r"/", String.Regex, "#pop"),
+            (r".", String.Regex),
         ],
     }
 
@@ -206,74 +308,84 @@ class SpicyEvtLexer(RegexLexer):
     """
     For `Spicy <https://github.com/zeek/spicy>`_ Zeek interface definitions.
     """
-    name = 'SpicyEvt'
-    aliases = ['spicy-evt']
-    filenames = ['*.evt']
 
-    _id = r'[a-zA-Z_][a-zA-Z_0-9]*'
+    name = "SpicyEvt"
+    aliases = ["spicy-evt"]
+    filenames = ["*.evt"]
+
+    _id = r"[a-zA-Z_][a-zA-Z_0-9]*"
 
     tokens = {
-        'root': [
-            include('whitespace'),
-            include('comments'),
-            include('directives'),
-            include('hooks'),
-            include('modules'),
-            include('keywords'),
-            include('literals'),
-            include('operators'),
-            include('punctuation'),
-            include('function-call'),
-            include('identifiers'),
+        "root": [
+            include("whitespace"),
+            include("comments"),
+            include("directives"),
+            include("hooks"),
+            include("modules"),
+            include("keywords"),
+            include("literals"),
+            include("operators"),
+            include("punctuation"),
+            include("function-call"),
+            include("identifiers"),
         ],
-
-        'whitespace': SpicyLexer.tokens['whitespace'],
-        'comments': SpicyLexer.tokens['comments'],
-        'directives': SpicyLexer.tokens['directives'],
-        'hooks': SpicyLexer.tokens['hooks'],
-        'modules': SpicyLexer.tokens['modules'],
-
-        'keywords': [
-            (fr'\b(analyzer|with|replaces)(\s+)({_id}(::{_id})*)',
-                bygroups(Keyword, Text, Name.Class)),
-
-            (words(('protocol', 'packet', 'file'),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword.Type),
-
-            (words(('port', 'event',
-                    'parse', 'over',
-                    'mime-type'),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword),
-
-            (words(('cast'),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword),
-
-            (words(('if', 'else',
-                    'switch', 'case', 'default',
-                    'try', 'catch',
-                    'break', 'return', 'continue',
-                    'while', 'for', 'foreach',
+        "whitespace": SpicyLexer.tokens["whitespace"],
+        "comments": SpicyLexer.tokens["comments"],
+        "directives": SpicyLexer.tokens["directives"],
+        "hooks": SpicyLexer.tokens["hooks"],
+        "modules": SpicyLexer.tokens["modules"],
+        "keywords": [
+            (
+                rf"\b(analyzer|with|replaces)(\s+)({_id}(::{_id})*)",
+                bygroups(Keyword, Text, Name.Class),
+            ),
+            (
+                words(("protocol", "packet", "file"), prefix=r"\b", suffix=r"\b"),
+                Keyword.Type,
+            ),
+            (
+                words(
+                    ("port", "event", "parse", "over", "mime-type"),
+                    prefix=r"\b",
+                    suffix=r"\b",
+                ),
+                Keyword,
+            ),
+            (words(("cast"), prefix=r"\b", suffix=r"\b"), Keyword),
+            (
+                words(
+                    (
+                        "if",
+                        "else",
+                        "switch",
+                        "case",
+                        "default",
+                        "try",
+                        "catch",
+                        "break",
+                        "return",
+                        "continue",
+                        "while",
+                        "for",
+                        "foreach",
                     ),
-                prefix=r'\b', suffix=r'\b'),
-             Keyword),
+                    prefix=r"\b",
+                    suffix=r"\b",
+                ),
+                Keyword,
+            ),
         ],
-
-        'literals': SpicyLexer.tokens['literals'],
-        'operators': SpicyLexer.tokens['operators'],
-        'punctuation': SpicyLexer.tokens['punctuation'],
-        'function-call': SpicyLexer.tokens['function-call'],
-
-        'identifiers': [
-            (r'\b(ZEEK_VERSION)\b', Name.Builtin),
-            (r'\b(self)\b', Name.Builtin.Pseudo),
-            (r'[$](conn|file|is_orig)', Name.Builtin.Pseudo),
-            (r'([a-zA-Z_]\w*)(::)', bygroups(Name, Punctuation)),
-            (r'[a-zA-Z_]\w*', Name),
+        "literals": SpicyLexer.tokens["literals"],
+        "operators": SpicyLexer.tokens["operators"],
+        "punctuation": SpicyLexer.tokens["punctuation"],
+        "function-call": SpicyLexer.tokens["function-call"],
+        "identifiers": [
+            (r"\b(ZEEK_VERSION)\b", Name.Builtin),
+            (r"\b(self)\b", Name.Builtin.Pseudo),
+            (r"[$](conn|file|is_orig)", Name.Builtin.Pseudo),
+            (r"([a-zA-Z_]\w*)(::)", bygroups(Name, Punctuation)),
+            (r"[a-zA-Z_]\w*", Name),
         ],
-
-        'string': SpicyLexer.tokens['string'],
-        'regex': SpicyLexer.tokens['regex'],
+        "string": SpicyLexer.tokens["string"],
+        "regex": SpicyLexer.tokens["regex"],
     }

--- a/doc/scripts/spicy-pygments.py
+++ b/doc/scripts/spicy-pygments.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
-from pygments.lexer import RegexLexer, bygroups, include, words, bygroups
-from pygments.token import *
+from pygments.lexer import RegexLexer, include, words, bygroups
+from pygments.token import Comment, Keyword, Name, Number, Operator, Punctuation, String, Text
 from sphinx.highlighting import lexers
 
 

--- a/doc/scripts/spicy.py
+++ b/doc/scripts/spicy.py
@@ -249,7 +249,7 @@ class SpicyCode(CodeBlock):
         if file:
             self.file = self.env.relfn2path(os.path.join("examples/", file))
             try:
-                os.mkdir(os.path.dirname(self.file))
+                os.mkdir(os.path.dirname(self.file[1]))
             except FileExistsError:
                 pass
             except FileNotFoundError:

--- a/doc/scripts/spicy.py
+++ b/doc/scripts/spicy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
 """X
@@ -52,7 +50,7 @@ class SpicyGeneric(ObjectDescription):
             if key in objects:
                 self.env.warn(
                     self.env.docname,
-                    "duplicate description of %s %s, " % (self.objtype, name)
+                    f"duplicate description of {self.objtype} {name}, "
                     + "other instance in "
                     + self.env.doc2path(objects[key]),
                     self.lineno,
@@ -136,7 +134,7 @@ class SpicyMethod(SpicyGeneric):
         #        except ValueError:
         #            rnode = nodes.inline("", result)
 
-        signode += nodes.literal("", "%s(%s)" % (method, args))
+        signode += nodes.literal("", f"{method}({args})")
 
         if result != "-":
             signode += nodes.inline("", " → ")
@@ -354,7 +352,7 @@ class SpicyOutput(LiteralInclude):
         source_orig = args[1][0]
         file = "_" + source_orig
         index = "_%s" % args[1][1] if len(args[1]) > 1 else ""
-        output = "examples/%s.output%s" % (file, index)
+        output = f"examples/{file}.output{index}"
         args = list(args)
         args[1] = [output]
         args[2]["lines"] = "2-"

--- a/doc/scripts/spicy.py
+++ b/doc/scripts/spicy.py
@@ -10,7 +10,7 @@ import os.path
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.util.nodes import make_refnode, logging
-from sphinx.util.console import bold, purple, darkgreen, red, term_width_line
+from sphinx.util.console import darkgreen, red
 from sphinx.roles import XRefRole
 from sphinx.locale import _
 from sphinx.domains import Domain, ObjType
@@ -18,7 +18,6 @@ from sphinx.directives.code import CodeBlock, LiteralInclude
 from sphinx.directives import ObjectDescription
 from sphinx import version_info
 from sphinx import addnodes
-import sys
 import subprocess
 
 
@@ -122,7 +121,6 @@ class SpicyMethod(SpicyGeneric):
     def handle_signature(self, sig, signode):
         m = sig.split()
         name = m[0]
-        self = m[1]
         method = m[2]
         const = m[3]
         result = m[4].replace("~", " ")
@@ -252,7 +250,9 @@ class SpicyCode(CodeBlock):
             self.file = self.env.relfn2path(os.path.join("examples/", file))
             try:
                 os.mkdir(os.path.dirname(self.file))
-            except:
+            except FileExistsError:
+                pass
+            except FileNotFoundError:
                 pass
         else:
             self.file = None
@@ -338,7 +338,7 @@ class SpicyOutput(LiteralInclude):
 
         if "show-as" in options:
             self.show_as = options.get("show-as", None)
-            if not "prefix" in options:
+            if "prefix" not in options:
                 self.prefix = None
 
         self.content_hash = ("# Automatically generated; do not edit. -- <HASH> %s/%s/%s" %
@@ -367,12 +367,12 @@ class SpicyOutput(LiteralInclude):
             return literal
 
     def update(self, source_orig, source, destination, cmd):
-        if os.path.exists(destination) and not "UPDATE_SPICY_CODE" in os.environ:
+        if os.path.exists(destination) and "UPDATE_SPICY_CODE" not in os.environ:
             destination_time = os.path.getmtime(destination)
 
             if os.path.exists(source):
                 source_time = os.path.getmtime(source)
-            elif not "UPDATE_SPICY_CODE" in os.environ:
+            elif "UPDATE_SPICY_CODE" not in os.environ:
                 return
 
             if source_time <= destination_time:

--- a/doc/scripts/spicy.py
+++ b/doc/scripts/spicy.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
 """X
-    The Spicy domain for Sphinx.
+The Spicy domain for Sphinx.
 """
 
 import os.path
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 def make_index_tuple(indextype, indexentry, targetname, targetname2):
-    if version_info >= (1, 4, 0, '', 0):
+    if version_info >= (1, 4, 0, "", 0):
         return (indextype, indexentry, targetname, targetname2, None)
     else:
         return (indextype, indexentry, targetname, targetname2)
@@ -40,30 +40,32 @@ def make_index_tuple(indextype, indexentry, targetname, targetname2):
 
 class SpicyGeneric(ObjectDescription):
     def add_target_and_index(self, name, sig, signode):
-        targetname = self.objtype + '-' + name
+        targetname = self.objtype + "-" + name
         if targetname not in self.state.document.ids:
-            signode['names'].append(targetname)
-            signode['ids'].append(targetname)
-            signode['first'] = (not self.names)
+            signode["names"].append(targetname)
+            signode["ids"].append(targetname)
+            signode["first"] = not self.names
             self.state.document.note_explicit_target(signode)
 
-            objects = self.env.domaindata['spicy']['objects']
+            objects = self.env.domaindata["spicy"]["objects"]
             key = (self.objtype, name)
             if key in objects:
-                self.env.warn(self.env.docname,
-                              'duplicate description of %s %s, ' %
-                              (self.objtype, name) +
-                              'other instance in ' +
-                              self.env.doc2path(objects[key]),
-                              self.lineno)
+                self.env.warn(
+                    self.env.docname,
+                    "duplicate description of %s %s, " % (self.objtype, name)
+                    + "other instance in "
+                    + self.env.doc2path(objects[key]),
+                    self.lineno,
+                )
             objects[key] = self.env.docname
         indextext = self.get_index_text(self.objtype, name)
         if indextext:
-            self.indexnode['entries'].append(make_index_tuple('single', indextext,
-                                                              targetname, targetname))
+            self.indexnode["entries"].append(
+                make_index_tuple("single", indextext, targetname, targetname)
+            )
 
     def get_index_text(self, objectname, name):
-        return _('%s (%s)') % (name, self.objtype)
+        return _("%s (%s)") % (name, self.objtype)
 
     def handle_signature(self, sig, signode):
         signode += addnodes.desc_name("", sig)
@@ -124,15 +126,15 @@ class SpicyMethod(SpicyGeneric):
         method = m[2]
         const = m[3]
         result = m[4].replace("~", " ")
-        args = sig[sig.find("(") + 1:-1].replace("~", " ")
+        args = sig[sig.find("(") + 1 : -1].replace("~", " ")
 
-#        try:
-#            (ns, id) = result.split("::")
-#            rnode = addnodes.pending_xref("", refdomain='spicy', reftype='type', reftarget=result)
-#            rnode += nodes.literal("", id, classes=['xref'])
-#
-#        except ValueError:
-#            rnode = nodes.inline("", result)
+        #        try:
+        #            (ns, id) = result.split("::")
+        #            rnode = addnodes.pending_xref("", refdomain='spicy', reftype='type', reftarget=result)
+        #            rnode += nodes.literal("", id, classes=['xref'])
+        #
+        #        except ValueError:
+        #            rnode = nodes.inline("", result)
 
         signode += nodes.literal("", "%s(%s)" % (method, args))
 
@@ -172,69 +174,71 @@ class SpicyMethodXRefRole(XRefRole):
         i = title.find("::")
 
         if i > 0:
-            title = title[i+2:] + "()"
+            title = title[i + 2 :] + "()"
 
         return title, target
 
 
 class SpicyDomain(Domain):
     """Spicy domain."""
-    name = 'spicy'
-    label = 'Spicy'
+
+    name = "spicy"
+    label = "Spicy"
 
     object_types = {
-        'operator':    ObjType(_('operator'), 'op'),
-        'method':      ObjType(_('method'),   'method'),
-        'type':        ObjType(_('type'),     'type'),
-        'function':    ObjType(_('function'), 'function'),
+        "operator": ObjType(_("operator"), "op"),
+        "method": ObjType(_("method"), "method"),
+        "type": ObjType(_("type"), "type"),
+        "function": ObjType(_("function"), "function"),
     }
 
     directives = {
-        'operator':      SpicyOperator,
-        'method':        SpicyMethod,
-        'type':          SpicyType,
-        'function':      SpicyFunction,
+        "operator": SpicyOperator,
+        "method": SpicyMethod,
+        "type": SpicyType,
+        "function": SpicyFunction,
     }
 
     roles = {
-        'op':         XRefRole(),
-        'method':     SpicyMethodXRefRole(),
-        'type':       XRefRole(),
-        'function':   XRefRole(),
+        "op": XRefRole(),
+        "method": SpicyMethodXRefRole(),
+        "type": XRefRole(),
+        "function": XRefRole(),
     }
 
     initial_data = {
-        'objects': {},  # fullname -> docname, objtype
+        "objects": {},  # fullname -> docname, objtype
     }
 
     def clear_doc(self, docname):
-        for (typ, name), doc in list(self.data['objects'].items()):
+        for (typ, name), doc in list(self.data["objects"].items()):
             if doc == docname:
-                del self.data['objects'][typ, name]
+                del self.data["objects"][typ, name]
 
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node,
-                     contnode):
-        objects = self.data['objects']
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        objects = self.data["objects"]
         objtypes = self.objtypes_for_role(typ)
         for objtype in objtypes:
             if (objtype, target) in objects:
-                return make_refnode(builder, fromdocname,
-                                    objects[objtype, target],
-                                    objtype + '-' + target,
-                                    contnode, target + ' ' + objtype)
+                return make_refnode(
+                    builder,
+                    fromdocname,
+                    objects[objtype, target],
+                    objtype + "-" + target,
+                    contnode,
+                    target + " " + objtype,
+                )
 
     def get_objects(self):
-        for (typ, name), docname in self.data['objects'].items():
-            yield name, name, typ, docname, typ + '-' + name, 1
+        for (typ, name), docname in self.data["objects"].items():
+            yield name, name, typ, docname, typ + "-" + name, 1
 
 
 class SpicyCode(CodeBlock):
     required_arguments = 0
     optional_arguments = 1
 
-    option_spec = {
-        'exec': directives.unchanged
-    }
+    option_spec = {"exec": directives.unchanged}
 
     def __init__(self, *args, **kwargs):
         if len(args[1]) > 0:
@@ -243,8 +247,8 @@ class SpicyCode(CodeBlock):
             file = None
 
         args = list(args)
-        args[1] = self.arguments = ['spicy']
-        args[2]['lines'] = "2-"
+        args[1] = self.arguments = ["spicy"]
+        args[2]["lines"] = "2-"
         super(CodeBlock, self).__init__(*args, **kwargs)
         if file:
             self.file = self.env.relfn2path(os.path.join("examples/", file))
@@ -268,7 +272,7 @@ class SpicyCode(CodeBlock):
 
     def run(self):
         literal = CodeBlock.run(self)
-        language = literal[0]['language']
+        language = literal[0]["language"]
 
         if not self.file:
             return literal
@@ -286,7 +290,8 @@ class SpicyCode(CodeBlock):
             self.message("updating %s" % darkgreen(self.file[0]))
             f = open(self.file[1], "w")
             f.write(
-                "# Automatically generated; edit in Sphinx source code, not here.\n")
+                "# Automatically generated; edit in Sphinx source code, not here.\n"
+            )
             f.write(text)
             f.close()
 
@@ -306,7 +311,7 @@ class SpicyCode(CodeBlock):
 
         ntext = ntext.strip()
         literal[0] = nodes.literal_block(ntext, ntext)
-        literal[0]['language'] = language
+        literal[0]["language"] = language
 
         return literal
 
@@ -316,11 +321,11 @@ class SpicyOutput(LiteralInclude):
     optional_arguments = 1
 
     option_spec = {
-        'exec': directives.unchanged_required,
-        'prefix': directives.unchanged,
-        'show-as': directives.unchanged,
-        'show-with': directives.unchanged,
-        'expect-failure': bool
+        "exec": directives.unchanged_required,
+        "prefix": directives.unchanged,
+        "show-as": directives.unchanged,
+        "show-with": directives.unchanged,
+        "expect-failure": bool,
     }
 
     def __init__(self, *args, **kwargs):
@@ -330,7 +335,7 @@ class SpicyOutput(LiteralInclude):
         self.prefix = options.get("prefix", None)
         self.show_as = ""
         self.show_with = ""
-        self.expect_failure = ("expect-failure" in options)
+        self.expect_failure = "expect-failure" in options
 
         if "show-with" in options:
             self.show_with = options["show-with"]
@@ -341,17 +346,19 @@ class SpicyOutput(LiteralInclude):
             if "prefix" not in options:
                 self.prefix = None
 
-        self.content_hash = ("# Automatically generated; do not edit. -- <HASH> %s/%s/%s" %
-                             (self.exec_,  self.show_as, self.expect_failure))
+        self.content_hash = (
+            "# Automatically generated; do not edit. -- <HASH> %s/%s/%s"
+            % (self.exec_, self.show_as, self.expect_failure)
+        )
 
         source_orig = args[1][0]
         file = "_" + source_orig
-        index = ("_%s" % args[1][1] if len(args[1]) > 1 else "")
+        index = "_%s" % args[1][1] if len(args[1]) > 1 else ""
         output = "examples/%s.output%s" % (file, index)
         args = list(args)
         args[1] = [output]
-        args[2]['lines'] = "2-"
-        args[2]['language'] = "text"
+        args[2]["lines"] = "2-"
+        args[2]["language"] = "text"
         super(LiteralInclude, self).__init__(*args, **kwargs)
 
         source = self.env.relfn2path(os.path.join("examples/", file))[0]
@@ -384,7 +391,10 @@ class SpicyOutput(LiteralInclude):
         # Abort if that's not the case.
         if "CI" in os.environ:
             self.error(
-                "error during CI: {} is not up to date in repository".format(destination))
+                "error during CI: {} is not up to date in repository".format(
+                    destination
+                )
+            )
             return
 
         all_good = True
@@ -402,14 +412,14 @@ class SpicyOutput(LiteralInclude):
 
             try:
                 output = subprocess.check_output(
-                    one_cmd, shell=True, stderr=subprocess.STDOUT)
+                    one_cmd, shell=True, stderr=subprocess.STDOUT
+                )
 
                 if not output:
                     output = b"\n"
 
                 if self.expect_failure:
-                    self.error(
-                        "execution of '%s' expected to fail, but succeeded")
+                    self.error("execution of '%s' expected to fail, but succeeded")
                     all_good = False
 
             except subprocess.CalledProcessError as e:
@@ -430,9 +440,10 @@ class SpicyOutput(LiteralInclude):
 
                 if show_as:
                     one_cmd = "# %s\n" % show_as[0].strip()
-                    one_cmd = one_cmd.replace("%INPUT", self.show_with if self.show_with else source_orig)
-                    output = output.replace(
-                        source.encode(), self.show_with.encode())
+                    one_cmd = one_cmd.replace(
+                        "%INPUT", self.show_with if self.show_with else source_orig
+                    )
+                    output = output.replace(source.encode(), self.show_with.encode())
                     out.write(one_cmd.encode())
                     show_as = show_as[1:]
 
@@ -450,5 +461,5 @@ class SpicyOutput(LiteralInclude):
         logger.info(msg)
 
 
-directives.register_directive('spicy-code', SpicyCode)
-directives.register_directive('spicy-output', SpicyOutput)
+directives.register_directive("spicy-code", SpicyCode)
+directives.register_directive("spicy-output", SpicyOutput)

--- a/hilti/runtime/src/exception.cc
+++ b/hilti/runtime/src/exception.cc
@@ -80,8 +80,7 @@ Exception::Exception(Internal, const char* type, std::string_view desc, std::str
     : Exception(Internal(), type, ! location.empty() ? fmt("%s (%s)", desc, location) : fmt("%s", desc), desc,
                 location) {}
 
-Exception::Exception() : std::runtime_error("<no error>") { /* no profiling */
-}
+Exception::Exception() : std::runtime_error("<no error>") { /* no profiling */ }
 
 Exception::~Exception() = default;
 

--- a/spicy/toolchain/bin/spicy-dump/main.cc
+++ b/spicy/toolchain/bin/spicy-dump/main.cc
@@ -117,7 +117,7 @@ void SpicyDump::parseOptions(int argc, char** argv) {
     driver_options.logger = std::make_unique<hilti::Logger>();
 
     while ( true ) {
-        int c = getopt_long(argc, argv, "ABD:f:hdX:QVlp:PSRL:J", long_options, nullptr);
+        int c = getopt_long(argc, argv, "BAD:f:hdX:QVlp:PSRL:J", long_options, nullptr);
 
         if ( c < 0 )
             break;

--- a/tests/Scripts/stray_baselines.py
+++ b/tests/Scripts/stray_baselines.py
@@ -6,17 +6,20 @@ import os
 import re
 import sys
 
-TEST_DIR = os.path.realpath(__file__ + '/../../')
+TEST_DIR = os.path.realpath(__file__ + "/../../")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         available_tests = set(
             map(
-                lambda x: x.decode('utf-8'),
+                lambda x: x.decode("utf-8"),
                 subprocess.check_output(
-                    ['btest', '-l', '-c', TEST_DIR + '/btest.cfg']).splitlines()))
+                    ["btest", "-l", "-c", TEST_DIR + "/btest.cfg"]
+                ).splitlines(),
+            )
+        )
 
-        test_baselines = set(os.listdir(TEST_DIR + '/Baseline'))
+        test_baselines = set(os.listdir(TEST_DIR + "/Baseline"))
     except subprocess.CalledProcessError:
         # We need to run against at least btest-0.70 in order to list tests,
         # but this is not available in the latest release, yet.
@@ -28,12 +31,18 @@ if __name__ == '__main__':
 
     stray_tests = sorted(
         list(
-            filter(lambda cand: not re.match('\\d$',
-                                             cand.split('-')[-1]),
-                   test_baselines.difference(available_tests))))
+            filter(
+                lambda cand: not re.match("\\d$", cand.split("-")[-1]),
+                test_baselines.difference(available_tests),
+            )
+        )
+    )
 
     if stray_tests:
-        print('No matching tests for the following baselines:\n\n{}'.format(
-            '\n'.join(stray_tests)),
-            file=sys.stderr)
+        print(
+            "No matching tests for the following baselines:\n\n{}".format(
+                "\n".join(stray_tests)
+            ),
+            file=sys.stderr,
+        )
         sys.exit(1)


### PR DESCRIPTION
This PR makes a pass over our Python scripts. We add a [simple linter and formatter](https://docs.astral.sh/ruff/). We also modernize scripts with [`pyupgrade`](https://pypi.org/project/pyupgrade/).

While we are at it we also bump some other pre-commit hooks.