### PR TITLE
Rework AST memory management

### DIFF
--- a/hilti/runtime/include/profiler-state.h
+++ b/hilti/runtime/include/profiler-state.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 namespace hilti::rt::profiler {
 

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SOURCES
     src/ast/types/union.cc
     src/base/code-formatter.cc
     src/base/logger.cc
+    src/base/monotonic_buffer_resource.cc
     src/base/preprocessor.cc
     src/base/timing.cc
     src/base/util.cc

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <memory_resource>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -15,8 +16,7 @@
 #include <hilti/ast/forward.h>
 #include <hilti/ast/node.h>
 #include <hilti/base/logger.h>
-
-#include "base/uniquer.h"
+#include <hilti/base/uniquer.h>
 
 namespace hilti {
 
@@ -24,6 +24,10 @@ class ASTContext;
 class Context;
 class Driver;
 struct Plugin;
+
+namespace type {
+struct Wildcard;
+}
 
 /**
  * Parses a HILTI source file into an AST.
@@ -34,23 +38,7 @@ struct Plugin;
  *
  * @returns the parsed AST, or a corresponding error if parsing failed.
  */
-Result<ModulePtr> parseSource(Builder* builder, std::istream& in, const std::string& filename);
-
-/**
- * Root node for the AST inside an AST context. This will always exist exactly
- * once.
- */
-class ASTRoot : public Node {
-public:
-    static auto create(ASTContext* ctx) { return std::shared_ptr<ASTRoot>(new ASTRoot(ctx)); }
-
-protected:
-    ASTRoot(ASTContext* ctx) : Node(ctx, NodeTags, {}, Meta(Location("<root>"))) {}
-
-    std::string _dump() const final;
-
-    HILTI_NODE_0(ASTRoot, final);
-};
+Result<declaration::Module*> parseSource(Builder* builder, std::istream& in, const std::string& filename);
 
 namespace ast {
 
@@ -180,8 +168,8 @@ public:
                                                   std::vector<hilti::rt::filesystem::path> search_dirs);
 
     /** Adds a new, empty module to the AST. */
-    std::shared_ptr<declaration::Module> newModule(Builder* builder, const ID& id,
-                                                   const hilti::rt::filesystem::path& process_extension);
+    declaration::Module* newModule(Builder* builder, const ID& id,
+                                   const hilti::rt::filesystem::path& process_extension);
 
     /**
      * Retrieves a module node from the AST given its UID. Returns null if no
@@ -189,7 +177,7 @@ public:
      *
      * @param uid UID of module to return
      */
-    ModulePtr module(const declaration::module::UID& uid) const {
+    declaration::Module* module(const declaration::module::UID& uid) const {
         if ( auto m = _modules_by_uid.find(uid); m != _modules_by_uid.end() )
             return m->second;
         else
@@ -257,7 +245,7 @@ public:
      * @returns the index now associated with the declaration; it's value is
      * guaranteed to not be `None` (and hence be larger than zero).
      */
-    ast::DeclarationIndex register_(const DeclarationPtr& decl);
+    ast::DeclarationIndex register_(Declaration* decl);
 
     /**
      * Returns the declaration associated with an index.
@@ -266,7 +254,7 @@ public:
      * not trigger an internal error; unless its `None`, in which case it
      * returns `null`.
      */
-    DeclarationPtr lookup(ast::DeclarationIndex index); // must exists, otherwise internal error -> result is not null
+    Declaration* lookup(ast::DeclarationIndex index); // must exists, otherwise internal error -> result is not null
 
     /**
      * Replaces a previously registered declaration with a new one. This means
@@ -283,7 +271,7 @@ public:
      * the method returns without doing anything
      * @param new new declaration to take the place of the old one
      */
-    void replace(const Declaration* old, const DeclarationPtr& new_);
+    void replace(Declaration* old, Declaration* new_);
 
     /**
      * Registers a type with the context, assigning it a unique index through
@@ -297,7 +285,7 @@ public:
      * @returns the index now associated with the type; it's value is
      * guaranteed to not be `None` (and hence be larger than zero).
      */
-    ast::TypeIndex register_(const UnqualifiedTypePtr& type);
+    ast::TypeIndex register_(UnqualifiedType* type);
 
     /**
      * Returns the type associated with an index.
@@ -306,7 +294,7 @@ public:
      * not trigger an internal error; unless its `None`, in which case it
      * returns `null`.
      */
-    UnqualifiedTypePtr lookup(ast::TypeIndex index);
+    UnqualifiedType* lookup(ast::TypeIndex index);
 
     /**
      * Replaces a previously registered type with a new one. This means
@@ -319,7 +307,7 @@ public:
      * the method returns without doing any tying
      * @param new new type to take the place of the old one
      */
-    void replace(const UnqualifiedType* old, const UnqualifiedTypePtr& new_);
+    void replace(UnqualifiedType* old, UnqualifiedType* new_);
 
     /**
      * Given an ID that's supposed to become a declaration's canonical ID,
@@ -335,7 +323,61 @@ public:
      */
     void dump(const hilti::logging::DebugStream& stream, const std::string& prefix);
 
+    /**
+     * Factory function creating a new node of type T. This allocates the new
+     * through the context-wide memory resource.
+     *
+     * @param args arguments to pass to the constructor of T
+     */
+    template<typename T, typename... Args>
+    T* make(Args&&... args) {
+        return new (allocateNode<T>()) T(std::forward<Args>(args)...);
+    }
+
+    /**
+     * Factory function creating a new node of type T. This allocates the new
+     * through the context-wide memory resource.
+     *
+     * We need this variant because `std::initializer_list` cannot be passed
+     * through the generic `std::forward`.
+     *
+     * @param ctx first argument to pass to the constructor of T; must be `this`
+     * @param children second argument to pass to the constructor of T
+     * @param args remaining arguments to pass to the constructor of T
+     */
+    template<typename T, typename... Args>
+    T* make(ASTContext* ctx, std::initializer_list<Node*> children, Args&&... args) {
+        assert(ctx == this);
+        return new (allocateNode<T>()) T(ctx, children, std::forward<Args>(args)...);
+    }
+
+    /**
+     * Factory function creating a new node of type T. This allocates the new
+     * through the context-wide memory resource.
+     *
+     * We need this variant because `std::initializer_list` cannot be passed
+     * through the generic `std::forward`.
+     *
+     * @param ctx first argument to pass to the constructor of T; must be `this`
+     * @param wildcard second argument to pass to the constructor of T; must be `this`
+     * @param children third second argument to pass to the constructor of T
+     * @param args remaining arguments to pass to the constructor of T
+     */
+    template<typename T, typename... Args>
+    T* make(ASTContext* ctx, type::Wildcard&& wildcard, std::initializer_list<Node*> children, Args&&... args) {
+        assert(ctx == this);
+        return new (allocateNode<T>())
+            T(ctx, std::forward<type::Wildcard>(wildcard), children, std::forward<Args>(args)...);
+    }
+
 private:
+    template<typename T>
+    T* allocateNode() {
+        auto* t = reinterpret_cast<T*>(_memory_resource.allocate(sizeof(T), alignof(T)));
+        _nodes.emplace_back(t);
+        return t;
+    }
+
     // The following methods implement the corresponding phases of AST processing.
 
     Result<declaration::module::UID> _parseSource(Builder* builder, const hilti::rt::filesystem::path& path,
@@ -354,7 +396,7 @@ private:
 
     // Adds a module to the AST. The module must not be part of any AST yet
     // (including the current one).
-    declaration::module::UID _addModuleToAST(ModulePtr module);
+    declaration::module::UID _addModuleToAST(declaration::Module* module);
 
     // Performs internal consistency checks on the AST. Meant to execute only
     // in debug builds as it may affect performance.
@@ -382,22 +424,42 @@ private:
     // Dumps the accumulated state tables of the context to a debugging stream.
     void _dumpDeclarations(const logging::DebugStream& stream, const Plugin& plugin);
 
-    Context* _context = nullptr;         // compiler context
-    std::shared_ptr<ASTRoot> _root;      // root node of the AST
+    Context* _context = nullptr;                          // compiler context
+    std::pmr::monotonic_buffer_resource _memory_resource; // memory resource for all AST nodes
+    std::vector<Node*> _nodes; // all nodes allocated through the context so that we can run destructors at the end
+
+    ASTRoot* _root = nullptr;            // root node of the AST
     bool _resolved = false;              // true if `processAST()` has finished successfully
     Driver* _driver = nullptr;           // pointer to compiler drive during `processAST()`, null outside of that
     util::Uniquer<ID> _canon_id_uniquer; // Produces unique canonified IDs
 
     uint64_t _total_rounds = 0; // total number of rounds of AST processing
 
-    std::unordered_map<declaration::module::UID, ModulePtr> _modules_by_uid; // all known modules indexed by UID
-    std::unordered_map<std::string, ModulePtr> _modules_by_path;             // all known modules indexed by path
-    std::map<std::pair<ID, ID>, ModulePtr>
+    std::unordered_map<declaration::module::UID, declaration::Module*>
+        _modules_by_uid;                                                    // all known modules indexed by UID
+    std::unordered_map<std::string, declaration::Module*> _modules_by_path; // all known modules indexed by path
+    std::map<std::pair<ID, ID>, declaration::Module*>
         _modules_by_id_and_scope; // all known modules indexed by their ID and search scope
 
-    std::vector<DeclarationPtr>
+    std::vector<Declaration*>
         _declarations_by_index; // all registered declarations; vector position corresponds to their index
-    std::vector<UnqualifiedTypePtr> _types_by_index; // all registered types; vector position corresponds to their index
+    std::vector<UnqualifiedType*> _types_by_index; // all registered types; vector position corresponds to their index
+};
+
+/**
+ * Root node for the AST inside an AST context. This will always exist exactly
+ * once.
+ */
+class ASTRoot : public Node {
+public:
+    static auto create(ASTContext* ctx) { return ctx->make<ASTRoot>(ctx); }
+
+protected:
+    ASTRoot(ASTContext* ctx) : Node(ctx, NodeTags, {}, Meta(Location("<root>"))) {}
+
+    std::string _dump() const final;
+
+    HILTI_NODE_0(ASTRoot, final);
 };
 
 } // namespace hilti

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -4,7 +4,6 @@
 
 #include <map>
 #include <memory>
-#include <memory_resource>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -16,6 +15,7 @@
 #include <hilti/ast/forward.h>
 #include <hilti/ast/node.h>
 #include <hilti/base/logger.h>
+#include <hilti/base/monotonic_buffer_resource.h>
 #include <hilti/base/uniquer.h>
 
 namespace hilti {
@@ -424,8 +424,8 @@ private:
     // Dumps the accumulated state tables of the context to a debugging stream.
     void _dumpDeclarations(const logging::DebugStream& stream, const Plugin& plugin);
 
-    Context* _context = nullptr;                          // compiler context
-    std::pmr::monotonic_buffer_resource _memory_resource; // memory resource for all AST nodes
+    Context* _context = nullptr;                        // compiler context
+    detail::monotonic_buffer_resource _memory_resource; // memory resource for all AST nodes
     std::vector<Node*> _nodes; // all nodes allocated through the context so that we can run destructors at the end
 
     ASTRoot* _root = nullptr;            // root node of the AST

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -441,9 +441,8 @@ private:
     std::map<std::pair<ID, ID>, declaration::Module*>
         _modules_by_id_and_scope; // all known modules indexed by their ID and search scope
 
-    std::vector<Declaration*>
-        _declarations_by_index; // all registered declarations; vector position corresponds to their index
-    std::vector<UnqualifiedType*> _types_by_index; // all registered types; vector position corresponds to their index
+    Declarations _declarations_by_index; // all registered declarations; vector position corresponds to their index
+    UnqualifiedTypes _types_by_index;    // all registered types; vector position corresponds to their index
 };
 
 /**

--- a/hilti/toolchain/include/ast/attribute.h
+++ b/hilti/toolchain/include/ast/attribute.h
@@ -27,7 +27,7 @@ public:
      *
      * @exception `std::out_of_range` if the attribute does not have an argument
      */
-    NodePtr value() const { return child(0); }
+    Node* value() const { return child(0); }
 
     /**
      * Returns the expression argument associated with the attribute.
@@ -35,7 +35,7 @@ public:
      * @return the argument, or an error if the attribute does not have an
      * argument, or if it's not an expression.
      */
-    Result<ExpressionPtr> valueAsExpression() const;
+    Result<Expression*> valueAsExpression() const;
 
     /**
      * Returns the expression argument associated with the attribute as a
@@ -66,7 +66,7 @@ public:
      * result's value is false); a failure if a coercion would have been
      * necessary, but failed, or the attribute does not have a expression value.
      */
-    Result<bool> coerceValueTo(Builder* builder, const QualifiedTypePtr& dst);
+    Result<bool> coerceValueTo(Builder* builder, QualifiedType* dst);
 
     node::Properties properties() const final {
         auto p = node::Properties{{"tag", _tag}};
@@ -81,8 +81,8 @@ public:
      * @param v node representing the argument to associate with the attribute; must be an expression
      * @param m meta data to associate with the node
      */
-    static auto create(ASTContext* ctx, const std::string& tag, const ExpressionPtr& v, const Meta& m = Meta()) {
-        return std::shared_ptr<Attribute>(new Attribute(ctx, {v}, tag, m));
+    static auto create(ASTContext* ctx, const std::string& tag, Expression* v, const Meta& m = Meta()) {
+        return ctx->make<Attribute>(ctx, {v}, tag, m);
     }
 
     /**
@@ -119,7 +119,7 @@ public:
      *
      * @return attribute if found
      */
-    AttributePtr find(std::string_view tag) const;
+    Attribute* find(std::string_view tag) const;
 
     /**
      * Retrieves all attributes with a given name from the set.
@@ -136,7 +136,7 @@ public:
     bool has(std::string_view tag) const { return find(tag) != nullptr; }
 
     /** Adds an attribute to the set. */
-    void add(ASTContext* ctx, const AttributePtr& a) { addChild(ctx, a); }
+    void add(ASTContext* ctx, Attribute* a) { addChild(ctx, a); }
 
     /** Removes all attributes of the given tag. */
     void remove(std::string_view tag);
@@ -145,7 +145,7 @@ public:
     operator bool() const { return ! attributes().empty(); }
 
     static auto create(ASTContext* ctx, Attributes attrs = {}, Meta m = Meta()) {
-        return std::shared_ptr<AttributeSet>(new AttributeSet(ctx, Nodes{std::move(attrs)}, std::move(m)));
+        return ctx->make<AttributeSet>(ctx, Nodes{std::move(attrs)}, std::move(m));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/attribute.h
+++ b/hilti/toolchain/include/ast/attribute.h
@@ -145,7 +145,7 @@ public:
     operator bool() const { return ! attributes().empty(); }
 
     static auto create(ASTContext* ctx, Attributes attrs = {}, Meta m = Meta()) {
-        return ctx->make<AttributeSet>(ctx, Nodes{std::move(attrs)}, std::move(m));
+        return ctx->make<AttributeSet>(ctx, std::move(attrs), std::move(m));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -42,9 +42,7 @@ public:
     Builder(ASTContext* ctx) : NodeFactory(ctx) { _static_state.block = statement::Block::create(ctx, {}, {}); }
 
     /** Construct a builder that adds any flow-level nodes to a given pre-existing block. */
-    Builder(ASTContext* context, std::shared_ptr<statement::Block> block) : NodeFactory(context) {
-        _static_state.block = std::move(block);
-    }
+    Builder(ASTContext* context, statement::Block* block) : NodeFactory(context) { _static_state.block = block; }
 
     /**
      * Returns the current block associated with the builder for creating
@@ -61,9 +59,7 @@ public:
      * perform later during AST resolving. This version associated the source
      * expressions meta data with the coercion.
      */
-    auto coerceTo(const ExpressionPtr& e, const QualifiedTypePtr& t) {
-        return expressionPendingCoerced(e, t, e->meta());
-    }
+    auto coerceTo(Expression* e, QualifiedType* t) { return expressionPendingCoerced(e, t, e->meta()); }
 
     /**
      * Expresses the coercion of an expression into a target type. Note that
@@ -71,14 +67,12 @@ public:
      * perform later during AST resolving. This version associated custom meta
      * data with the coercion.
      */
-    auto coerceTo(const ExpressionPtr& e, const QualifiedTypePtr& t, const Meta& m) {
-        return expressionPendingCoerced(e, t, m);
-    }
+    auto coerceTo(Expression* e, QualifiedType* t, const Meta& m) { return expressionPendingCoerced(e, t, m); }
 
     //////// Helpers for operators
 
     /** Constructs a node representing the main node for constructor call operator. */
-    auto ctorType(const UnqualifiedTypePtr& t) { return typeType(qualifiedType(t, Constness::Const)); }
+    auto ctorType(UnqualifiedType* t) { return typeType(qualifiedType(t, Constness::Const)); }
 
     //////// Declarations
 
@@ -94,97 +88,97 @@ public:
         return declarationImportedModule(hilti::ID(std::move(module), m), parse_extension, std::move(search_scope), m);
     }
 
-    auto local(ID id_, const QualifiedTypePtr& t, Meta m = Meta()) {
+    auto local(ID id_, QualifiedType* t, Meta m = Meta()) {
         return statementDeclaration(declarationLocalVariable(std::move(id_), t, {}, std::move(m)));
     }
 
-    auto local(ID id_, ExpressionPtr init, const Meta& m = Meta()) {
-        return statementDeclaration(declarationLocalVariable(std::move(id_), std::move(init), m));
+    auto local(ID id_, Expression* init, const Meta& m = Meta()) {
+        return statementDeclaration(declarationLocalVariable(std::move(id_), init, m));
     }
 
-    auto local(ID id_, const QualifiedTypePtr& t, ExpressionPtr init, Meta m = Meta()) {
-        return statementDeclaration(declarationLocalVariable(std::move(id_), t, std::move(init), std::move(m)));
+    auto local(ID id_, QualifiedType* t, Expression* init, Meta m = Meta()) {
+        return statementDeclaration(declarationLocalVariable(std::move(id_), t, init, std::move(m)));
     }
 
-    auto local(ID id_, const QualifiedTypePtr& t, Expressions args, Meta m = Meta()) {
+    auto local(ID id_, QualifiedType* t, Expressions args, Meta m = Meta()) {
         return statementDeclaration(declarationLocalVariable(std::move(id_), t, std::move(args), {}, std::move(m)));
     }
 
-    auto global(ID id_, const QualifiedTypePtr& t, declaration::Linkage linkage = declaration::Linkage::Private,
+    auto global(ID id_, QualifiedType* t, declaration::Linkage linkage = declaration::Linkage::Private,
                 Meta m = Meta()) {
         return declarationGlobalVariable(std::move(id_), t, {}, linkage, std::move(m));
     }
 
-    auto global(ID id_, const ExpressionPtr& init, declaration::Linkage linkage = declaration::Linkage::Private,
+    auto global(ID id_, Expression* init, declaration::Linkage linkage = declaration::Linkage::Private,
                 const Meta& m = Meta()) {
         return declarationGlobalVariable(std::move(id_), init, linkage, m);
     }
 
-    auto global(ID id_, const QualifiedTypePtr& t, ExpressionPtr init,
+    auto global(ID id_, QualifiedType* t, Expression* init,
                 declaration::Linkage linkage = declaration::Linkage::Private, Meta m = Meta()) {
-        return declarationGlobalVariable(std::move(id_), t, std::move(init), linkage, std::move(m));
+        return declarationGlobalVariable(std::move(id_), t, init, linkage, std::move(m));
     }
 
-    auto global(ID id_, const QualifiedTypePtr& t, Expressions args,
+    auto global(ID id_, QualifiedType* t, Expressions args,
                 declaration::Linkage linkage = declaration::Linkage::Private, Meta m = Meta()) {
         return declarationGlobalVariable(std::move(id_), t, std::move(args), {}, linkage, std::move(m));
     }
 
-    auto type(ID id, const QualifiedTypePtr& type, declaration::Linkage linkage = declaration::Linkage::Private,
+    auto type(ID id, QualifiedType* type, declaration::Linkage linkage = declaration::Linkage::Private,
               Meta m = Meta()) {
         return declarationType(std::move(id), type, linkage, std::move(m));
     }
 
-    auto type(ID id, const QualifiedTypePtr& type, AttributeSetPtr attrs,
+    auto type(ID id, QualifiedType* type, AttributeSet* attrs,
               declaration::Linkage linkage = declaration::Linkage::Private, Meta m = Meta()) {
-        return declarationType(std::move(id), type, std::move(attrs), linkage, std::move(m));
+        return declarationType(std::move(id), type, attrs, linkage, std::move(m));
     }
 
-    auto constant(ID id_, const ExpressionPtr& init, declaration::Linkage linkage = declaration::Linkage::Private,
+    auto constant(ID id_, Expression* init, declaration::Linkage linkage = declaration::Linkage::Private,
                   Meta m = Meta()) {
         return declarationConstant(std::move(id_), init, linkage, std::move(m));
     }
 
-    auto parameter(ID id, const UnqualifiedTypePtr& type, parameter::Kind kind = parameter::Kind::In, Meta m = Meta()) {
+    auto parameter(ID id, UnqualifiedType* type, parameter::Kind kind = parameter::Kind::In, Meta m = Meta()) {
         return declarationParameter(std::move(id), type, kind, {}, {}, std::move(m));
     }
 
-    auto parameter(ID id, const UnqualifiedTypePtr& type, const ExpressionPtr& default_,
-                   parameter::Kind kind = parameter::Kind::In, Meta m = Meta()) {
+    auto parameter(ID id, UnqualifiedType* type, Expression* default_, parameter::Kind kind = parameter::Kind::In,
+                   Meta m = Meta()) {
         return declarationParameter(std::move(id), type, kind, default_, {}, std::move(m));
     }
 
     template<typename... Params>
     static auto parameters(Params&&... params) {
-        return std::vector<hilti::type::function::ParameterPtr>{std::forward<Params>(params)...};
+        return std::vector<hilti::type::function::Parameter*>{std::forward<Params>(params)...};
     }
 
     using NodeFactory::function;
 
-    auto function(const ID& id, const QualifiedTypePtr& result, const declaration::Parameters& params,
+    auto function(const ID& id, QualifiedType* result, const declaration::Parameters& params,
                   type::function::Flavor flavor = type::function::Flavor::Standard,
                   declaration::Linkage linkage = declaration::Linkage::Private,
-                  function::CallingConvention cc = function::CallingConvention::Standard,
-                  const AttributeSetPtr& attrs = {}, const Meta& m = Meta()) {
+                  function::CallingConvention cc = function::CallingConvention::Standard, AttributeSet* attrs = {},
+                  const Meta& m = Meta()) {
         auto ft = typeFunction(result, params, flavor, m);
         auto f = function(id, ft, {}, cc, attrs, m);
         return declarationFunction(f, linkage, m);
     }
 
-    auto function(const ID& id, const QualifiedTypePtr& result, const declaration::Parameters& params,
-                  const StatementPtr& body, type::function::Flavor flavor = type::function::Flavor::Standard,
+    auto function(const ID& id, QualifiedType* result, const declaration::Parameters& params, Statement* body,
+                  type::function::Flavor flavor = type::function::Flavor::Standard,
                   declaration::Linkage linkage = declaration::Linkage::Private,
-                  function::CallingConvention cc = function::CallingConvention::Standard,
-                  const AttributeSetPtr& attrs = {}, const Meta& m = Meta()) {
+                  function::CallingConvention cc = function::CallingConvention::Standard, AttributeSet* attrs = {},
+                  const Meta& m = Meta()) {
         auto ft = typeFunction(result, params, flavor, m);
         auto f = function(id, ft, body, cc, attrs, m);
         return declarationFunction(f, linkage, m);
     }
 
-    auto function(const ID& id, const std::shared_ptr<type::Function>& ftype, const StatementPtr& body,
+    auto function(const ID& id, type::Function* ftype, Statement* body,
                   declaration::Linkage linkage = declaration::Linkage::Private,
-                  function::CallingConvention cc = function::CallingConvention::Standard,
-                  const AttributeSetPtr& attrs = {}, const Meta& m = Meta()) {
+                  function::CallingConvention cc = function::CallingConvention::Standard, AttributeSet* attrs = {},
+                  const Meta& m = Meta()) {
         auto f = function(id, ftype, body, cc, attrs, m);
         return declarationFunction(f, linkage, m);
     }
@@ -208,22 +202,21 @@ public:
 
     auto bytes(std::string s, const Meta& m = Meta()) { return expressionCtor(ctorBytes(std::move(s), m), m); }
 
-    auto default_(const UnqualifiedTypePtr& t, const Meta& m = Meta()) { return expressionCtor(ctorDefault(t, m), m); }
+    auto default_(UnqualifiedType* t, const Meta& m = Meta()) { return expressionCtor(ctorDefault(t, m), m); }
 
-    auto default_(const UnqualifiedTypePtr& t, Expressions type_args, const Meta& m = Meta()) {
+    auto default_(UnqualifiedType* t, Expressions type_args, const Meta& m = Meta()) {
         return expressionCtor(ctorDefault(t, std::move(type_args), m), m);
     }
 
-    auto exception(const UnqualifiedTypePtr& t, const std::string& msg, const Meta& m = Meta()) {
+    auto exception(UnqualifiedType* t, const std::string& msg, const Meta& m = Meta()) {
         return expressionCtor(ctorException(t, stringLiteral(msg), m), m);
     }
 
-    auto exception(const UnqualifiedTypePtr& t, const ExpressionPtr& msg, const Meta& m = Meta()) {
+    auto exception(UnqualifiedType* t, Expression* msg, const Meta& m = Meta()) {
         return expressionCtor(ctorException(t, msg, m), m);
     }
 
-    auto exception(const UnqualifiedTypePtr& t, const ExpressionPtr& what, const ExpressionPtr& where,
-                   const Meta& m = Meta()) {
+    auto exception(UnqualifiedType* t, Expression* what, Expression* where, const Meta& m = Meta()) {
         return expressionCtor(ctorException(t, what, where, m), m);
     }
 
@@ -239,17 +232,17 @@ public:
 
     auto null(const Meta& m = Meta()) { return expressionCtor(ctorNull(m), m); }
 
-    auto optional(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionCtor(ctorOptional(e, m), m); }
+    auto optional(Expression* e, const Meta& m = Meta()) { return expressionCtor(ctorOptional(e, m), m); }
 
-    auto optional(const QualifiedTypePtr& t, const Meta& m = Meta()) { return expressionCtor(ctorOptional(t, m), m); }
+    auto optional(QualifiedType* t, const Meta& m = Meta()) { return expressionCtor(ctorOptional(t, m), m); }
 
     auto port(hilti::rt::Port p, const Meta& m = Meta()) { return expressionCtor(ctorPort(p, m), m); }
 
-    auto regexp(std::string p, const AttributeSetPtr& attrs = {}, const Meta& m = Meta()) {
+    auto regexp(std::string p, AttributeSet* attrs = {}, const Meta& m = Meta()) {
         return expressionCtor(ctorRegExp({std::move(p)}, attrs, m), m);
     }
 
-    auto regexp(std::vector<std::string> p, const AttributeSetPtr& attrs = {}, const Meta& m = Meta()) {
+    auto regexp(std::vector<std::string> p, AttributeSet* attrs = {}, const Meta& m = Meta()) {
         return expressionCtor(ctorRegExp(std::move(p), attrs, m), m);
     }
 
@@ -259,188 +252,177 @@ public:
         return expressionCtor(ctorStruct(std::move(f), m), m);
     }
 
-    auto struct_(ctor::struct_::Fields f, QualifiedTypePtr t, const Meta& m = Meta()) {
-        return expressionCtor(ctorStruct(std::move(f), std::move(t), m), m);
+    auto struct_(ctor::struct_::Fields f, QualifiedType* t, const Meta& m = Meta()) {
+        return expressionCtor(ctorStruct(std::move(f), t, m), m);
     }
 
     auto tuple(const Expressions& v, const Meta& m = Meta()) { return expressionCtor(ctorTuple(v, m), m); }
 
     auto vector(const Expressions& v, const Meta& m = Meta()) { return expressionCtor(ctorVector(v, m), m); }
 
-    auto vector(const QualifiedTypePtr& t, Expressions v, const Meta& m = Meta()) {
+    auto vector(QualifiedType* t, Expressions v, const Meta& m = Meta()) {
         return expressionCtor(ctorVector(t, std::move(v), m), m);
     }
 
-    auto vector(const QualifiedTypePtr& t, const Meta& m = Meta()) { return expressionCtor(ctorVector(t, {}, m), m); }
+    auto vector(QualifiedType* t, const Meta& m = Meta()) { return expressionCtor(ctorVector(t, {}, m), m); }
 
     auto void_(const Meta& m = Meta()) { return expressionVoid(m); }
 
-    auto strongReference(const QualifiedTypePtr& t, const Meta& m = Meta()) {
+    auto strongReference(QualifiedType* t, const Meta& m = Meta()) {
         return expressionCtor(ctorStrongReference(t, m), m);
     }
 
-    auto weakReference(const QualifiedTypePtr& t, const Meta& m = Meta()) {
-        return expressionCtor(ctorWeakReference(t, m), m);
-    }
+    auto weakReference(QualifiedType* t, const Meta& m = Meta()) { return expressionCtor(ctorWeakReference(t, m), m); }
 
-    auto valueReference(const ExpressionPtr& e, const Meta& m = Meta()) {
-        return expressionCtor(ctorValueReference(e, m), m);
-    }
+    auto valueReference(Expression* e, const Meta& m = Meta()) { return expressionCtor(ctorValueReference(e, m), m); }
 
     // Operator expressions
 
-    auto and_(const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& m = Meta()) {
-        return expressionLogicalAnd(op0, op1, m);
+    auto and_(Expression* op0, Expression* op1, const Meta& m = Meta()) { return expressionLogicalAnd(op0, op1, m); }
+
+    auto or_(Expression* op0, Expression* op1, const Meta& m = Meta()) { return expressionLogicalOr(op0, op1, m); }
+
+    auto begin(Expression* e, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Begin, {e}, m);
     }
 
-    auto or_(const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& m = Meta()) {
-        return expressionLogicalOr(op0, op1, m);
+    auto cast(Expression* e, QualifiedType* dst, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Cast, {e, expressionType(dst)}, m);
     }
 
-    auto begin(ExpressionPtr e, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Begin, {std::move(e)}, m);
+    auto delete_(Expression* self, const ID& field, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Delete, {self, expressionMember(field)}, m);
     }
 
-    auto cast(ExpressionPtr e, const QualifiedTypePtr& dst, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Cast, {std::move(e), expressionType(dst)}, m);
+    auto deref(Expression* e, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Deref, {e}, m);
     }
 
-    auto delete_(ExpressionPtr self, const ID& field, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Delete, {std::move(self), expressionMember(field)}, m);
-    }
-
-    auto deref(ExpressionPtr e, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Deref, {std::move(e)}, m);
-    }
-
-    auto end(ExpressionPtr e, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::End, {std::move(e)}, m);
+    auto end(Expression* e, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::End, {e}, m);
     }
 
     auto call(const ID& id_, const Expressions& v, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::Call, {id(id_, m), tuple(v, m)}, m);
     }
 
-    auto index(ExpressionPtr value, unsigned int index, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Index, {std::move(value), integer(index, m)}, m);
+    auto index(Expression* value, unsigned int index, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Index, {value, integer(index, m)}, m);
     }
 
-    auto size(ExpressionPtr op, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Size, {std::move(op)}, m);
+    auto size(Expression* op, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Size, {op}, m);
     }
 
-    auto modulo(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Modulo, {std::move(op1), std::move(op2)}, m);
+    auto modulo(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Modulo, {op1, op2}, m);
     }
 
-    auto lowerEqual(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::LowerEqual, {std::move(op1), std::move(op2)}, m);
+    auto lowerEqual(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::LowerEqual, {op1, op2}, m);
     }
 
-    auto greaterEqual(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::GreaterEqual, {std::move(op1), std::move(op2)}, m);
+    auto greaterEqual(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::GreaterEqual, {op1, op2}, m);
     }
 
-    auto lower(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Lower, {std::move(op1), std::move(op2)}, m);
+    auto lower(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Lower, {op1, op2}, m);
     }
 
-    auto greater(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Greater, {std::move(op1), std::move(op2)}, m);
+    auto greater(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Greater, {op1, op2}, m);
     }
 
-    auto equal(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Equal, {std::move(op1), std::move(op2)}, m);
+    auto equal(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Equal, {op1, op2}, m);
     }
 
-    auto unequal(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Unequal, {std::move(op1), std::move(op2)}, m);
+    auto unequal(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Unequal, {op1, op2}, m);
     }
 
-    auto member(ExpressionPtr self, std::string id_, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Member,
-                                            {std::move(self), expressionMember(ID(std::move(id_)), m)}, m);
-    }
-
-    auto hasMember(ExpressionPtr self, std::string id_, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::HasMember,
-                                            {std::move(self), expressionMember(ID(std::move(id_)), m)}, m);
-    }
-
-    auto tryMember(ExpressionPtr self, std::string id_, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::TryMember,
-                                            {std::move(self), expressionMember(ID(std::move(id_)), m)}, m);
-    }
-
-    auto memberCall(ExpressionPtr self, std::string id_, const Expressions& args = {}, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::MemberCall,
-                                            {std::move(self), expressionMember(ID(std::move(id_)), m), tuple(args, m)},
+    auto member(Expression* self, std::string id_, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Member, {self, expressionMember(ID(std::move(id_)), m)},
                                             m);
     }
 
-    auto memberCall(ExpressionPtr self, std::string id_, std::shared_ptr<ctor::Tuple> args, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::MemberCall,
-                                            {std::move(self), expressionMember(ID(std::move(id_)), m),
-                                             expressionCtor(std::move(args))},
+    auto hasMember(Expression* self, std::string id_, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::HasMember, {self, expressionMember(ID(std::move(id_)), m)},
                                             m);
     }
 
-    auto pack(const QualifiedTypePtr& type, const Expressions& args, const Meta& m = Meta()) {
+    auto tryMember(Expression* self, std::string id_, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::TryMember, {self, expressionMember(ID(std::move(id_)), m)},
+                                            m);
+    }
+
+    auto memberCall(Expression* self, std::string id_, const Expressions& args = {}, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::MemberCall,
+                                            {self, expressionMember(ID(std::move(id_)), m), tuple(args, m)}, m);
+    }
+
+    auto memberCall(Expression* self, std::string id_, ctor::Tuple* args, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::MemberCall,
+                                            {self, expressionMember(ID(std::move(id_)), m), expressionCtor(args)}, m);
+    }
+
+    auto pack(QualifiedType* type, const Expressions& args, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::Pack, {expressionType(type, m), tuple(args, m)}, m);
     }
 
-    auto unpack(const QualifiedTypePtr& type, const Expressions& args, const Meta& m = Meta()) {
+    auto unpack(QualifiedType* type, const Expressions& args, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::Unpack,
                                             {expressionType(type, m), tuple(args, m), expressionCtor(ctorBool(false))},
                                             m);
     }
 
-    auto unset(ExpressionPtr self, const ID& field, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Unset, {std::move(self), expressionMember(field)}, m);
+    auto unset(Expression* self, const ID& field, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Unset, {self, expressionMember(field)}, m);
     }
 
-    auto sumAssign(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::SumAssign, {std::move(op1), std::move(op2)}, m);
+    auto sumAssign(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::SumAssign, {op1, op2}, m);
     }
 
-    auto deferred(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionDeferred(e, m); }
+    auto deferred(Expression* e, const Meta& m = Meta()) { return expressionDeferred(e, m); }
 
-    auto differenceAssign(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::DifferenceAssign, {std::move(op1), std::move(op2)}, m);
+    auto differenceAssign(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::DifferenceAssign, {op1, op2}, m);
     }
 
-    auto sum(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Sum, {std::move(op1), std::move(op2)}, m);
+    auto sum(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Sum, {op1, op2}, m);
     }
 
-    auto difference(ExpressionPtr op1, ExpressionPtr op2, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Difference, {std::move(op1), std::move(op2)}, m);
+    auto difference(Expression* op1, Expression* op2, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Difference, {op1, op2}, m);
     }
 
-    auto decrementPostfix(ExpressionPtr op, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::DecrPostfix, {std::move(op)}, m);
+    auto decrementPostfix(Expression* op, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::DecrPostfix, {op}, m);
     }
 
-    auto decrementPrefix(ExpressionPtr op, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::DecrPrefix, {std::move(op)}, m);
+    auto decrementPrefix(Expression* op, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::DecrPrefix, {op}, m);
     }
 
-    auto incrementPostfix(ExpressionPtr op, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::IncrPostfix, {std::move(op)}, m);
+    auto incrementPostfix(Expression* op, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::IncrPostfix, {op}, m);
     }
 
-    auto incrementPrefix(ExpressionPtr op, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::IncrPrefix, {std::move(op)}, m);
+    auto incrementPrefix(Expression* op, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::IncrPrefix, {op}, m);
     }
 
-    auto new_(const UnqualifiedTypePtr& t, const Meta& m = Meta()) {
+    auto new_(UnqualifiedType* t, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::New,
                                             {expressionType(qualifiedType(t, hilti::Constness::Const), m),
                                              expressionCtor(ctorTuple({}, m))},
                                             m);
     }
 
-    auto new_(const UnqualifiedTypePtr& t, const Expressions& args, const Meta& m = Meta()) {
+    auto new_(UnqualifiedType* t, const Expressions& args, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::New,
                                             {expressionType(qualifiedType(t, hilti::Constness::Const), m),
                                              expressionCtor(ctorTuple(args, m))},
@@ -449,38 +431,35 @@ public:
 
     // Other expressions
 
-    auto expression(const CtorPtr& c, const Meta& m = Meta()) { return expressionCtor(c, m); }
+    auto expression(Ctor* c, const Meta& m = Meta()) { return expressionCtor(c, m); }
 
     auto expression(const Location& l) { return stringLiteral(std::string(l)); }
 
     auto expression(const Meta& m) { return expression(m.location()); }
 
-    auto grouping(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionGrouping(e, m); }
+    auto grouping(Expression* e, const Meta& m = Meta()) { return expressionGrouping(e, m); }
 
-    auto move(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionMove(e, m); }
+    auto move(Expression* e, const Meta& m = Meta()) { return expressionMove(e, m); }
 
-    auto typeinfo(const QualifiedTypePtr& t, const Meta& m = Meta()) {
-        return expressionTypeInfo(expressionType(t, m), m);
-    }
+    auto typeinfo(QualifiedType* t, const Meta& m = Meta()) { return expressionTypeInfo(expressionType(t, m), m); }
 
-    auto typeinfo(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionTypeInfo(e, m); }
+    auto typeinfo(Expression* e, const Meta& m = Meta()) { return expressionTypeInfo(e, m); }
 
-    auto assign(const ExpressionPtr& target, const ExpressionPtr& src, const Meta& m = Meta()) {
+    auto assign(Expression* target, Expression* src, const Meta& m = Meta()) {
         return expressionAssign(target, src, m);
     }
 
-    auto not_(const ExpressionPtr& e, const Meta& m = Meta()) { return expressionLogicalNot(e, m); }
+    auto not_(Expression* e, const Meta& m = Meta()) { return expressionLogicalNot(e, m); }
 
-    auto ternary(const ExpressionPtr& cond, const ExpressionPtr& true_, const ExpressionPtr& false_,
-                 const Meta& m = Meta()) {
+    auto ternary(Expression* cond, Expression* true_, Expression* false_, const Meta& m = Meta()) {
         return expressionTernary(cond, true_, false_, m);
     }
 
-    auto min(const ExpressionPtr& e1, const ExpressionPtr& e2, const Meta& m = Meta()) {
+    auto min(Expression* e1, Expression* e2, const Meta& m = Meta()) {
         return ternary(lowerEqual(e1, e2, m), e1, e2, m);
     }
 
-    auto max(const ExpressionPtr& e1, const ExpressionPtr& e2, const Meta& m = Meta()) {
+    auto max(Expression* e1, Expression* e2, const Meta& m = Meta()) {
         return ternary(lowerEqual(e1, e2, m), e2, e1, m);
     }
 
@@ -493,47 +472,47 @@ public:
 
     //////////// Variables and statements
 
-    ExpressionPtr addTmp(const std::string& prefix, const ExpressionPtr& init);
-    ExpressionPtr addTmp(const std::string& prefix, const QualifiedTypePtr& t, const Expressions& args = {});
-    ExpressionPtr addTmp(const std::string& prefix, const QualifiedTypePtr& t, const ExpressionPtr& init);
-    ExpressionPtr addTmp(const std::string& prefix, const UnqualifiedTypePtr& t, const Expressions& args = {}) {
+    Expression* addTmp(const std::string& prefix, Expression* init);
+    Expression* addTmp(const std::string& prefix, QualifiedType* t, const Expressions& args = {});
+    Expression* addTmp(const std::string& prefix, QualifiedType* t, Expression* init);
+    Expression* addTmp(const std::string& prefix, UnqualifiedType* t, const Expressions& args = {}) {
         return addTmp(prefix, qualifiedType(t, Constness::Mutable), args);
     }
-    ExpressionPtr addTmp(const std::string& prefix, const UnqualifiedTypePtr& t, const ExpressionPtr& init) {
+    Expression* addTmp(const std::string& prefix, UnqualifiedType* t, Expression* init) {
         return addTmp(prefix, qualifiedType(t, Constness::Mutable), init);
     }
 
-    void addLocal(ID id, const QualifiedTypePtr& t, Meta m = Meta()) {
+    void addLocal(ID id, QualifiedType* t, Meta m = Meta()) {
         block()->_add(context(), local(std::move(id), t, std::move(m)));
     }
 
-    void addLocal(ID id, ExpressionPtr init, const Meta& m = Meta()) {
-        block()->_add(context(), local(std::move(id), std::move(init), m));
+    void addLocal(ID id, Expression* init, const Meta& m = Meta()) {
+        block()->_add(context(), local(std::move(id), init, m));
     }
 
-    void addLocal(ID id, const QualifiedTypePtr& t, ExpressionPtr init, Meta m = Meta()) {
-        block()->_add(context(), local(std::move(id), t, std::move(init), std::move(m)));
+    void addLocal(ID id, QualifiedType* t, Expression* init, Meta m = Meta()) {
+        block()->_add(context(), local(std::move(id), t, init, std::move(m)));
     }
 
-    void addLocal(ID id, const QualifiedTypePtr& t, std::vector<hilti::ExpressionPtr> args, Meta m = Meta()) {
+    void addLocal(ID id, QualifiedType* t, std::vector<hilti::Expression*> args, Meta m = Meta()) {
         block()->_add(context(), local(std::move(id), t, std::move(args), std::move(m)));
     }
 
-    void addExpression(const ExpressionPtr& expr) { block()->_add(context(), statementExpression(expr, expr->meta())); }
+    void addExpression(Expression* expr) { block()->_add(context(), statementExpression(expr, expr->meta())); }
 
-    void addAssert(const ExpressionPtr& cond, std::string_view msg, Meta m = Meta()) {
+    void addAssert(Expression* cond, std::string_view msg, Meta m = Meta()) {
         block()->_add(context(), statementAssert(cond, stringMutable(msg), std::move(m)));
     }
 
-    void addAssign(const ExpressionPtr& dst, const ExpressionPtr& src, const Meta& m = Meta()) {
+    void addAssign(Expression* dst, Expression* src, const Meta& m = Meta()) {
         block()->_add(context(), statementExpression(assign(dst, src, m), m));
     }
 
-    void addSumAssign(ExpressionPtr dst, ExpressionPtr src, const Meta& m = Meta()) {
-        block()->_add(context(), statementExpression(sumAssign(std::move(dst), std::move(src), m), m));
+    void addSumAssign(Expression* dst, Expression* src, const Meta& m = Meta()) {
+        block()->_add(context(), statementExpression(sumAssign(dst, src, m), m));
     }
 
-    void addAssign(const ID& dst, const ExpressionPtr& src, const Meta& m = Meta()) {
+    void addAssign(const ID& dst, Expression* src, const Meta& m = Meta()) {
         block()->_add(context(), statementExpression(assign(id(dst), src, m), m));
     }
 
@@ -541,16 +520,16 @@ public:
 
     void addContinue(Meta m = Meta()) { block()->_add(context(), statementContinue(std::move(m))); }
 
-    void addSumAssign(const ID& dst, ExpressionPtr src, const Meta& m = Meta()) {
-        block()->_add(context(), statementExpression(sumAssign(id(dst), std::move(src), m), m));
+    void addSumAssign(const ID& dst, Expression* src, const Meta& m = Meta()) {
+        block()->_add(context(), statementExpression(sumAssign(id(dst), src, m), m));
     }
 
     void addCall(const ID& id, const Expressions& v, const Meta& m = Meta()) {
         block()->_add(context(), statementExpression(call(id, v, m), m));
     }
 
-    void addMemberCall(ExpressionPtr self, const ID& id, const Expressions& v, const Meta& m = Meta()) {
-        block()->_add(context(), statementExpression(memberCall(std::move(self), id, v, m), m));
+    void addMemberCall(Expression* self, const ID& id, const Expressions& v, const Meta& m = Meta()) {
+        block()->_add(context(), statementExpression(memberCall(self, id, v, m), m));
     }
 
     void addComment(std::string comment,
@@ -560,19 +539,15 @@ public:
         block()->_add(context(), statementComment(std::move(comment), separator, m));
     }
 
-    void addReturn(const ExpressionPtr& e, Meta m = Meta()) {
-        block()->_add(context(), statementReturn(e, std::move(m)));
-    }
+    void addReturn(Expression* e, Meta m = Meta()) { block()->_add(context(), statementReturn(e, std::move(m))); }
 
-    void addReturn(const CtorPtr& c, const Meta& m = Meta()) {
+    void addReturn(Ctor* c, const Meta& m = Meta()) {
         block()->_add(context(), statementReturn(expressionCtor(c, m), m));
     }
 
     void addReturn(Meta m = Meta()) { block()->_add(context(), statementReturn(std::move(m))); }
 
-    void addThrow(const ExpressionPtr& excpt, Meta m = Meta()) {
-        block()->_add(context(), statementThrow(excpt, std::move(m)));
-    }
+    void addThrow(Expression* excpt, Meta m = Meta()) { block()->_add(context(), statementThrow(excpt, std::move(m))); }
 
     void addRethrow(Meta m = Meta()) { block()->_add(context(), statementThrow(std::move(m))); }
 
@@ -581,21 +556,21 @@ public:
     void addDebugDedent(std::string_view stream);
 
     void addPrint(const Expressions& exprs) { addCall("hilti::print", exprs); }
-    void addPrint(const ExpressionPtr& expr) { addCall("hilti::print", {expr}); }
+    void addPrint(Expression* expr) { addCall("hilti::print", {expr}); }
 
     void setLocation(const Location& l);
 
     bool empty() const { return block()->statements().empty() && _tmps().empty(); }
 
-    ExpressionPtr startProfiler(std::string_view name, ExpressionPtr size = nullptr);
-    void stopProfiler(ExpressionPtr profiler, ExpressionPtr size = nullptr);
+    Expression* startProfiler(std::string_view name, Expression* size = nullptr);
+    void stopProfiler(Expression* profiler, Expression* size = nullptr);
 
 protected:
     Builder(Builder* parent) : NodeFactory(parent->context()), _state(parent->_state) {}
 
 private:
     struct State {
-        std::shared_ptr<statement::Block> block;
+        statement::Block* block = nullptr;
         std::map<std::string, int> tmps;
     };
 
@@ -615,54 +590,52 @@ class ExtendedBuilderTemplate : public Builder {
 public:
     using Builder::Builder;
 
-    auto addWhile(const std::shared_ptr<statement::Declaration>& init, const ExpressionPtr& cond,
-                  const Meta& m = Meta()) {
+    auto addWhile(statement::Declaration* init, Expression* cond, const Meta& m = Meta()) {
         auto body = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), Builder::statementWhile(init->declaration(), cond, body, {}, m));
         return _newBuilder(body);
     }
 
-    auto addWhile(const ExpressionPtr& cond, const Meta& m = Meta()) {
+    auto addWhile(Expression* cond, const Meta& m = Meta()) {
         auto body = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), Builder::statementWhile(cond, body, {}, m));
         return _newBuilder(body);
     }
 
-    auto addWhileElse(const std::shared_ptr<statement::Declaration>& init, const ExpressionPtr& cond,
-                      const Meta& m = Meta()) {
+    auto addWhileElse(statement::Declaration* init, Expression* cond, const Meta& m = Meta()) {
         auto body = Builder::statementBlock();
         auto else_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), statementWhile(init->declaration(), cond, body, else_, m));
         return std::make_pair(_newBuilder(body), _newBuilder(else_));
     }
 
-    auto addWhileElse(const ExpressionPtr& cond, const Meta& m = Meta()) {
+    auto addWhileElse(Expression* cond, const Meta& m = Meta()) {
         auto body = Builder::statementBlock();
         auto else_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), statementWhile(cond, body, else_, m));
         return std::make_pair(_newBuilder(body), _newBuilder(else_));
     }
 
-    auto addIf(const std::shared_ptr<statement::Declaration>& init, const ExpressionPtr& cond, Meta m = Meta()) {
+    auto addIf(statement::Declaration* init, Expression* cond, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(),
                                Builder::statementIf(init->declaration(), cond, true_, {}, std::move(m)));
         return _newBuilder(true_);
     }
 
-    auto addIf(const std::shared_ptr<statement::Declaration>& init, Meta m = Meta()) {
+    auto addIf(statement::Declaration* init, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), statementIf(init->declaration(), {}, true_, {}, std::move(m)));
         return _newBuilder(true_);
     }
 
-    auto addIf(const ExpressionPtr& cond, Meta m = Meta()) {
+    auto addIf(Expression* cond, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), Builder::statementIf(cond, true_, {}, std::move(m)));
         return _newBuilder(true_);
     }
 
-    auto addIfElse(const std::shared_ptr<statement::Declaration>& init, const ExpressionPtr& cond, Meta m = Meta()) {
+    auto addIfElse(statement::Declaration* init, Expression* cond, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         auto false_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(),
@@ -670,14 +643,14 @@ public:
         return std::make_pair(_newBuilder(true_), _newBuilder(false_));
     }
 
-    auto addIfElse(const std::shared_ptr<statement::Declaration>& init, Meta m = Meta()) {
+    auto addIfElse(statement::Declaration* init, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         auto false_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), statementIf(init->declaration(), {}, true_, false_, std::move(m)));
         return std::make_pair(_newBuilder(true_), _newBuilder(false_));
     }
 
-    auto addIfElse(const ExpressionPtr& cond, Meta m = Meta()) {
+    auto addIfElse(Expression* cond, Meta m = Meta()) {
         auto true_ = Builder::statementBlock();
         auto false_ = Builder::statementBlock();
         Builder::block()->_add(Builder::context(), Builder::statementIf(cond, true_, false_, std::move(m)));
@@ -697,10 +670,9 @@ public:
 
     class SwitchProxy {
     public:
-        SwitchProxy(ExtendedBuilderTemplate* b, std::shared_ptr<statement::Switch> s)
-            : _builder(b), _switch(std::move(s)) {}
+        SwitchProxy(ExtendedBuilderTemplate* b, statement::Switch* s) : _builder(b), _switch(s) {}
 
-        auto addCase(ExpressionPtr expr, const Meta& m = Meta()) { return _addCase({std::move(expr)}, m); }
+        auto addCase(Expression* expr, const Meta& m = Meta()) { return _addCase({expr}, m); }
 
         auto addCase(const Expressions& exprs, const Meta& m = Meta()) { return _addCase(exprs, m); }
 
@@ -714,16 +686,16 @@ public:
         }
 
         ExtendedBuilderTemplate* _builder;
-        std::shared_ptr<statement::Switch> _switch;
+        statement::Switch* _switch = nullptr;
     };
 
-    auto addSwitch(const ExpressionPtr& cond, Meta m = Meta()) {
+    auto addSwitch(Expression* cond, Meta m = Meta()) {
         auto switch_ = Builder::statementSwitch(cond, {}, std::move(m));
         Builder::block()->_add(Builder::context(), switch_);
         return SwitchProxy(this, switch_);
     }
 
-    auto addSwitch(const std::shared_ptr<statement::Declaration>& cond, Meta m = Meta()) {
+    auto addSwitch(statement::Declaration* cond, Meta m = Meta()) {
         auto switch_ = Builder::statementSwitch(cond->declaration(), {}, std::move(m));
         Builder::block()->_add(Builder::context(), switch_);
         return SwitchProxy(this, switch_);
@@ -731,9 +703,9 @@ public:
 
     class TryProxy {
     public:
-        TryProxy(ExtendedBuilderTemplate* b, std::shared_ptr<statement::Try> s) : _builder(b), _try(std::move(s)) {}
+        TryProxy(ExtendedBuilderTemplate* b, statement::Try* s) : _builder(b), _try(s) {}
 
-        auto addCatch(const declaration::ParameterPtr& p, const Meta& m = Meta()) {
+        auto addCatch(declaration::Parameter* p, const Meta& m = Meta()) {
             auto body = _builder->statementBlock(m);
             _try->addCatch(_builder->context(), _builder->statementTryCatch(p, body, m));
             return _builder->_newBuilder(body);
@@ -754,7 +726,7 @@ public:
 
     private:
         ExtendedBuilderTemplate* _builder;
-        std::shared_ptr<statement::Try> _try;
+        statement::Try* _try = nullptr;
     };
 
     auto addTry(Meta m = Meta()) {
@@ -765,7 +737,7 @@ public:
     }
 
 private:
-    std::shared_ptr<ExtendedBuilderTemplate> _newBuilder(std::shared_ptr<statement::Block> block) {
+    std::shared_ptr<ExtendedBuilderTemplate> _newBuilder(statement::Block* block) {
         return std::make_shared<ExtendedBuilderTemplate>(Builder::context(), block);
     }
 };

--- a/hilti/toolchain/include/ast/builder/node-factory.h
+++ b/hilti/toolchain/include/ast/builder/node-factory.h
@@ -25,7 +25,7 @@ public:
     /** Returns the AST context in use for creating nodes. */
     ASTContext* context() const { return _context; }
 
-    auto attribute(const std::string& tag, const ExpressionPtr& v, const Meta& m = Meta()) {
+    auto attribute(const std::string& tag, Expression* v, const Meta& m = Meta()) {
         return hilti::Attribute::create(context(), tag, v, m);
     }
     auto attribute(const std::string& tag, const Meta& m = Meta()) {
@@ -37,83 +37,81 @@ public:
     auto ctorAddress(hilti::rt::Address v, const Meta& meta = {}) {
         return hilti::ctor::Address::create(context(), v, meta);
     }
-    auto ctorBitfield(const ctor::bitfield::BitRanges& bits, QualifiedTypePtr type, const Meta& m = Meta()) {
-        return hilti::ctor::Bitfield::create(context(), bits, std::move(type), m);
+    auto ctorBitfield(const ctor::bitfield::BitRanges& bits, QualifiedType* type, const Meta& m = Meta()) {
+        return hilti::ctor::Bitfield::create(context(), bits, type, m);
     }
-    auto ctorBitfieldBitRange(const ID& id, const ExpressionPtr& expr, const Meta& meta = Meta()) {
-        return hilti::ctor::bitfield::BitRange::create(context(), id, expr, meta);
+    auto ctorBitfieldBitRange(const ID& id, Expression* expr, Meta meta = Meta()) {
+        return hilti::ctor::bitfield::BitRange::create(context(), id, expr, std::move(meta));
     }
     auto ctorBool(bool v, const Meta& meta = {}) { return hilti::ctor::Bool::create(context(), v, meta); }
     auto ctorBytes(std::string value, const Meta& meta = {}) {
         return hilti::ctor::Bytes::create(context(), std::move(value), meta);
     }
-    auto ctorCoerced(const CtorPtr& orig, const CtorPtr& new_, const Meta& meta = {}) {
-        return hilti::ctor::Coerced::create(context(), orig, new_, meta);
+    auto ctorCoerced(Ctor* orig, Ctor* new_, Meta meta = {}) {
+        return hilti::ctor::Coerced::create(context(), orig, new_, std::move(meta));
     }
-    auto ctorDefault(const UnqualifiedTypePtr& type, Expressions type_args, const Meta& meta = {}) {
+    auto ctorDefault(UnqualifiedType* type, Expressions type_args, const Meta& meta = {}) {
         return hilti::ctor::Default::create(context(), type, std::move(type_args), meta);
     }
-    auto ctorDefault(const UnqualifiedTypePtr& type, const Meta& meta = {}) {
+    auto ctorDefault(UnqualifiedType* type, const Meta& meta = {}) {
         return hilti::ctor::Default::create(context(), type, meta);
     }
-    auto ctorEnum(const type::enum_::LabelPtr& label, const Meta& meta = {}) {
+    auto ctorEnum(type::enum_::Label* label, const Meta& meta = {}) {
         return hilti::ctor::Enum::create(context(), label, meta);
     }
     auto ctorError(std::string v, const Meta& meta = {}) {
         return hilti::ctor::Error::create(context(), std::move(v), meta);
     }
-    auto ctorException(const UnqualifiedTypePtr& type, const ExpressionPtr& value, const ExpressionPtr& location,
-                       const Meta& meta = {}) {
+    auto ctorException(UnqualifiedType* type, Expression* value, Expression* location, const Meta& meta = {}) {
         return hilti::ctor::Exception::create(context(), type, value, location, meta);
     }
-    auto ctorException(const UnqualifiedTypePtr& type, const ExpressionPtr& value, const Meta& meta = {}) {
+    auto ctorException(UnqualifiedType* type, Expression* value, const Meta& meta = {}) {
         return hilti::ctor::Exception::create(context(), type, value, meta);
     }
     auto ctorInterval(hilti::rt::Interval v, const Meta& meta = {}) {
         return hilti::ctor::Interval::create(context(), v, meta);
     }
-    auto ctorLibrary(const CtorPtr& ctor, const QualifiedTypePtr& type, const Meta& meta = {}) {
+    auto ctorLibrary(Ctor* ctor, QualifiedType* type, const Meta& meta = {}) {
         return hilti::ctor::Library::create(context(), ctor, type, meta);
     }
-    auto ctorList(Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::List::create(context(), std::move(exprs), meta);
+    auto ctorList(Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::List::create(context(), std::move(exprs), std::move(meta));
     }
-    auto ctorList(const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::List::create(context(), etype, std::move(exprs), meta);
+    auto ctorList(QualifiedType* etype, Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::List::create(context(), etype, std::move(exprs), std::move(meta));
     }
-    auto ctorMap(const QualifiedTypePtr& key, const QualifiedTypePtr& value, ctor::map::Elements elements,
-                 const Meta& meta = {}) {
-        return hilti::ctor::Map::create(context(), key, value, std::move(elements), meta);
+    auto ctorMap(QualifiedType* key, QualifiedType* value, ctor::map::Elements elements, Meta meta = {}) {
+        return hilti::ctor::Map::create(context(), key, value, std::move(elements), std::move(meta));
     }
-    auto ctorMap(ctor::map::Elements elements, const Meta& meta = {}) {
-        return hilti::ctor::Map::create(context(), std::move(elements), meta);
+    auto ctorMap(ctor::map::Elements elements, Meta meta = {}) {
+        return hilti::ctor::Map::create(context(), std::move(elements), std::move(meta));
     }
-    auto ctorMapElement(const ExpressionPtr& key, const ExpressionPtr& value, Meta meta = {}) {
+    auto ctorMapElement(Expression* key, Expression* value, Meta meta = {}) {
         return hilti::ctor::map::Element::create(context(), key, value, std::move(meta));
     }
     auto ctorNetwork(hilti::rt::Network v, const Meta& meta = {}) {
         return hilti::ctor::Network::create(context(), v, meta);
     }
     auto ctorNull(const Meta& meta = {}) { return hilti::ctor::Null::create(context(), meta); }
-    auto ctorOptional(const ExpressionPtr& expr, const Meta& meta = {}) {
+    auto ctorOptional(Expression* expr, const Meta& meta = {}) {
         return hilti::ctor::Optional::create(context(), expr, meta);
     }
-    auto ctorOptional(const QualifiedTypePtr& type, const Meta& meta = {}) {
+    auto ctorOptional(QualifiedType* type, const Meta& meta = {}) {
         return hilti::ctor::Optional::create(context(), type, meta);
     }
     auto ctorPort(hilti::rt::Port v, const Meta& meta = {}) { return hilti::ctor::Port::create(context(), v, meta); }
     auto ctorReal(double v, const Meta& meta = {}) { return hilti::ctor::Real::create(context(), v, meta); }
-    auto ctorRegExp(std::vector<std::string> v, AttributeSetPtr attrs, const Meta& meta = {}) {
-        return hilti::ctor::RegExp::create(context(), std::move(v), std::move(attrs), meta);
+    auto ctorRegExp(std::vector<std::string> v, AttributeSet* attrs, const Meta& meta = {}) {
+        return hilti::ctor::RegExp::create(context(), std::move(v), attrs, meta);
     }
-    auto ctorResult(const ExpressionPtr& expr, const Meta& meta = {}) {
+    auto ctorResult(Expression* expr, const Meta& meta = {}) {
         return hilti::ctor::Result::create(context(), expr, meta);
     }
-    auto ctorSet(Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::Set::create(context(), std::move(exprs), meta);
+    auto ctorSet(Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::Set::create(context(), std::move(exprs), std::move(meta));
     }
-    auto ctorSet(const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::Set::create(context(), etype, std::move(exprs), meta);
+    auto ctorSet(QualifiedType* etype, Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::Set::create(context(), etype, std::move(exprs), std::move(meta));
     }
     auto ctorSignedInteger(int64_t value, unsigned int width, const Meta& meta = {}) {
         return hilti::ctor::SignedInteger::create(context(), value, width, meta);
@@ -124,91 +122,88 @@ public:
     auto ctorString(std::string value, bool is_literal, const Meta& meta = {}) {
         return hilti::ctor::String::create(context(), std::move(value), is_literal, meta);
     }
-    auto ctorStrongReference(const QualifiedTypePtr& t, const Meta& meta = {}) {
+    auto ctorStrongReference(QualifiedType* t, const Meta& meta = {}) {
         return hilti::ctor::StrongReference::create(context(), t, meta);
     }
-    auto ctorStruct(ctor::struct_::Fields fields, QualifiedTypePtr t, const Meta& meta = {}) {
-        return hilti::ctor::Struct::create(context(), std::move(fields), std::move(t), meta);
+    auto ctorStruct(ctor::struct_::Fields fields, QualifiedType* t, Meta meta = {}) {
+        return hilti::ctor::Struct::create(context(), std::move(fields), t, std::move(meta));
     }
     auto ctorStruct(ctor::struct_::Fields fields, const Meta& meta = {}) {
         return hilti::ctor::Struct::create(context(), std::move(fields), meta);
     }
-    auto ctorStructField(ID id, const ExpressionPtr& expr, Meta meta = {}) {
+    auto ctorStructField(ID id, Expression* expr, Meta meta = {}) {
         return hilti::ctor::struct_::Field::create(context(), std::move(id), expr, std::move(meta));
     }
     auto ctorTime(hilti::rt::Time v, const Meta& meta = {}) { return hilti::ctor::Time::create(context(), v, meta); }
-    auto ctorTuple(const Expressions& exprs, const Meta& meta = {}) {
-        return hilti::ctor::Tuple::create(context(), exprs, meta);
+    auto ctorTuple(const Expressions& exprs, Meta meta = {}) {
+        return hilti::ctor::Tuple::create(context(), exprs, std::move(meta));
     }
-    auto ctorUnion(const QualifiedTypePtr& type, const ExpressionPtr& value, const Meta& meta = {}) {
-        return hilti::ctor::Union::create(context(), type, value, meta);
+    auto ctorUnion(QualifiedType* type, Expression* value, Meta meta = {}) {
+        return hilti::ctor::Union::create(context(), type, value, std::move(meta));
     }
     auto ctorUnsignedInteger(uint64_t value, unsigned int width, const Meta& meta = {}) {
         return hilti::ctor::UnsignedInteger::create(context(), value, width, meta);
     }
-    auto ctorUnsignedInteger(uint64_t value, unsigned int width, const UnqualifiedTypePtr& t, const Meta& meta = {}) {
-        return hilti::ctor::UnsignedInteger::create(context(), value, width, t, meta);
+    auto ctorUnsignedInteger(uint64_t value, unsigned int width, UnqualifiedType* t, Meta meta = {}) {
+        return hilti::ctor::UnsignedInteger::create(context(), value, width, t, std::move(meta));
     }
-    auto ctorValueReference(const ExpressionPtr& expr, const Meta& meta = {}) {
-        return hilti::ctor::ValueReference::create(context(), expr, meta);
+    auto ctorValueReference(Expression* expr, Meta meta = {}) {
+        return hilti::ctor::ValueReference::create(context(), expr, std::move(meta));
     }
-    auto ctorVector(Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::Vector::create(context(), std::move(exprs), meta);
+    auto ctorVector(Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::Vector::create(context(), std::move(exprs), std::move(meta));
     }
-    auto ctorVector(const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
-        return hilti::ctor::Vector::create(context(), etype, std::move(exprs), meta);
+    auto ctorVector(QualifiedType* etype, Expressions exprs, Meta meta = {}) {
+        return hilti::ctor::Vector::create(context(), etype, std::move(exprs), std::move(meta));
     }
-    auto ctorWeakReference(const QualifiedTypePtr& t, const Meta& meta = {}) {
+    auto ctorWeakReference(QualifiedType* t, const Meta& meta = {}) {
         return hilti::ctor::WeakReference::create(context(), t, meta);
     }
-    auto declarationConstant(ID id, const ExpressionPtr& value,
-                             declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
+    auto declarationConstant(ID id, Expression* value, declaration::Linkage linkage = declaration::Linkage::Private,
+                             Meta meta = {}) {
         return hilti::declaration::Constant::create(context(), std::move(id), value, linkage, std::move(meta));
     }
-    auto declarationConstant(ID id, const QualifiedTypePtr& type, const ExpressionPtr& value,
+    auto declarationConstant(ID id, QualifiedType* type, Expression* value,
                              declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
         return hilti::declaration::Constant::create(context(), std::move(id), type, value, linkage, std::move(meta));
     }
-    auto declarationExpression(ID id, const ExpressionPtr& expr, AttributeSetPtr attrs, declaration::Linkage linkage,
+    auto declarationExpression(ID id, Expression* expr, AttributeSet* attrs, declaration::Linkage linkage,
                                Meta meta = {}) {
-        return hilti::declaration::Expression::create(context(), std::move(id), expr, std::move(attrs), linkage,
-                                                      std::move(meta));
+        return hilti::declaration::Expression::create(context(), std::move(id), expr, attrs, linkage, std::move(meta));
     }
-    auto declarationExpression(ID id, const ExpressionPtr& expr, declaration::Linkage linkage, Meta meta = {}) {
+    auto declarationExpression(ID id, Expression* expr, declaration::Linkage linkage, Meta meta = {}) {
         return hilti::declaration::Expression::create(context(), std::move(id), expr, linkage, std::move(meta));
     }
-    auto declarationField(ID id, ::hilti::function::CallingConvention cc, const type::FunctionPtr& ftype,
-                          AttributeSetPtr attrs, Meta meta = {}) {
-        return hilti::declaration::Field::create(context(), std::move(id), cc, ftype, std::move(attrs),
-                                                 std::move(meta));
+    auto declarationField(ID id, ::hilti::function::CallingConvention cc, type::Function* ftype, AttributeSet* attrs,
+                          Meta meta = {}) {
+        return hilti::declaration::Field::create(context(), std::move(id), cc, ftype, attrs, std::move(meta));
     }
-    auto declarationField(ID id, QualifiedTypePtr type, AttributeSetPtr attrs, Meta meta = {}) {
-        return hilti::declaration::Field::create(context(), std::move(id), std::move(type), std::move(attrs),
-                                                 std::move(meta));
+    auto declarationField(ID id, QualifiedType* type, AttributeSet* attrs, Meta meta = {}) {
+        return hilti::declaration::Field::create(context(), std::move(id), type, attrs, std::move(meta));
     }
-    auto declarationField(const ID& id, const FunctionPtr& inline_func, AttributeSetPtr attrs, Meta meta = {}) {
-        return hilti::declaration::Field::create(context(), id, inline_func, std::move(attrs), std::move(meta));
+    auto declarationField(const ID& id, Function* inline_func, AttributeSet* attrs, Meta meta = {}) {
+        return hilti::declaration::Field::create(context(), id, inline_func, attrs, std::move(meta));
     }
-    auto declarationFunction(const FunctionPtr& function, declaration::Linkage linkage = declaration::Linkage::Private,
-                             const Meta& meta = {}) {
-        return hilti::declaration::Function::create(context(), function, linkage, meta);
+    auto declarationFunction(hilti::Function* function, declaration::Linkage linkage = declaration::Linkage::Private,
+                             Meta meta = {}) {
+        return hilti::declaration::Function::create(context(), function, linkage, std::move(meta));
     }
-    auto declarationGlobalVariable(ID id, const ExpressionPtr& init,
+    auto declarationGlobalVariable(ID id, Expression* init,
                                    declaration::Linkage linkage = declaration::Linkage::Private,
                                    const Meta& meta = {}) {
         return hilti::declaration::GlobalVariable::create(context(), std::move(id), init, linkage, meta);
     }
-    auto declarationGlobalVariable(ID id, const QualifiedTypePtr& type, ExpressionPtr init = nullptr,
+    auto declarationGlobalVariable(ID id, QualifiedType* type, Expression* init = nullptr,
                                    declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
-        return hilti::declaration::GlobalVariable::create(context(), std::move(id), type, std::move(init), linkage,
+        return hilti::declaration::GlobalVariable::create(context(), std::move(id), type, init, linkage,
                                                           std::move(meta));
     }
-    auto declarationGlobalVariable(ID id, const QualifiedTypePtr& type, Expressions args, ExpressionPtr init = nullptr,
+    auto declarationGlobalVariable(ID id, QualifiedType* type, Expressions args, Expression* init = nullptr,
                                    declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
-        return hilti::declaration::GlobalVariable::create(context(), std::move(id), type, std::move(args),
-                                                          std::move(init), linkage, std::move(meta));
+        return hilti::declaration::GlobalVariable::create(context(), std::move(id), type, std::move(args), init,
+                                                          linkage, std::move(meta));
     }
-    auto declarationGlobalVariable(ID id, const QualifiedTypePtr& type,
+    auto declarationGlobalVariable(ID id, QualifiedType* type,
                                    declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
         return hilti::declaration::GlobalVariable::create(context(), std::move(id), type, linkage, std::move(meta));
     }
@@ -226,130 +221,127 @@ public:
     auto declarationImportedModule(ID id, hilti::rt::filesystem::path path, Meta meta = {}) {
         return hilti::declaration::ImportedModule::create(context(), std::move(id), std::move(path), std::move(meta));
     }
-    auto declarationLocalVariable(ID id, ExpressionPtr init, const Meta& meta = {}) {
-        return hilti::declaration::LocalVariable::create(context(), std::move(id), std::move(init), meta);
+    auto declarationLocalVariable(ID id, Expression* init, const Meta& meta = {}) {
+        return hilti::declaration::LocalVariable::create(context(), std::move(id), init, meta);
     }
     auto declarationLocalVariable(ID id, const Meta& meta = {}) {
         return hilti::declaration::LocalVariable::create(context(), std::move(id), meta);
     }
-    auto declarationLocalVariable(ID id, const QualifiedTypePtr& type, ExpressionPtr init, Meta meta = {}) {
-        return hilti::declaration::LocalVariable::create(context(), std::move(id), type, std::move(init),
+    auto declarationLocalVariable(ID id, QualifiedType* type, Expression* init, Meta meta = {}) {
+        return hilti::declaration::LocalVariable::create(context(), std::move(id), type, init, std::move(meta));
+    }
+    auto declarationLocalVariable(ID id, QualifiedType* type, Expressions args, Expression* init = nullptr,
+                                  Meta meta = {}) {
+        return hilti::declaration::LocalVariable::create(context(), std::move(id), type, std::move(args), init,
                                                          std::move(meta));
     }
-    auto declarationLocalVariable(ID id, const QualifiedTypePtr& type, Expressions args, ExpressionPtr init = nullptr,
-                                  Meta meta = {}) {
-        return hilti::declaration::LocalVariable::create(context(), std::move(id), type, std::move(args),
-                                                         std::move(init), std::move(meta));
-    }
-    auto declarationLocalVariable(ID id, const QualifiedTypePtr& type, Meta meta = {}) {
+    auto declarationLocalVariable(ID id, QualifiedType* type, Meta meta = {}) {
         return hilti::declaration::LocalVariable::create(context(), std::move(id), type, std::move(meta));
     }
-    auto declarationModule(const declaration::module::UID& uid, const ID& scope = {}, const Meta& meta = {}) {
-        return hilti::declaration::Module::create(context(), uid, scope, meta);
+    auto declarationModule(const declaration::module::UID& uid, const ID& scope = {}, Meta meta = {}) {
+        return hilti::declaration::Module::create(context(), uid, scope, std::move(meta));
     }
     auto declarationModule(const declaration::module::UID& uid, const ID& scope, const Declarations& decls,
-                           Statements stmts, const Meta& meta = {}) {
-        return hilti::declaration::Module::create(context(), uid, scope, decls, std::move(stmts), meta);
+                           Statements stmts, Meta meta = {}) {
+        return hilti::declaration::Module::create(context(), uid, scope, decls, std::move(stmts), std::move(meta));
     }
     auto declarationModule(const declaration::module::UID& uid, const ID& scope, const Declarations& decls,
-                           const Meta& meta = {}) {
-        return hilti::declaration::Module::create(context(), uid, scope, decls, meta);
+                           Meta meta = {}) {
+        return hilti::declaration::Module::create(context(), uid, scope, decls, std::move(meta));
     }
-    auto declarationParameter(ID id, const UnqualifiedTypePtr& type, parameter::Kind kind,
-                              const hilti::ExpressionPtr& default_, AttributeSetPtr attrs, Meta meta = {}) {
-        return hilti::declaration::Parameter::create(context(), std::move(id), type, kind, default_, std::move(attrs),
+    auto declarationParameter(ID id, UnqualifiedType* type, parameter::Kind kind, hilti::Expression* default_,
+                              AttributeSet* attrs, Meta meta = {}) {
+        return hilti::declaration::Parameter::create(context(), std::move(id), type, kind, default_, attrs,
                                                      std::move(meta));
     }
-    auto declarationParameter(ID id, const UnqualifiedTypePtr& type, parameter::Kind kind,
-                              const hilti::ExpressionPtr& default_, bool is_type_param, AttributeSetPtr attrs,
-                              Meta meta = {}) {
+    auto declarationParameter(ID id, UnqualifiedType* type, parameter::Kind kind, hilti::Expression* default_,
+                              bool is_type_param, AttributeSet* attrs, Meta meta = {}) {
         return hilti::declaration::Parameter::create(context(), std::move(id), type, kind, default_, is_type_param,
-                                                     std::move(attrs), std::move(meta));
+                                                     attrs, std::move(meta));
     }
     auto declarationProperty(ID id, Meta meta = {}) {
         return hilti::declaration::Property::create(context(), std::move(id), std::move(meta));
     }
-    auto declarationProperty(ID id, const ExpressionPtr& expr, Meta meta = {}) {
+    auto declarationProperty(ID id, Expression* expr, Meta meta = {}) {
         return hilti::declaration::Property::create(context(), std::move(id), expr, std::move(meta));
     }
-    auto declarationType(ID id, const QualifiedTypePtr& type, AttributeSetPtr attrs,
+    auto declarationType(ID id, QualifiedType* type, AttributeSet* attrs,
                          declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
-        return hilti::declaration::Type::create(context(), std::move(id), type, std::move(attrs), linkage,
-                                                std::move(meta));
+        return hilti::declaration::Type::create(context(), std::move(id), type, attrs, linkage, std::move(meta));
     }
-    auto declarationType(ID id, const QualifiedTypePtr& type,
-                         declaration::Linkage linkage = declaration::Linkage::Private, Meta meta = {}) {
+    auto declarationType(ID id, QualifiedType* type, declaration::Linkage linkage = declaration::Linkage::Private,
+                         Meta meta = {}) {
         return hilti::declaration::Type::create(context(), std::move(id), type, linkage, std::move(meta));
     }
-    auto expressionAssign(const ExpressionPtr& target, const ExpressionPtr& src, const Meta& meta = {}) {
-        return hilti::expression::Assign::create(context(), target, src, meta);
+    auto expressionAssign(Expression* target, Expression* src, Meta meta = {}) {
+        return hilti::expression::Assign::create(context(), target, src, std::move(meta));
     }
-    auto expressionBuiltInFunction(const std::string& name, const std::string& cxxname, const QualifiedTypePtr& type,
+    auto expressionBuiltInFunction(const std::string& name, const std::string& cxxname, QualifiedType* type,
                                    const type::function::Parameters& parameters, const Expressions& arguments,
-                                   const Meta& meta = {}) {
-        return hilti::expression::BuiltInFunction::create(context(), name, cxxname, type, parameters, arguments, meta);
+                                   Meta meta = {}) {
+        return hilti::expression::BuiltInFunction::create(context(), name, cxxname, type, parameters, arguments,
+                                                          std::move(meta));
     }
-    auto expressionCoerced(const ExpressionPtr& expr, const QualifiedTypePtr& target, const Meta& meta = {}) {
-        return hilti::expression::Coerced::create(context(), expr, target, meta);
+    auto expressionCoerced(Expression* expr, QualifiedType* target, Meta meta = {}) {
+        return hilti::expression::Coerced::create(context(), expr, target, std::move(meta));
     }
-    auto expressionCtor(const CtorPtr& ctor, const Meta& meta = {}) {
-        return hilti::expression::Ctor::create(context(), ctor, meta);
+    auto expressionCtor(Ctor* ctor, Meta meta = {}) {
+        return hilti::expression::Ctor::create(context(), ctor, std::move(meta));
     }
-    auto expressionDeferred(const ExpressionPtr& expr, bool catch_exception, const Meta& meta = {}) {
+    auto expressionDeferred(Expression* expr, bool catch_exception, const Meta& meta = {}) {
         return hilti::expression::Deferred::create(context(), expr, catch_exception, meta);
     }
-    auto expressionDeferred(const ExpressionPtr& expr, const Meta& meta = {}) {
+    auto expressionDeferred(Expression* expr, const Meta& meta = {}) {
         return hilti::expression::Deferred::create(context(), expr, meta);
     }
-    auto expressionGrouping(const ExpressionPtr& expr, const Meta& meta = {}) {
-        return hilti::expression::Grouping::create(context(), expr, meta);
+    auto expressionGrouping(Expression* expr, Meta meta = {}) {
+        return hilti::expression::Grouping::create(context(), expr, std::move(meta));
     }
     auto expressionKeyword(expression::keyword::Kind kind, const Meta& meta = {}) {
         return hilti::expression::Keyword::create(context(), kind, meta);
     }
-    auto expressionKeyword(expression::keyword::Kind kind, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return hilti::expression::Keyword::create(context(), kind, type, meta);
+    auto expressionKeyword(expression::keyword::Kind kind, QualifiedType* type, Meta meta = {}) {
+        return hilti::expression::Keyword::create(context(), kind, type, std::move(meta));
     }
-    auto expressionListComprehension(const ExpressionPtr& input, const ExpressionPtr& output, const ID& id,
-                                     const ExpressionPtr& cond, const Meta& meta = {}) {
-        return hilti::expression::ListComprehension::create(context(), input, output, id, cond, meta);
+    auto expressionListComprehension(Expression* input, Expression* output, const ID& id, Expression* cond,
+                                     Meta meta = {}) {
+        return hilti::expression::ListComprehension::create(context(), input, output, id, cond, std::move(meta));
     }
-    auto expressionLogicalAnd(const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& meta = {}) {
+    auto expressionLogicalAnd(Expression* op0, Expression* op1, const Meta& meta = {}) {
         return hilti::expression::LogicalAnd::create(context(), op0, op1, meta);
     }
-    auto expressionLogicalNot(const ExpressionPtr& expression, const Meta& meta = {}) {
+    auto expressionLogicalNot(Expression* expression, const Meta& meta = {}) {
         return hilti::expression::LogicalNot::create(context(), expression, meta);
     }
-    auto expressionLogicalOr(const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& meta = {}) {
+    auto expressionLogicalOr(Expression* op0, Expression* op1, const Meta& meta = {}) {
         return hilti::expression::LogicalOr::create(context(), op0, op1, meta);
     }
-    auto expressionMember(const QualifiedTypePtr& member_type, const hilti::ID& id, const Meta& meta = {}) {
-        return hilti::expression::Member::create(context(), member_type, id, meta);
+    auto expressionMember(QualifiedType* member_type, const hilti::ID& id, Meta meta = {}) {
+        return hilti::expression::Member::create(context(), member_type, id, std::move(meta));
     }
     auto expressionMember(const hilti::ID& id, const Meta& meta = {}) {
         return hilti::expression::Member::create(context(), id, meta);
     }
-    auto expressionMove(const ExpressionPtr& expression, const Meta& meta = {}) {
-        return hilti::expression::Move::create(context(), expression, meta);
+    auto expressionMove(Expression* expression, Meta meta = {}) {
+        return hilti::expression::Move::create(context(), expression, std::move(meta));
     }
     auto expressionName(const hilti::ID& id, const Meta& meta = {}) {
         return hilti::expression::Name::create(context(), id, meta);
     }
-    auto expressionPendingCoerced(const ExpressionPtr& expr, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return hilti::expression::PendingCoerced::create(context(), expr, type, meta);
+    auto expressionPendingCoerced(Expression* expr, QualifiedType* type, Meta meta = {}) {
+        return hilti::expression::PendingCoerced::create(context(), expr, type, std::move(meta));
     }
-    auto expressionTernary(const ExpressionPtr& cond, const ExpressionPtr& true_, const ExpressionPtr& false_,
-                           const Meta& meta = {}) {
-        return hilti::expression::Ternary::create(context(), cond, true_, false_, meta);
+    auto expressionTernary(Expression* cond, Expression* true_, Expression* false_, Meta meta = {}) {
+        return hilti::expression::Ternary::create(context(), cond, true_, false_, std::move(meta));
     }
-    auto expressionType(const QualifiedTypePtr& type, const Meta& meta = {}) {
+    auto expressionType(QualifiedType* type, const Meta& meta = {}) {
         return hilti::expression::Type_::create(context(), type, meta);
     }
-    auto expressionTypeInfo(const ExpressionPtr& expr, const Meta& meta = {}) {
-        return hilti::expression::TypeInfo::create(context(), expr, meta);
+    auto expressionTypeInfo(Expression* expr, Meta meta = {}) {
+        return hilti::expression::TypeInfo::create(context(), expr, std::move(meta));
     }
-    auto expressionTypeWrapped(const ExpressionPtr& expr, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return hilti::expression::TypeWrapped::create(context(), expr, type, meta);
+    auto expressionTypeWrapped(Expression* expr, QualifiedType* type, Meta meta = {}) {
+        return hilti::expression::TypeWrapped::create(context(), expr, type, std::move(meta));
     }
     auto expressionUnresolvedOperator(operator_::Kind kind, Expressions operands, const Meta& meta = {}) {
         return hilti::expression::UnresolvedOperator::create(context(), kind, std::move(operands), meta);
@@ -359,25 +351,25 @@ public:
         return hilti::expression::UnresolvedOperator::create(context(), kind, operands, meta);
     }
     auto expressionVoid(const Meta& meta = {}) { return hilti::expression::Void::create(context(), meta); }
-    auto function(const ID& id, const type::FunctionPtr& ftype, const StatementPtr& body,
-                  function::CallingConvention cc = function::CallingConvention::Standard,
-                  AttributeSetPtr attrs = nullptr, const Meta& meta = {}) {
-        return hilti::Function::create(context(), id, ftype, body, cc, std::move(attrs), meta);
+    auto function(const ID& id, type::Function* ftype, Statement* body,
+                  function::CallingConvention cc = function::CallingConvention::Standard, AttributeSet* attrs = nullptr,
+                  const Meta& meta = {}) {
+        return hilti::Function::create(context(), id, ftype, body, cc, attrs, meta);
     }
-    auto qualifiedType(const UnqualifiedTypePtr& t, Constness const_, Meta m = Meta()) {
+    auto qualifiedType(UnqualifiedType* t, Constness const_, Meta m = Meta()) {
         return hilti::QualifiedType::create(context(), t, const_, std::move(m));
     }
-    auto qualifiedType(const UnqualifiedTypePtr& t, Constness const_, Side side, const Meta& m = Meta()) {
+    auto qualifiedType(UnqualifiedType* t, Constness const_, Side side, const Meta& m = Meta()) {
         return hilti::QualifiedType::create(context(), t, const_, side, m);
     }
-    auto statementAssert(const ExpressionPtr& expr, const ExpressionPtr& msg = nullptr, Meta meta = {}) {
+    auto statementAssert(Expression* expr, Expression* msg = nullptr, Meta meta = {}) {
         return hilti::statement::Assert::create(context(), expr, msg, std::move(meta));
     }
-    auto statementAssert(statement::assert::Exception _unused, const ExpressionPtr& expr,
-                         const UnqualifiedTypePtr& excpt, const ExpressionPtr& msg = nullptr, const Meta& meta = {}) {
-        return hilti::statement::Assert::create(context(), _unused, expr, excpt, msg, meta);
+    auto statementAssert(statement::assert::Exception _unused, Expression* expr, UnqualifiedType* excpt,
+                         Expression* msg = nullptr, Meta meta = {}) {
+        return hilti::statement::Assert::create(context(), _unused, expr, excpt, msg, std::move(meta));
     }
-    auto statementBlock(Meta meta = {}) { return hilti::statement::Block::create(context(), std::move(meta)); }
+    auto statementBlock(const Meta& meta = {}) { return hilti::statement::Block::create(context(), meta); }
     auto statementBlock(Statements stmts, Meta meta = {}) {
         return hilti::statement::Block::create(context(), std::move(stmts), std::move(meta));
     }
@@ -388,115 +380,113 @@ public:
         return hilti::statement::Comment::create(context(), std::move(comment), separator, std::move(meta));
     }
     auto statementContinue(Meta meta = {}) { return hilti::statement::Continue::create(context(), std::move(meta)); }
-    auto statementDeclaration(const hilti::DeclarationPtr& d, Meta meta = {}) {
+    auto statementDeclaration(hilti::Declaration* d, Meta meta = {}) {
         return hilti::statement::Declaration::create(context(), d, std::move(meta));
     }
-    auto statementExpression(const ExpressionPtr& e, Meta meta = {}) {
+    auto statementExpression(Expression* e, Meta meta = {}) {
         return hilti::statement::Expression::create(context(), e, std::move(meta));
     }
-    auto statementFor(const hilti::ID& id, const ExpressionPtr& seq, const StatementPtr& body, Meta meta = {}) {
+    auto statementFor(const hilti::ID& id, Expression* seq, Statement* body, Meta meta = {}) {
         return hilti::statement::For::create(context(), id, seq, body, std::move(meta));
     }
-    auto statementIf(const DeclarationPtr& init, const ExpressionPtr& cond, const StatementPtr& true_,
-                     const StatementPtr& false_, Meta meta = {}) {
+    auto statementIf(Declaration* init, Expression* cond, Statement* true_, Statement* false_, Meta meta = {}) {
         return hilti::statement::If::create(context(), init, cond, true_, false_, std::move(meta));
     }
-    auto statementIf(const ExpressionPtr& cond, const StatementPtr& true_, const StatementPtr& false_, Meta meta = {}) {
+    auto statementIf(Expression* cond, Statement* true_, Statement* false_, Meta meta = {}) {
         return hilti::statement::If::create(context(), cond, true_, false_, std::move(meta));
     }
     auto statementReturn(Meta meta = {}) { return hilti::statement::Return::create(context(), std::move(meta)); }
-    auto statementReturn(const ExpressionPtr& expr, Meta meta = {}) {
+    auto statementReturn(Expression* expr, Meta meta = {}) {
         return hilti::statement::Return::create(context(), expr, std::move(meta));
     }
-    auto statementSetLocation(const ExpressionPtr& expr, Meta meta = {}) {
+    auto statementSetLocation(Expression* expr, Meta meta = {}) {
         return hilti::statement::SetLocation::create(context(), expr, std::move(meta));
     }
-    auto statementSwitch(DeclarationPtr cond, const statement::switch_::Cases& cases, Meta meta = {}) {
-        return hilti::statement::Switch::create(context(), std::move(cond), cases, std::move(meta));
-    }
-    auto statementSwitch(const ExpressionPtr& cond, const statement::switch_::Cases& cases, Meta meta = {}) {
+    auto statementSwitch(Declaration* cond, const statement::switch_::Cases& cases, Meta meta = {}) {
         return hilti::statement::Switch::create(context(), cond, cases, std::move(meta));
     }
-    auto statementSwitchCase(const ExpressionPtr& expr, const StatementPtr& body, Meta meta = {}) {
+    auto statementSwitch(Expression* cond, const statement::switch_::Cases& cases, Meta meta = {}) {
+        return hilti::statement::Switch::create(context(), cond, cases, std::move(meta));
+    }
+    auto statementSwitchCase(Expression* expr, Statement* body, Meta meta = {}) {
         return hilti::statement::switch_::Case::create(context(), expr, body, std::move(meta));
     }
-    auto statementSwitchCase(const Expressions& exprs, const StatementPtr& body, Meta meta = {}) {
+    auto statementSwitchCase(const Expressions& exprs, Statement* body, Meta meta = {}) {
         return hilti::statement::switch_::Case::create(context(), exprs, body, std::move(meta));
     }
-    auto statementSwitchCase(statement::switch_::Default _unused, const StatementPtr& body, Meta meta = {}) {
+    auto statementSwitchCase(statement::switch_::Default _unused, Statement* body, Meta meta = {}) {
         return hilti::statement::switch_::Case::create(context(), _unused, body, std::move(meta));
     }
     auto statementThrow(Meta meta = {}) { return hilti::statement::Throw::create(context(), std::move(meta)); }
-    auto statementThrow(const ExpressionPtr& expr, Meta meta = {}) {
+    auto statementThrow(Expression* expr, Meta meta = {}) {
         return hilti::statement::Throw::create(context(), expr, std::move(meta));
     }
-    auto statementTry(StatementPtr body, const statement::try_::Catches& catches, Meta meta = {}) {
-        return hilti::statement::Try::create(context(), std::move(body), catches, std::move(meta));
+    auto statementTry(Statement* body, const statement::try_::Catches& catches, Meta meta = {}) {
+        return hilti::statement::Try::create(context(), body, catches, std::move(meta));
     }
-    auto statementTryCatch(const DeclarationPtr& param, const StatementPtr& body, Meta meta = {}) {
+    auto statementTryCatch(Declaration* param, Statement* body, Meta meta = {}) {
         return hilti::statement::try_::Catch::create(context(), param, body, std::move(meta));
     }
-    auto statementTryCatch(const StatementPtr& body, Meta meta = {}) {
+    auto statementTryCatch(Statement* body, Meta meta = {}) {
         return hilti::statement::try_::Catch::create(context(), body, std::move(meta));
     }
-    auto statementWhile(const DeclarationPtr& init, const ExpressionPtr& cond, const StatementPtr& body,
-                        const StatementPtr& else_ = nullptr, const Meta& meta = {}) {
-        return hilti::statement::While::create(context(), init, cond, body, else_, meta);
+    auto statementWhile(Declaration* init, Expression* cond, Statement* body, Statement* else_ = nullptr,
+                        Meta meta = {}) {
+        return hilti::statement::While::create(context(), init, cond, body, else_, std::move(meta));
     }
-    auto statementWhile(const ExpressionPtr& cond, const StatementPtr& body, const Meta& meta = {}) {
-        return hilti::statement::While::create(context(), cond, body, meta);
+    auto statementWhile(Expression* cond, Statement* body, Meta meta = {}) {
+        return hilti::statement::While::create(context(), cond, body, std::move(meta));
     }
-    auto statementWhile(const ExpressionPtr& cond, const StatementPtr& body, const StatementPtr& else_ = nullptr,
-                        const Meta& meta = {}) {
-        return hilti::statement::While::create(context(), cond, body, else_, meta);
+    auto statementWhile(Expression* cond, Statement* body, Statement* else_ = nullptr, Meta meta = {}) {
+        return hilti::statement::While::create(context(), cond, body, else_, std::move(meta));
     }
     auto statementYield(Meta meta = {}) { return hilti::statement::Yield::create(context(), std::move(meta)); }
     auto typeAddress(const Meta& m = Meta()) { return hilti::type::Address::create(context(), m); }
     auto typeAny(Meta m = Meta()) { return hilti::type::Any::create(context(), std::move(m)); }
     auto typeAuto(const Meta& m = Meta()) { return hilti::type::Auto::create(context(), m); }
-    auto typeBitfield(int width, type::bitfield::BitRanges bits, AttributeSetPtr attrs, const Meta& m = Meta()) {
-        return hilti::type::Bitfield::create(context(), width, std::move(bits), std::move(attrs), m);
+    auto typeBitfield(int width, type::bitfield::BitRanges bits, AttributeSet* attrs, const Meta& m = Meta()) {
+        return hilti::type::Bitfield::create(context(), width, std::move(bits), attrs, m);
     }
     auto typeBitfield(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::Bitfield::create(context(), _, m);
     }
-    auto typeBitfieldBitRange(const ID& id, int lower, int upper, int field_width, AttributeSetPtr attrs = {},
-                              const ExpressionPtr& ctor_value = nullptr, const Meta& meta = Meta()) {
-        return hilti::type::bitfield::BitRange::create(context(), id, lower, upper, field_width, std::move(attrs),
-                                                       ctor_value, meta);
+    auto typeBitfieldBitRange(const ID& id, int lower, int upper, int field_width, AttributeSet* attrs = {},
+                              Expression* ctor_value = nullptr, Meta meta = Meta()) {
+        return hilti::type::bitfield::BitRange::create(context(), id, lower, upper, field_width, attrs, ctor_value,
+                                                       std::move(meta));
     }
-    auto typeBitfieldBitRange(const ID& id, int lower, int upper, int field_width, AttributeSetPtr attrs = {},
-                              const Meta& meta = Meta()) {
-        return hilti::type::bitfield::BitRange::create(context(), id, lower, upper, field_width, std::move(attrs),
-                                                       meta);
+    auto typeBitfieldBitRange(const ID& id, int lower, int upper, int field_width, AttributeSet* attrs = {},
+                              Meta meta = Meta()) {
+        return hilti::type::bitfield::BitRange::create(context(), id, lower, upper, field_width, attrs,
+                                                       std::move(meta));
     }
-    auto typeBool(const Meta& meta = {}) { return hilti::type::Bool::create(context(), meta); }
+    auto typeBool(Meta meta = {}) { return hilti::type::Bool::create(context(), std::move(meta)); }
     auto typeBytes(const Meta& meta = {}) { return hilti::type::Bytes::create(context(), meta); }
-    auto typeBytesIterator(const Meta& meta = {}) { return hilti::type::bytes::Iterator::create(context(), meta); }
-    auto typeDocOnly(const std::string& description, const Meta& meta = {}) {
-        return hilti::type::DocOnly::create(context(), description, meta);
+    auto typeBytesIterator(Meta meta = {}) { return hilti::type::bytes::Iterator::create(context(), std::move(meta)); }
+    auto typeDocOnly(const std::string& description, Meta meta = {}) {
+        return hilti::type::DocOnly::create(context(), description, std::move(meta));
     }
     auto typeEnum(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Enum::create(context(), _, m); }
     auto typeEnum(type::enum_::Labels labels, Meta meta = {}) {
         return hilti::type::Enum::create(context(), std::move(labels), std::move(meta));
     }
-    auto typeEnumLabel(const ID& id, const Meta& meta = {}) {
-        return hilti::type::enum_::Label::create(context(), id, meta);
+    auto typeEnumLabel(const ID& id, Meta meta = {}) {
+        return hilti::type::enum_::Label::create(context(), id, std::move(meta));
     }
-    auto typeEnumLabel(const ID& id, int value, const Meta& meta = {}) {
-        return hilti::type::enum_::Label::create(context(), id, value, meta);
+    auto typeEnumLabel(const ID& id, int value, Meta meta = {}) {
+        return hilti::type::enum_::Label::create(context(), id, value, std::move(meta));
     }
     auto typeError(Meta meta = {}) { return hilti::type::Error::create(context(), std::move(meta)); }
-    auto typeException(const Meta& meta = {}) { return hilti::type::Exception::create(context(), meta); }
-    auto typeException(const UnqualifiedTypePtr& base, Meta meta = {}) {
+    auto typeException(Meta meta = {}) { return hilti::type::Exception::create(context(), std::move(meta)); }
+    auto typeException(UnqualifiedType* base, Meta meta = {}) {
         return hilti::type::Exception::create(context(), base, std::move(meta));
     }
     auto typeException(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::Exception::create(context(), _, m);
     }
-    auto typeFunction(const QualifiedTypePtr& result, const declaration::Parameters& params,
-                      type::function::Flavor flavor = type::function::Flavor::Standard, const Meta& meta = {}) {
-        return hilti::type::Function::create(context(), result, params, flavor, meta);
+    auto typeFunction(QualifiedType* result, const declaration::Parameters& params,
+                      type::function::Flavor flavor = type::function::Flavor::Standard, Meta meta = {}) {
+        return hilti::type::Function::create(context(), result, params, flavor, std::move(meta));
     }
     auto typeFunction(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::Function::create(context(), _, m);
@@ -505,21 +495,19 @@ public:
     auto typeLibrary(const std::string& cxx_name, Meta meta = {}) {
         return hilti::type::Library::create(context(), cxx_name, std::move(meta));
     }
-    auto typeList(const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return hilti::type::List::create(context(), t, meta);
-    }
+    auto typeList(QualifiedType* t, const Meta& meta = {}) { return hilti::type::List::create(context(), t, meta); }
     auto typeList(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::List::create(context(), _, m); }
-    auto typeListIterator(const QualifiedTypePtr& etype, Meta meta = {}) {
+    auto typeListIterator(QualifiedType* etype, Meta meta = {}) {
         return hilti::type::list::Iterator::create(context(), etype, std::move(meta));
     }
     auto typeListIterator(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::list::Iterator::create(context(), _, m);
     }
-    auto typeMap(const QualifiedTypePtr& ktype, const QualifiedTypePtr& vtype, const Meta& meta = {}) {
+    auto typeMap(QualifiedType* ktype, QualifiedType* vtype, const Meta& meta = {}) {
         return hilti::type::Map::create(context(), ktype, vtype, meta);
     }
     auto typeMap(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Map::create(context(), _, m); }
-    auto typeMapIterator(const QualifiedTypePtr& ktype, const QualifiedTypePtr& vtype, const Meta& meta = {}) {
+    auto typeMapIterator(QualifiedType* ktype, QualifiedType* vtype, const Meta& meta = {}) {
         return hilti::type::map::Iterator::create(context(), ktype, vtype, meta);
     }
     auto typeMapIterator(type::Wildcard _, const Meta& meta = Meta()) {
@@ -529,7 +517,7 @@ public:
         return hilti::type::Member::create(context(), id, std::move(meta));
     }
     auto typeMember(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Member::create(context(), _, m); }
-    auto typeName(const ID& id, const Meta& meta = {}) { return hilti::type::Name::create(context(), id, meta); }
+    auto typeName(const ID& id, Meta meta = {}) { return hilti::type::Name::create(context(), id, std::move(meta)); }
     auto typeNetwork(Meta meta = {}) { return hilti::type::Network::create(context(), std::move(meta)); }
     auto typeNull(Meta meta = {}) { return hilti::type::Null::create(context(), std::move(meta)); }
     auto typeOperandList(type::Wildcard _, const Meta& m = Meta()) {
@@ -538,28 +526,27 @@ public:
     auto typeOperandList(type::operand_list::Operands operands, Meta meta = {}) {
         return hilti::type::OperandList::create(context(), std::move(operands), std::move(meta));
     }
-    auto typeOperandListOperand(ID id, parameter::Kind kind, const UnqualifiedTypePtr& type, bool optional = false,
+    auto typeOperandListOperand(ID id, parameter::Kind kind, UnqualifiedType* type, bool optional = false,
                                 std::string doc = "", Meta meta = {}) {
         return hilti::type::operand_list::Operand::create(context(), std::move(id), kind, type, optional,
                                                           std::move(doc), std::move(meta));
     }
-    auto typeOperandListOperand(ID id, parameter::Kind kind, const UnqualifiedTypePtr& type,
-                                const ExpressionPtr& default_, bool optional, std::string doc = "",
-                                const Meta& meta = {}) {
+    auto typeOperandListOperand(ID id, parameter::Kind kind, UnqualifiedType* type, Expression* default_, bool optional,
+                                std::string doc = "", Meta meta = {}) {
         return hilti::type::operand_list::Operand::create(context(), std::move(id), kind, type, default_, optional,
-                                                          std::move(doc), meta);
+                                                          std::move(doc), std::move(meta));
     }
-    auto typeOperandListOperand(ID id, parameter::Kind kind, const UnqualifiedTypePtr& type,
-                                const ExpressionPtr& default_, std::string doc = "", const Meta& meta = {}) {
+    auto typeOperandListOperand(ID id, parameter::Kind kind, UnqualifiedType* type, Expression* default_,
+                                std::string doc = "", Meta meta = {}) {
         return hilti::type::operand_list::Operand::create(context(), std::move(id), kind, type, default_,
-                                                          std::move(doc), meta);
+                                                          std::move(doc), std::move(meta));
     }
-    auto typeOperandListOperand(parameter::Kind kind, const UnqualifiedTypePtr& type, bool optional = false,
+    auto typeOperandListOperand(parameter::Kind kind, UnqualifiedType* type, bool optional = false,
                                 std::string doc = "", Meta meta = {}) {
         return hilti::type::operand_list::Operand::create(context(), kind, type, optional, std::move(doc),
                                                           std::move(meta));
     }
-    auto typeOptional(const QualifiedTypePtr& t, Meta m = Meta()) {
+    auto typeOptional(QualifiedType* t, Meta m = Meta()) {
         return hilti::type::Optional::create(context(), t, std::move(m));
     }
     auto typeOptional(type::Wildcard _, const Meta& m = Meta()) {
@@ -568,15 +555,13 @@ public:
     auto typePort(Meta meta = {}) { return hilti::type::Port::create(context(), std::move(meta)); }
     auto typeReal(Meta meta = {}) { return hilti::type::Real::create(context(), std::move(meta)); }
     auto typeRegExp(Meta meta = {}) { return hilti::type::RegExp::create(context(), std::move(meta)); }
-    auto typeResult(const QualifiedTypePtr& t, Meta m = Meta()) {
+    auto typeResult(QualifiedType* t, Meta m = Meta()) {
         return hilti::type::Result::create(context(), t, std::move(m));
     }
     auto typeResult(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Result::create(context(), _, m); }
-    auto typeSet(const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return hilti::type::Set::create(context(), t, meta);
-    }
+    auto typeSet(QualifiedType* t, const Meta& meta = {}) { return hilti::type::Set::create(context(), t, meta); }
     auto typeSet(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Set::create(context(), _, m); }
-    auto typeSetIterator(const QualifiedTypePtr& etype, Meta meta = {}) {
+    auto typeSetIterator(QualifiedType* etype, Meta meta = {}) {
         return hilti::type::set::Iterator::create(context(), etype, std::move(meta));
     }
     auto typeSetIterator(type::Wildcard _, const Meta& m = Meta()) {
@@ -589,53 +574,59 @@ public:
         return hilti::type::SignedInteger::create(context(), width, m);
     }
     auto typeStream(const Meta& meta = {}) { return hilti::type::Stream::create(context(), meta); }
-    auto typeStreamIterator(const Meta& meta = {}) { return hilti::type::stream::Iterator::create(context(), meta); }
+    auto typeStreamIterator(Meta meta = {}) {
+        return hilti::type::stream::Iterator::create(context(), std::move(meta));
+    }
     auto typeStreamView(const Meta& meta = {}) { return hilti::type::stream::View::create(context(), meta); }
     auto typeString(Meta meta = {}) { return hilti::type::String::create(context(), std::move(meta)); }
-    auto typeStrongReference(const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeStrongReference(QualifiedType* type, Meta meta = {}) {
         return hilti::type::StrongReference::create(context(), type, std::move(meta));
     }
     auto typeStrongReference(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::StrongReference::create(context(), _, m);
     }
-    auto typeStruct(const Declarations& fields, const Meta& meta = {}) {
-        return hilti::type::Struct::create(context(), fields, meta);
+    auto typeStruct(const Declarations& fields, Meta meta = {}) {
+        return hilti::type::Struct::create(context(), fields, std::move(meta));
     }
-    auto typeStruct(const declaration::Parameters& params, Declarations fields, const Meta& meta = {}) {
-        return hilti::type::Struct::create(context(), params, std::move(fields), meta);
+    auto typeStruct(const declaration::Parameters& params, Declarations fields, Meta meta = {}) {
+        return hilti::type::Struct::create(context(), params, std::move(fields), std::move(meta));
     }
-    auto typeStruct(type::Struct::AnonymousStruct _, Declarations fields, const Meta& meta = {}) {
-        return hilti::type::Struct::create(context(), _, std::move(fields), meta);
+    auto typeStruct(type::Struct::AnonymousStruct _, Declarations fields, Meta meta = {}) {
+        return hilti::type::Struct::create(context(), _, std::move(fields), std::move(meta));
     }
-    auto typeStruct(type::Wildcard _, const Meta& meta = {}) { return hilti::type::Struct::create(context(), _, meta); }
+    auto typeStruct(type::Wildcard _, Meta meta = {}) {
+        return hilti::type::Struct::create(context(), _, std::move(meta));
+    }
     auto typeTime(Meta meta = {}) { return hilti::type::Time::create(context(), std::move(meta)); }
-    auto typeTuple(const QualifiedTypes& types, const Meta& meta = {}) {
-        return hilti::type::Tuple::create(context(), types, meta);
+    auto typeTuple(const QualifiedTypes& types, Meta meta = {}) {
+        return hilti::type::Tuple::create(context(), types, std::move(meta));
     }
     auto typeTuple(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Tuple::create(context(), _, m); }
     auto typeTuple(type::tuple::Elements elements, Meta meta = {}) {
         return hilti::type::Tuple::create(context(), std::move(elements), std::move(meta));
     }
-    auto typeTupleElement(ID id, const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeTupleElement(ID id, QualifiedType* type, Meta meta = {}) {
         return hilti::type::tuple::Element::create(context(), std::move(id), type, std::move(meta));
     }
-    auto typeTupleElement(const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeTupleElement(QualifiedType* type, Meta meta = {}) {
         return hilti::type::tuple::Element::create(context(), type, std::move(meta));
     }
-    auto typeType(const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeType(QualifiedType* type, Meta meta = {}) {
         return hilti::type::Type_::create(context(), type, std::move(meta));
     }
     auto typeType(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Type_::create(context(), _, m); }
-    auto typeUnion(const Declarations& fields, const Meta& meta = {}) {
-        return hilti::type::Union::create(context(), fields, meta);
+    auto typeUnion(const Declarations& fields, Meta meta = {}) {
+        return hilti::type::Union::create(context(), fields, std::move(meta));
     }
-    auto typeUnion(const declaration::Parameters& params, Declarations fields, const Meta& meta = {}) {
-        return hilti::type::Union::create(context(), params, std::move(fields), meta);
+    auto typeUnion(const declaration::Parameters& params, Declarations fields, Meta meta = {}) {
+        return hilti::type::Union::create(context(), params, std::move(fields), std::move(meta));
     }
-    auto typeUnion(type::Union::AnonymousUnion _, Declarations fields, const Meta& meta = {}) {
-        return hilti::type::Union::create(context(), _, std::move(fields), meta);
+    auto typeUnion(type::Union::AnonymousUnion _, Declarations fields, Meta meta = {}) {
+        return hilti::type::Union::create(context(), _, std::move(fields), std::move(meta));
     }
-    auto typeUnion(type::Wildcard _, const Meta& meta = {}) { return hilti::type::Union::create(context(), _, meta); }
+    auto typeUnion(type::Wildcard _, Meta meta = {}) {
+        return hilti::type::Union::create(context(), _, std::move(meta));
+    }
     auto typeUnknown(Meta meta = {}) { return hilti::type::Unknown::create(context(), std::move(meta)); }
     auto typeUnsignedInteger(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::UnsignedInteger::create(context(), _, m);
@@ -643,24 +634,22 @@ public:
     auto typeUnsignedInteger(unsigned int width, const Meta& m = Meta()) {
         return hilti::type::UnsignedInteger::create(context(), width, m);
     }
-    auto typeValueReference(const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeValueReference(QualifiedType* type, Meta meta = {}) {
         return hilti::type::ValueReference::create(context(), type, std::move(meta));
     }
     auto typeValueReference(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::ValueReference::create(context(), _, m);
     }
-    auto typeVector(const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return hilti::type::Vector::create(context(), t, meta);
-    }
+    auto typeVector(QualifiedType* t, const Meta& meta = {}) { return hilti::type::Vector::create(context(), t, meta); }
     auto typeVector(type::Wildcard _, const Meta& m = Meta()) { return hilti::type::Vector::create(context(), _, m); }
-    auto typeVectorIterator(const QualifiedTypePtr& etype, Meta meta = {}) {
+    auto typeVectorIterator(QualifiedType* etype, Meta meta = {}) {
         return hilti::type::vector::Iterator::create(context(), etype, std::move(meta));
     }
     auto typeVectorIterator(type::Wildcard _, const Meta& m = Meta()) {
         return hilti::type::vector::Iterator::create(context(), _, m);
     }
     auto typeVoid(Meta meta = {}) { return hilti::type::Void::create(context(), std::move(meta)); }
-    auto typeWeakReference(const QualifiedTypePtr& type, Meta meta = {}) {
+    auto typeWeakReference(QualifiedType* type, Meta meta = {}) {
         return hilti::type::WeakReference::create(context(), type, std::move(meta));
     }
     auto typeWeakReference(type::Wildcard _, const Meta& m = Meta()) {

--- a/hilti/toolchain/include/ast/ctor.h
+++ b/hilti/toolchain/include/ast/ctor.h
@@ -16,7 +16,7 @@ public:
     ~Ctor() override;
 
     /** Returns the HILTI type of the constructor's value. */
-    virtual QualifiedTypePtr type() const = 0;
+    virtual QualifiedType* type() const = 0;
 
 protected:
     Ctor(ASTContext* ctx, node::Tags node_tags, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/ctors/address.h
+++ b/hilti/toolchain/include/ast/ctors/address.h
@@ -18,7 +18,7 @@ class Address : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", to_string(_value)}};
@@ -26,9 +26,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, hilti::rt::Address v, const Meta& meta = {}) {
-        return std::shared_ptr<Address>(
-            new Address(ctx, {QualifiedType::create(ctx, type::Address::create(ctx, meta), Constness::Const)}, v,
-                        meta));
+        return ctx->make<Address>(ctx, {QualifiedType::create(ctx, type::Address::create(ctx, meta), Constness::Const)},
+                                  v, meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/bitfield.h
+++ b/hilti/toolchain/include/ast/ctors/bitfield.h
@@ -34,15 +34,15 @@ public:
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, const ID& id, const ExpressionPtr& expr, const Meta& meta = Meta()) {
-        return std::shared_ptr<BitRange>(new BitRange(ctx, {expr}, id, meta));
+    static auto create(ASTContext* ctx, const ID& id, Expression* expr, Meta meta = Meta()) {
+        return ctx->make<BitRange>(ctx, {expr}, id, std::move(meta));
     }
 
 protected:
     friend class type::Bitfield;
 
-    BitRange(ASTContext* ctx, Nodes children, ID id, const Meta& meta = Meta())
-        : Node(ctx, NodeTags, std::move(children), meta), _id(std::move(id)) {}
+    BitRange(ASTContext* ctx, Nodes children, ID id, Meta meta = Meta())
+        : Node(ctx, NodeTags, std::move(children), std::move(meta)), _id(std::move(id)) {}
 
     HILTI_NODE_0(ctor::bitfield::BitRange, final);
 
@@ -50,8 +50,7 @@ private:
     ID _id;
 };
 
-using BitRangePtr = std::shared_ptr<BitRange>;
-using BitRanges = std::vector<BitRangePtr>;
+using BitRanges = std::vector<BitRange*>;
 
 } // namespace bitfield
 
@@ -65,7 +64,7 @@ public:
     auto btype() const { return type()->type()->as<type::Bitfield>(); }
 
     /** Returns a field initialized by the constructor by its ID. */
-    bitfield::BitRangePtr bits(const ID& id) const {
+    bitfield::BitRange* bits(const ID& id) const {
         for ( const auto& b : bits() ) {
             if ( b->id() == id )
                 return b;
@@ -74,11 +73,11 @@ public:
         return {};
     }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const ctor::bitfield::BitRanges& bits, QualifiedTypePtr type,
+    static auto create(ASTContext* ctx, const ctor::bitfield::BitRanges& bits, QualifiedType* type,
                        const Meta& m = Meta()) {
-        return std::shared_ptr<Bitfield>(new Bitfield(ctx, node::flatten(std::move(type), bits), m));
+        return ctx->make<Bitfield>(ctx, node::flatten(type, bits), m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/bitfield.h
+++ b/hilti/toolchain/include/ast/ctors/bitfield.h
@@ -50,7 +50,7 @@ private:
     ID _id;
 };
 
-using BitRanges = std::vector<BitRange*>;
+using BitRanges = NodeVector<BitRange>;
 
 } // namespace bitfield
 

--- a/hilti/toolchain/include/ast/ctors/bool.h
+++ b/hilti/toolchain/include/ast/ctors/bool.h
@@ -15,7 +15,7 @@ class Bool : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}};
@@ -23,8 +23,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, bool v, const Meta& meta = {}) {
-        return std::shared_ptr<Bool>(
-            new Bool(ctx, {QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)}, v, meta));
+        return ctx->make<Bool>(ctx, {QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)}, v,
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/bytes.h
+++ b/hilti/toolchain/include/ast/ctors/bytes.h
@@ -16,7 +16,7 @@ class Bytes : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}};
@@ -24,8 +24,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, std::string value, const Meta& meta = {}) {
-        return CtorPtr(new Bytes(ctx, {QualifiedType::create(ctx, type::Bytes::create(ctx, meta), Constness::Const)},
-                                 std::move(value), meta));
+        return ctx->make<Bytes>(ctx, {QualifiedType::create(ctx, type::Bytes::create(ctx, meta), Constness::Const)},
+                                std::move(value), meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/coerced.h
+++ b/hilti/toolchain/include/ast/ctors/coerced.h
@@ -15,10 +15,10 @@ public:
     auto originalCtor() const { return child<Ctor>(0); }
     auto coercedCtor() const { return child<Ctor>(1); }
 
-    QualifiedTypePtr type() const final { return coercedCtor()->type(); }
+    QualifiedType* type() const final { return coercedCtor()->type(); }
 
-    static auto create(ASTContext* ctx, const CtorPtr& orig, const CtorPtr& new_, const Meta& meta = {}) {
-        return std::shared_ptr<Coerced>(new Coerced(ctx, {orig, new_}, meta));
+    static auto create(ASTContext* ctx, Ctor* orig, Ctor* new_, Meta meta = {}) {
+        return ctx->make<Coerced>(ctx, {orig, new_}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/default.h
+++ b/hilti/toolchain/include/ast/ctors/default.h
@@ -16,7 +16,7 @@ class Default : public Ctor {
 public:
     auto typeArguments() const { return children<Expression>(1, {}); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     void setTypeArguments(ASTContext* ctx, Expressions exprs) {
         removeChildren(1, {});
@@ -24,20 +24,19 @@ public:
     }
 
     /** Constructs a default value of a given type. */
-    static auto create(ASTContext* ctx, const UnqualifiedTypePtr& type, const Meta& meta = {}) {
-        return std::shared_ptr<Default>(
-            new Default(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta)}, meta));
+    static auto create(ASTContext* ctx, UnqualifiedType* type, const Meta& meta = {}) {
+        return ctx->make<Default>(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta)}, meta);
     }
 
     /**
      * Constructs a default value of a given type, passing specified arguments to
      * types with parameters.
      */
-    static auto create(ASTContext* ctx, const UnqualifiedTypePtr& type, Expressions type_args, const Meta& meta = {}) {
-        return CtorPtr(
-            new Default(ctx,
-                        node::flatten(QualifiedType::create(ctx, type, Constness::Const, meta), std::move(type_args)),
-                        meta));
+    static auto create(ASTContext* ctx, UnqualifiedType* type, Expressions type_args, const Meta& meta = {}) {
+        return ctx->make<Default>(ctx,
+                                  node::flatten(QualifiedType::create(ctx, type, Constness::Const, meta),
+                                                std::move(type_args)),
+                                  meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/enum.h
+++ b/hilti/toolchain/include/ast/ctors/enum.h
@@ -16,12 +16,12 @@ class Enum : public Ctor {
 public:
     auto value() const { return child<type::enum_::Label>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const type::enum_::LabelPtr& label, const Meta& meta = {}) {
-        return std::shared_ptr<Enum>(
-            new Enum(ctx, {label, QualifiedType::createExternal(ctx, label->enumType(), Constness::Const, meta)},
-                     meta));
+    static auto create(ASTContext* ctx, type::enum_::Label* label, const Meta& meta = {}) {
+        return ctx->make<Enum>(ctx,
+                               {label, QualifiedType::createExternal(ctx, label->enumType(), Constness::Const, meta)},
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/error.h
+++ b/hilti/toolchain/include/ast/ctors/error.h
@@ -16,7 +16,7 @@ class Error : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}};
@@ -24,8 +24,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, std::string v, const Meta& meta = {}) {
-        return CtorPtr(new Error(ctx, {QualifiedType::create(ctx, type::Error::create(ctx, meta), Constness::Const)},
-                                 std::move(v), meta));
+        return ctx->make<Error>(ctx, {QualifiedType::create(ctx, type::Error::create(ctx, meta), Constness::Const)},
+                                std::move(v), meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/exception.h
+++ b/hilti/toolchain/include/ast/ctors/exception.h
@@ -18,19 +18,18 @@ public:
     auto value() const { return child<Expression>(1); }
     auto location() const { return childTryAs<Expression>(2); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     /** Constructs a exception value of a given type. */
-    static auto create(ASTContext* ctx, const UnqualifiedTypePtr& type, const ExpressionPtr& value,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Exception>(
-            new Exception(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta), value, nullptr}, meta));
+    static auto create(ASTContext* ctx, UnqualifiedType* type, Expression* value, const Meta& meta = {}) {
+        return ctx->make<Exception>(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta), value, nullptr},
+                                    meta);
     }
 
-    static auto create(ASTContext* ctx, const UnqualifiedTypePtr& type, const ExpressionPtr& value,
-                       const ExpressionPtr& location, const Meta& meta = {}) {
-        return std::shared_ptr<Exception>(
-            new Exception(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta), value, location}, meta));
+    static auto create(ASTContext* ctx, UnqualifiedType* type, Expression* value, Expression* location,
+                       const Meta& meta = {}) {
+        return ctx->make<Exception>(ctx, {QualifiedType::create(ctx, type, Constness::Const, meta), value, location},
+                                    meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/integer.h
+++ b/hilti/toolchain/include/ast/ctors/integer.h
@@ -18,7 +18,7 @@ public:
     const auto& value() const { return _value; }
     auto width() const { return _width; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}, {"width", _width}};
@@ -40,10 +40,10 @@ private:
 class SignedInteger : public detail::IntegerBase<int64_t> {
 public:
     static auto create(ASTContext* ctx, int64_t value, unsigned int width, const Meta& meta = {}) {
-        return CtorPtr(new SignedInteger(ctx,
-                                         {QualifiedType::create(ctx, type::SignedInteger::create(ctx, width, meta),
-                                                                Constness::Const)},
-                                         value, width, meta));
+        return ctx->make<SignedInteger>(ctx,
+                                        {QualifiedType::create(ctx, type::SignedInteger::create(ctx, width, meta),
+                                                               Constness::Const)},
+                                        value, width, meta);
     }
 
 protected:
@@ -57,15 +57,15 @@ protected:
 class UnsignedInteger : public detail::IntegerBase<uint64_t> {
 public:
     static auto create(ASTContext* ctx, uint64_t value, unsigned int width, const Meta& meta = {}) {
-        return CtorPtr(new UnsignedInteger(ctx,
-                                           {QualifiedType::create(ctx, type::UnsignedInteger::create(ctx, width, meta),
-                                                                  Constness::Const)},
-                                           value, width, meta));
+        return ctx->make<UnsignedInteger>(ctx,
+                                          {QualifiedType::create(ctx, type::UnsignedInteger::create(ctx, width, meta),
+                                                                 Constness::Const)},
+                                          value, width, meta);
     }
 
-    static auto create(ASTContext* ctx, uint64_t value, unsigned int width, const UnqualifiedTypePtr& t,
-                       const Meta& meta = {}) {
-        return CtorPtr(new UnsignedInteger(ctx, {QualifiedType::create(ctx, t, Constness::Const)}, value, width, meta));
+    static auto create(ASTContext* ctx, uint64_t value, unsigned int width, UnqualifiedType* t, Meta meta = {}) {
+        return ctx->make<UnsignedInteger>(ctx, {QualifiedType::create(ctx, t, Constness::Const)}, value, width,
+                                          std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/interval.h
+++ b/hilti/toolchain/include/ast/ctors/interval.h
@@ -17,7 +17,7 @@ class Interval : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", to_string(_value)}};
@@ -25,9 +25,9 @@ public:
     }
 
     static auto create(ASTContext* ctx, hilti::rt::Interval v, const Meta& meta = {}) {
-        return std::shared_ptr<Interval>(
-            new Interval(ctx, {QualifiedType::create(ctx, type::Interval::create(ctx, meta), Constness::Const)}, v,
-                         meta));
+        return ctx->make<Interval>(ctx,
+                                   {QualifiedType::create(ctx, type::Interval::create(ctx, meta), Constness::Const)}, v,
+                                   meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/library.h
+++ b/hilti/toolchain/include/ast/ctors/library.h
@@ -23,15 +23,15 @@ class Library : public Ctor {
 public:
     auto value() const { return child<Ctor>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const CtorPtr& ctor, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return std::shared_ptr<Library>(new Library(ctx,
-                                                    {
-                                                        ctor,
-                                                        type,
-                                                    },
-                                                    meta));
+    static auto create(ASTContext* ctx, Ctor* ctor, QualifiedType* type, const Meta& meta = {}) {
+        return ctx->make<Library>(ctx,
+                                  {
+                                      ctor,
+                                      type,
+                                  },
+                                  meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/list.h
+++ b/hilti/toolchain/include/ast/ctors/list.h
@@ -18,7 +18,7 @@ public:
     auto elementType() const { return type()->type()->as<type::List>()->elementType(); }
     auto value() const { return children<Expression>(1, {}); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     void setValue(ASTContext* ctx, Expressions exprs) {
         removeChildren(0, {});
@@ -26,18 +26,18 @@ public:
         addChildren(ctx, std::move(exprs));
     }
 
-    void setType(ASTContext* ctx, QualifiedTypePtr t) { setChild(ctx, 0, std::move(t)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, QualifiedType* etype, Expressions exprs, Meta meta = {}) {
         auto stype = QualifiedType::create(ctx, type::List::create(ctx, etype, meta), Constness::Const, meta);
-        return std::shared_ptr<List>(new List(ctx, node::flatten(stype, std::move(exprs)), meta));
+        return ctx->make<List>(ctx, node::flatten(stype, std::move(exprs)), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expressions exprs, Meta meta = {}) {
         // Bool is just an arbitrary place-holder type for empty values.
         auto etype = exprs.empty() ? QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const, meta) :
                                      QualifiedType::createAuto(ctx, meta);
-        return create(ctx, etype, std::move(exprs), meta);
+        return create(ctx, etype, std::move(exprs), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/map.h
+++ b/hilti/toolchain/include/ast/ctors/map.h
@@ -38,7 +38,7 @@ protected:
     HILTI_NODE_0(ctor::map::Element, final);
 };
 
-using Elements = std::vector<Element*>;
+using Elements = NodeVector<Element>;
 
 } // namespace map
 

--- a/hilti/toolchain/include/ast/ctors/map.h
+++ b/hilti/toolchain/include/ast/ctors/map.h
@@ -25,8 +25,8 @@ public:
     auto key() const { return child<Expression>(0); }
     auto value() const { return child<Expression>(1); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& key, const ExpressionPtr& value, Meta meta = {}) {
-        return std::shared_ptr<Element>(new Element(ctx, {key, value}, std::move(meta)));
+    static auto create(ASTContext* ctx, Expression* key, Expression* value, Meta meta = {}) {
+        return ctx->make<Element>(ctx, {key, value}, std::move(meta));
     }
 
 protected:
@@ -38,8 +38,7 @@ protected:
     HILTI_NODE_0(ctor::map::Element, final);
 };
 
-using ElementPtr = std::shared_ptr<Element>;
-using Elements = std::vector<ElementPtr>;
+using Elements = std::vector<Element*>;
 
 } // namespace map
 
@@ -62,27 +61,27 @@ public:
             return type(); // auto
     }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& type) { setChild(ctx, 0, type); }
+    void setType(ASTContext* ctx, QualifiedType* type) { setChild(ctx, 0, type); }
 
     void setValue(ASTContext* ctx, map::Elements exprs) {
         removeChildren(1, {});
         addChildren(ctx, std::move(exprs));
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& key, const QualifiedTypePtr& value,
-                       map::Elements elements, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, QualifiedType* key, QualifiedType* value, map::Elements elements,
+                       Meta meta = {}) {
         auto mtype = QualifiedType::create(ctx, type::Map::create(ctx, key, value, meta), Constness::Mutable, meta);
-        return std::shared_ptr<Map>(new Map(ctx, node::flatten(mtype, std::move(elements)), meta));
+        return ctx->make<Map>(ctx, node::flatten(mtype, std::move(elements)), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, map::Elements elements, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, map::Elements elements, Meta meta = {}) {
         // bool is just an arbitrary place-holder type for empty values.
         auto mtype = elements.empty() ?
                          QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Mutable, meta) :
                          QualifiedType::createAuto(ctx, meta);
-        return std::shared_ptr<Map>(new Map(ctx, node::flatten(mtype, std::move(elements)), meta));
+        return ctx->make<Map>(ctx, node::flatten(mtype, std::move(elements)), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/network.h
+++ b/hilti/toolchain/include/ast/ctors/network.h
@@ -17,7 +17,7 @@ class Network : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", to_string(_value)}};
@@ -25,9 +25,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, hilti::rt::Network v, const Meta& meta = {}) {
-        return std::shared_ptr<Network>(
-            new Network(ctx, {QualifiedType::create(ctx, type::Network::create(ctx, meta), Constness::Const)}, v,
-                        meta));
+        return ctx->make<Network>(ctx, {QualifiedType::create(ctx, type::Network::create(ctx, meta), Constness::Const)},
+                                  v, meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/null.h
+++ b/hilti/toolchain/include/ast/ctors/null.h
@@ -13,11 +13,11 @@ namespace hilti::ctor {
 /** AST node for a `Null` ctor. */
 class Null : public Ctor {
 public:
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     static auto create(ASTContext* ctx, const Meta& meta = {}) {
-        return std::shared_ptr<Null>(
-            new Null(ctx, {QualifiedType::create(ctx, type::Null::create(ctx, meta), Constness::Const)}, meta));
+        return ctx->make<Null>(ctx, {QualifiedType::create(ctx, type::Null::create(ctx, meta), Constness::Const)},
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/optional.h
+++ b/hilti/toolchain/include/ast/ctors/optional.h
@@ -16,38 +16,36 @@ namespace hilti::ctor {
 /** AST node for a `optional` ctor. */
 class Optional : public Ctor {
 public:
-    ExpressionPtr value() const { return child<Expression>(1); }
-    QualifiedTypePtr dereferencedType() const { return type()->type()->as<type::Optional>()->dereferencedType(); }
+    Expression* value() const { return child<Expression>(1); }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::Optional>()->dereferencedType(); }
 
-    QualifiedTypePtr type() const final {
-        if ( auto e = child(0) )
-            return child<QualifiedType>(0);
+    QualifiedType* type() const final {
+        if ( auto e = child<QualifiedType>(0) )
+            return e;
         else
             return child<Expression>(1)->type();
     }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
     /** Constructs a set value. */
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
-        return std::shared_ptr<Optional>(
-            new Optional(ctx,
-                         {
-                             QualifiedType::create(ctx, type::Auto::create(ctx), Constness::Const),
-                             expr,
-                         },
-                         meta));
+    static auto create(ASTContext* ctx, Expression* expr, const Meta& meta = {}) {
+        return ctx->make<Optional>(ctx,
+                                   {
+                                       QualifiedType::create(ctx, type::Auto::create(ctx), Constness::Const),
+                                       expr,
+                                   },
+                                   meta);
     }
 
     /** Constructs an unset value of type `t`. */
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return std::shared_ptr<Optional>(
-            new Optional(ctx,
-                         {
-                             QualifiedType::create(ctx, type::Optional::create(ctx, type), Constness::Const),
-                             nullptr,
-                         },
-                         meta));
+    static auto create(ASTContext* ctx, QualifiedType* type, const Meta& meta = {}) {
+        return ctx->make<Optional>(ctx,
+                                   {
+                                       QualifiedType::create(ctx, type::Optional::create(ctx, type), Constness::Const),
+                                       nullptr,
+                                   },
+                                   meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/port.h
+++ b/hilti/toolchain/include/ast/ctors/port.h
@@ -17,7 +17,7 @@ class Port : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", to_string(_value)}};
@@ -25,8 +25,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, hilti::rt::Port v, const Meta& meta = {}) {
-        return std::shared_ptr<Port>(
-            new Port(ctx, {QualifiedType::create(ctx, type::Port::create(ctx, meta), Constness::Const)}, v, meta));
+        return ctx->make<Port>(ctx, {QualifiedType::create(ctx, type::Port::create(ctx, meta), Constness::Const)}, v,
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/real.h
+++ b/hilti/toolchain/include/ast/ctors/real.h
@@ -15,7 +15,7 @@ class Real : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}};
@@ -23,8 +23,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, double v, const Meta& meta = {}) {
-        return std::shared_ptr<Real>(
-            new Real(ctx, {QualifiedType::create(ctx, type::Real::create(ctx, meta), Constness::Const)}, v, meta));
+        return ctx->make<Real>(ctx, {QualifiedType::create(ctx, type::Real::create(ctx, meta), Constness::Const)}, v,
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/reference.h
+++ b/hilti/toolchain/include/ast/ctors/reference.h
@@ -15,17 +15,15 @@ namespace hilti::ctor {
 /** AST node for a `strong_ref<T>` constructor value (which can only be null). */
 class StrongReference : public Ctor {
 public:
-    QualifiedTypePtr dereferencedType() const {
-        return type()->type()->as<type::StrongReference>()->dereferencedType();
-    }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::StrongReference>()->dereferencedType(); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return CtorPtr(new StrongReference(ctx,
-                                           {QualifiedType::create(ctx, type::StrongReference::create(ctx, t, meta),
-                                                                  Constness::Const)},
-                                           meta));
+    static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
+        return ctx->make<StrongReference>(ctx,
+                                          {QualifiedType::create(ctx, type::StrongReference::create(ctx, t, meta),
+                                                                 Constness::Const)},
+                                          meta);
     }
 
 protected:
@@ -38,15 +36,15 @@ protected:
 /** AST node for a `weak_ref<T>` constructor value (which can only be null). */
 class WeakReference : public Ctor {
 public:
-    QualifiedTypePtr dereferencedType() const { return type()->type()->as<type::WeakReference>()->dereferencedType(); }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::WeakReference>()->dereferencedType(); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return CtorPtr(
-            new WeakReference(ctx,
-                              {QualifiedType::create(ctx, type::WeakReference::create(ctx, t, meta), Constness::Const)},
-                              meta));
+    static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
+        return ctx->make<WeakReference>(ctx,
+                                        {QualifiedType::create(ctx, type::WeakReference::create(ctx, t, meta),
+                                                               Constness::Const)},
+                                        meta);
     }
 
 protected:
@@ -59,16 +57,16 @@ protected:
 /** AST node for a `value_ref<T>` constructor value. */
 class ValueReference : public Ctor {
 public:
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
-    ExpressionPtr expression() const { return child<Expression>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
+    Expression* expression() const { return child<Expression>(1); }
 
-    QualifiedTypePtr dereferencedType() const { return type()->type()->as<type::ValueReference>()->dereferencedType(); }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::ValueReference>()->dereferencedType(); }
 
-    void setType(ASTContext* ctx, QualifiedTypePtr t) { setChild(ctx, 0, std::move(t)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expression* expr, Meta meta = {}) {
         auto auto_ = QualifiedType::create(ctx, hilti::type::Auto::create(ctx), hilti::Constness::Const, meta);
-        return std::shared_ptr<ValueReference>(new ValueReference(ctx, {auto_, expr}, meta));
+        return ctx->make<ValueReference>(ctx, {auto_, expr}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/regexp.h
+++ b/hilti/toolchain/include/ast/ctors/regexp.h
@@ -24,20 +24,20 @@ public:
      */
     bool isNoSub() const { return attributes()->find("&nosub") != nullptr; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", util::join(_value, " | ")}};
         return Ctor::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, std::vector<std::string> v, AttributeSetPtr attrs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, std::vector<std::string> v, AttributeSet* attrs, const Meta& meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return CtorPtr(
-            new RegExp(ctx, {QualifiedType::create(ctx, type::RegExp::create(ctx, meta), Constness::Const), attrs},
-                       std::move(v), meta));
+        return ctx->make<RegExp>(ctx,
+                                 {QualifiedType::create(ctx, type::RegExp::create(ctx, meta), Constness::Const), attrs},
+                                 std::move(v), meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/result.h
+++ b/hilti/toolchain/include/ast/ctors/result.h
@@ -16,9 +16,9 @@ namespace hilti::ctor {
 /** AST node for a `optional` ctor. */
 class Result : public Ctor {
 public:
-    QualifiedTypePtr dereferencedType() const { return type()->type()->as<type::Result>()->dereferencedType(); }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::Result>()->dereferencedType(); }
 
-    ExpressionPtr value() const {
+    Expression* value() const {
         const auto& e = child<Expression>(1);
 
         if ( ! e->type()->type()->isA<type::Error>() )
@@ -27,7 +27,7 @@ public:
             return {};
     }
 
-    ExpressionPtr error() const {
+    Expression* error() const {
         const auto& e = child<Expression>(1);
 
         if ( e->type()->type()->isA<type::Error>() )
@@ -36,22 +36,22 @@ public:
             return {};
     }
 
-    QualifiedTypePtr type() const final {
-        if ( auto e = child(0) )
-            return child<QualifiedType>(0);
+    QualifiedType* type() const final {
+        if ( auto e = child<QualifiedType>(0) )
+            return e;
         else
             return child<Expression>(1)->type();
     }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
-        return std::shared_ptr<Result>(new Result(ctx,
-                                                  {
-                                                      nullptr,
-                                                      expr,
-                                                  },
-                                                  meta));
+    static auto create(ASTContext* ctx, Expression* expr, const Meta& meta = {}) {
+        return ctx->make<Result>(ctx,
+                                 {
+                                     nullptr,
+                                     expr,
+                                 },
+                                 meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/set.h
+++ b/hilti/toolchain/include/ast/ctors/set.h
@@ -18,26 +18,26 @@ public:
     auto elementType() const { return type()->type()->as<type::Set>()->elementType(); }
     auto value() const { return children<Expression>(1, {}); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
     void setValue(ASTContext* ctx, Expressions exprs) {
         removeChildren(1, {});
         addChildren(ctx, std::move(exprs));
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, QualifiedType* etype, Expressions exprs, Meta meta = {}) {
         auto stype = QualifiedType::create(ctx, type::Set::create(ctx, etype, meta), Constness::Mutable, meta);
-        return std::shared_ptr<Set>(new Set(ctx, node::flatten(stype, std::move(exprs)), meta));
+        return ctx->make<Set>(ctx, node::flatten(stype, std::move(exprs)), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expressions exprs, Meta meta = {}) {
         // bool is just an arbitrary place-holder type for empty values.
         auto etype = exprs.empty() ?
                          QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Mutable, meta) :
                          QualifiedType::createAuto(ctx, meta);
-        return create(ctx, etype, std::move(exprs), meta);
+        return create(ctx, etype, std::move(exprs), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/stream.h
+++ b/hilti/toolchain/include/ast/ctors/stream.h
@@ -16,7 +16,7 @@ class Stream : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}};
@@ -24,8 +24,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, std::string value, const Meta& meta = {}) {
-        return CtorPtr(new Stream(ctx, {QualifiedType::create(ctx, type::Stream::create(ctx, meta), Constness::Const)},
-                                  std::move(value), meta));
+        return ctx->make<Stream>(ctx, {QualifiedType::create(ctx, type::Stream::create(ctx, meta), Constness::Const)},
+                                 std::move(value), meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/string.h
+++ b/hilti/toolchain/include/ast/ctors/string.h
@@ -17,7 +17,7 @@ public:
     const auto& value() const { return _value; }
     auto isLiteral() const { return _is_literal; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", _value}, {"is_literal", _is_literal}};
@@ -25,8 +25,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, std::string value, bool is_literal, const Meta& meta = {}) {
-        return CtorPtr(new String(ctx, {QualifiedType::create(ctx, type::String::create(ctx, meta), Constness::Const)},
-                                  std::move(value), is_literal, meta));
+        return ctx->make<String>(ctx, {QualifiedType::create(ctx, type::String::create(ctx, meta), Constness::Const)},
+                                 std::move(value), is_literal, meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/struct.h
+++ b/hilti/toolchain/include/ast/ctors/struct.h
@@ -41,7 +41,7 @@ private:
     ID _id;
 };
 
-using Fields = std::vector<Field*>;
+using Fields = NodeVector<Field>;
 
 } // namespace struct_
 

--- a/hilti/toolchain/include/ast/ctors/struct.h
+++ b/hilti/toolchain/include/ast/ctors/struct.h
@@ -27,8 +27,8 @@ public:
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& expr, Meta meta = {}) {
-        return std::shared_ptr<Field>(new Field(ctx, {expr}, std::move(id), std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, Expression* expr, Meta meta = {}) {
+        return ctx->make<Field>(ctx, {expr}, std::move(id), std::move(meta));
     }
 
 protected:
@@ -41,8 +41,7 @@ private:
     ID _id;
 };
 
-using FieldPtr = std::shared_ptr<Field>;
-using Fields = std::vector<FieldPtr>;
+using Fields = std::vector<Field*>;
 
 } // namespace struct_
 
@@ -55,7 +54,7 @@ public:
     auto fields() const { return children<struct_::Field>(1, {}); }
 
     /** Returns a field initialized by the constructor by its ID. */
-    struct_::FieldPtr field(const ID& id) const {
+    struct_::Field* field(const ID& id) const {
         for ( const auto& f : fields() ) {
             if ( f->id() == id )
                 return f;
@@ -64,8 +63,8 @@ public:
         return nullptr;
     }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
     /** Implements the node interface. */
     node::Properties properties() const override {
@@ -73,13 +72,12 @@ public:
         return Ctor::properties() + node::WithUniqueID::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, struct_::Fields fields, QualifiedTypePtr t, const Meta& meta = {}) {
-        return std::shared_ptr<Struct>(new Struct(ctx, node::flatten(std::move(t), std::move(fields)), meta));
+    static auto create(ASTContext* ctx, struct_::Fields fields, QualifiedType* t, Meta meta = {}) {
+        return ctx->make<Struct>(ctx, node::flatten(t, std::move(fields)), std::move(meta));
     }
 
     static auto create(ASTContext* ctx, struct_::Fields fields, const Meta& meta = {}) {
-        return std::shared_ptr<Struct>(
-            new Struct(ctx, node::flatten(QualifiedType::createAuto(ctx, meta), std::move(fields)), meta));
+        return ctx->make<Struct>(ctx, node::flatten(QualifiedType::createAuto(ctx, meta), std::move(fields)), meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/time.h
+++ b/hilti/toolchain/include/ast/ctors/time.h
@@ -17,7 +17,7 @@ class Time : public Ctor {
 public:
     const auto& value() const { return _value; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"value", to_string(_value)}};
@@ -25,8 +25,8 @@ public:
     }
 
     static auto create(ASTContext* ctx, hilti::rt::Time v, const Meta& meta = {}) {
-        return std::shared_ptr<Time>(
-            new Time(ctx, {QualifiedType::create(ctx, type::Time::create(ctx, meta), Constness::Const)}, v, meta));
+        return ctx->make<Time>(ctx, {QualifiedType::create(ctx, type::Time::create(ctx, meta), Constness::Const)}, v,
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/tuple.h
+++ b/hilti/toolchain/include/ast/ctors/tuple.h
@@ -16,13 +16,13 @@ class Tuple : public Ctor {
 public:
     auto value() const { return children<Expression>(1, {}); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    void setType(ASTContext* ctx, QualifiedTypePtr t) { setChild(ctx, 0, std::move(t)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    static auto create(ASTContext* ctx, const Expressions& exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, const Expressions& exprs, Meta meta = {}) {
         auto type = _inferType(ctx, exprs, meta);
-        return std::shared_ptr<Tuple>(new Tuple(ctx, node::flatten(type, exprs), meta));
+        return ctx->make<Tuple>(ctx, node::flatten(type, exprs), std::move(meta));
     }
 
 protected:
@@ -31,7 +31,7 @@ protected:
     HILTI_NODE_1(ctor::Tuple, Ctor, final);
 
 private:
-    static QualifiedTypePtr _inferType(ASTContext* ctx, const Expressions& exprs, const Meta& meta) {
+    static QualifiedType* _inferType(ASTContext* ctx, const Expressions& exprs, const Meta& meta) {
         for ( const auto& e : exprs ) {
             if ( ! e->isResolved() )
                 return QualifiedType::createAuto(ctx, meta);

--- a/hilti/toolchain/include/ast/ctors/union.h
+++ b/hilti/toolchain/include/ast/ctors/union.h
@@ -14,13 +14,12 @@ namespace hilti::ctor {
 class Union : public Ctor {
 public:
     /** Returns the value to initialize the unit with. */
-    ExpressionPtr value() const { return child<Expression>(1); }
+    Expression* value() const { return child<Expression>(1); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, const ExpressionPtr& value,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Union>(new Union(ctx, {type, value}, meta));
+    static auto create(ASTContext* ctx, QualifiedType* type, Expression* value, Meta meta = {}) {
+        return ctx->make<Union>(ctx, {type, value}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/ctors/vector.h
+++ b/hilti/toolchain/include/ast/ctors/vector.h
@@ -18,26 +18,26 @@ public:
     auto elementType() const { return type()->type()->as<type::Vector>()->elementType(); }
     auto value() const { return children<Expression>(1, {}); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
     void setValue(ASTContext* ctx, Expressions exprs) {
         removeChildren(1, {});
         addChildren(ctx, std::move(exprs));
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& etype, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, QualifiedType* etype, Expressions exprs, Meta meta = {}) {
         auto stype = QualifiedType::create(ctx, type::Vector::create(ctx, etype, meta), Constness::Mutable, meta);
-        return std::shared_ptr<Vector>(new Vector(ctx, node::flatten(stype, std::move(exprs)), meta));
+        return ctx->make<Vector>(ctx, node::flatten(stype, std::move(exprs)), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, Expressions exprs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expressions exprs, Meta meta = {}) {
         // bool is just an arbitrary place-holder type for empty values.
         auto etype = exprs.empty() ?
                          QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Mutable, meta) :
                          QualifiedType::createAuto(ctx, meta);
-        return create(ctx, etype, std::move(exprs), meta);
+        return create(ctx, etype, std::move(exprs), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/declarations/constant.h
+++ b/hilti/toolchain/include/ast/declarations/constant.h
@@ -19,7 +19,7 @@ class Constant : public Declaration {
 public:
     auto value() const { return child<hilti::Expression>(1); }
 
-    QualifiedTypePtr type() const {
+    QualifiedType* type() const {
         if ( auto t = child<QualifiedType>(0) )
             return t;
         else
@@ -28,19 +28,19 @@ public:
 
     std::string_view displayName() const final { return "constant"; }
 
-    void setValue(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 1, std::move(e)); }
+    void setValue(ASTContext* ctx, hilti::Expression* e) { setChild(ctx, 1, e); }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, const ExpressionPtr& value,
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, hilti::Expression* value,
                        declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
-        QualifiedTypePtr t = type;
+        QualifiedType* t = type;
 
         if ( t )
             t = t->recreateAsConst(ctx);
 
-        return std::shared_ptr<Constant>(new Constant(ctx, {t, value}, std::move(id), linkage, std::move(meta)));
+        return ctx->make<Constant>(ctx, {t, value}, std::move(id), linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& value,
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* value,
                        declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
         return create(ctx, std::move(id), {}, value, linkage, std::move(meta));
     }

--- a/hilti/toolchain/include/ast/declarations/expression.h
+++ b/hilti/toolchain/include/ast/declarations/expression.h
@@ -20,16 +20,15 @@ public:
 
     std::string_view displayName() const final { return "expression"; }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& expr, AttributeSetPtr attrs,
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* expr, AttributeSet* attrs,
                        declaration::Linkage linkage, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Expression>(new Expression(ctx, {expr, attrs}, std::move(id), linkage, std::move(meta)));
+        return ctx->make<Expression>(ctx, {expr, attrs}, std::move(id), linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& expr, declaration::Linkage linkage,
-                       Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* expr, declaration::Linkage linkage, Meta meta = {}) {
         return create(ctx, std::move(id), expr, nullptr, linkage, std::move(meta));
     }
 

--- a/hilti/toolchain/include/ast/declarations/field.h
+++ b/hilti/toolchain/include/ast/declarations/field.h
@@ -30,7 +30,7 @@ public:
      */
     auto operator_() const { return _operator; }
 
-    QualifiedTypePtr type() const {
+    QualifiedType* type() const {
         if ( const auto& func = inlineFunction() )
             return func->type();
         else
@@ -47,7 +47,7 @@ public:
             return type->isResolved(cd);
     }
 
-    ExpressionPtr default_() const {
+    hilti::Expression* default_() const {
         if ( auto a = attributes()->find("&default") )
             return *a->valueAsExpression();
         else
@@ -62,9 +62,9 @@ public:
 
     auto linkedTypeIndex() const { return _linked_type_index; }
 
-    void setAttributes(ASTContext* ctx, AttributeSetPtr attrs) { setChild(ctx, 1, std::move(attrs)); }
+    void setAttributes(ASTContext* ctx, AttributeSet* attrs) { setChild(ctx, 1, attrs); }
     void setOperator(const Operator* op) { _operator = op; }
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
     void setLinkedTypeIndex(ast::TypeIndex idx) {
         assert(idx);
         _linked_type_index = idx;
@@ -74,7 +74,7 @@ public:
 
     node::Properties properties() const final;
 
-    static auto create(ASTContext* ctx, ID id, QualifiedTypePtr type, AttributeSetPtr attrs, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
@@ -82,26 +82,23 @@ public:
             // make it assignable
             type = type->recreateAsLhs(ctx);
 
-        return std::shared_ptr<Field>(
-            new Field(ctx, {std::move(type), attrs, nullptr}, std::move(id), {}, std::move(meta)));
+        return ctx->make<Field>(ctx, {type, attrs, nullptr}, std::move(id), std::nullopt, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, ::hilti::function::CallingConvention cc, const type::FunctionPtr& ftype,
-                       AttributeSetPtr attrs, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, ::hilti::function::CallingConvention cc, type::Function* ftype,
+                       AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Field>(new Field(ctx,
-                                                {QualifiedType::create(ctx, ftype, Constness::Const), attrs, nullptr},
-                                                std::move(id), cc, std::move(meta)));
+        return ctx->make<Field>(ctx, {QualifiedType::create(ctx, ftype, Constness::Const), attrs, nullptr},
+                                std::move(id), cc, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ID& id, const FunctionPtr& inline_func, AttributeSetPtr attrs,
-                       Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, hilti::Function* inline_func, AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Field>(new Field(ctx, {nullptr, attrs, inline_func}, id, {}, std::move(meta)));
+        return ctx->make<Field>(ctx, {nullptr, attrs, inline_func}, std::move(id), std::nullopt, std::move(meta));
     }
 
 protected:
@@ -119,7 +116,6 @@ private:
     ast::TypeIndex _linked_type_index;
 };
 
-using FieldPtr = std::shared_ptr<Field>;
-using FieldList = std::vector<FieldPtr>;
+using FieldList = std::vector<Field*>;
 
 } // namespace hilti::declaration

--- a/hilti/toolchain/include/ast/declarations/field.h
+++ b/hilti/toolchain/include/ast/declarations/field.h
@@ -116,6 +116,4 @@ private:
     ast::TypeIndex _linked_type_index;
 };
 
-using FieldList = std::vector<Field*>;
-
 } // namespace hilti::declaration

--- a/hilti/toolchain/include/ast/declarations/function.h
+++ b/hilti/toolchain/include/ast/declarations/function.h
@@ -9,10 +9,10 @@
 
 #include <hilti/ast/declaration.h>
 #include <hilti/ast/declarations/type.h>
+#include <hilti/ast/function.h>
 #include <hilti/ast/node-range.h>
 #include <hilti/ast/operator-registry.h>
 #include <hilti/ast/operator.h>
-#include <hilti/ast/types/struct.h>
 #include <hilti/ast/types/type.h>
 
 namespace hilti::declaration {
@@ -40,10 +40,12 @@ public:
     auto linkedPrototypeIndex() const { return _linked_prototype_index; }
 
     void setOperator(const Operator* op) { _operator = op; }
+
     void setLinkedDeclarationIndex(ast::DeclarationIndex index) {
         assert(index);
         _linked_declaration_index = index;
     }
+
     void setLinkedPrototypeIndex(ast::DeclarationIndex index) {
         assert(index);
         _linked_prototype_index = index;
@@ -53,9 +55,9 @@ public:
 
     node::Properties properties() const final;
 
-    static std::shared_ptr<Function> create(ASTContext* ctx, const FunctionPtr& function,
-                                            declaration::Linkage linkage = Linkage::Private, const Meta& meta = {}) {
-        return std::shared_ptr<Function>(new Function(ctx, {function}, function->id(), linkage, meta));
+    static Function* create(ASTContext* ctx, hilti::Function* function, declaration::Linkage linkage = Linkage::Private,
+                            Meta meta = {}) {
+        return ctx->make<Function>(ctx, {function}, function->id(), linkage, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/declarations/global-variable.h
+++ b/hilti/toolchain/include/ast/declarations/global-variable.h
@@ -20,8 +20,8 @@ public:
     auto init() const { return child<hilti::Expression>(1); }
     auto typeArguments() const { return children<hilti::Expression>(2, {}); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t->recreateAsLhs(ctx)); }
-    void setInit(ASTContext* ctx, ExpressionPtr init) { setChild(ctx, 1, std::move(init)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t->recreateAsLhs(ctx)); }
+    void setInit(ASTContext* ctx, hilti::Expression* init) { setChild(ctx, 1, init); }
 
     void setTypeArguments(ASTContext* ctx, Expressions args) {
         removeChildren(2, {});
@@ -30,25 +30,24 @@ public:
 
     std::string_view displayName() const final { return "global variable"; }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, Expressions args,
-                       ExpressionPtr init = nullptr, declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
-        return std::shared_ptr<GlobalVariable>(
-            new GlobalVariable(ctx, node::flatten(type->recreateAsLhs(ctx), std::move(init), std::move(args)),
-                               std::move(id), linkage, std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, Expressions args, hilti::Expression* init = nullptr,
+                       declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
+        return ctx->make<GlobalVariable>(ctx, node::flatten(type->recreateAsLhs(ctx), init, std::move(args)),
+                                         std::move(id), linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, ExpressionPtr init = nullptr,
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, hilti::Expression* init = nullptr,
                        declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
-        return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, std::move(init), linkage, std::move(meta));
+        return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, init, linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type,
-                       declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, declaration::Linkage linkage = Linkage::Private,
+                       Meta meta = {}) {
         return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, nullptr, linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& init,
-                       declaration::Linkage linkage = Linkage::Private, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* init, declaration::Linkage linkage = Linkage::Private,
+                       const Meta& meta = {}) {
         return create(ctx, std::move(id), QualifiedType::createAuto(ctx, meta), {}, init, linkage, meta);
     }
 

--- a/hilti/toolchain/include/ast/declarations/imported-module.h
+++ b/hilti/toolchain/include/ast/declarations/imported-module.h
@@ -51,28 +51,26 @@ public:
     }
 
     static auto create(ASTContext* ctx, ID id, const std::string& parse_extension, Meta meta = {}) {
-        return std::shared_ptr<ImportedModule>(
-            new ImportedModule(ctx, std::move(id), {}, parse_extension, {}, {}, std::move(meta)));
+        return ctx->make<ImportedModule>(ctx, std::move(id), hilti::rt::filesystem::path{}, parse_extension, ID{},
+                                         std::move(meta));
     }
 
     static auto create(ASTContext* ctx, ID id, const std::string& parse_extension, ID search_scope, Meta meta = {}) {
-        return DeclarationPtr(
-            new ImportedModule(ctx, std::move(id), {}, parse_extension, std::move(search_scope), {}, std::move(meta)));
+        return ctx->make<ImportedModule>(ctx, std::move(id), hilti::rt::filesystem::path{}, parse_extension,
+                                         std::move(search_scope), std::move(meta));
     }
 
     static auto create(ASTContext* ctx, ID id, hilti::rt::filesystem::path path, Meta meta = {}) {
-        return std::shared_ptr<ImportedModule>(
-            new ImportedModule(ctx, std::move(id), std::move(path), {}, {}, {}, std::move(meta)));
+        return ctx->make<ImportedModule>(ctx, std::move(id), std::move(path), std::string{}, ID{}, std::move(meta));
     }
 
 protected:
     ImportedModule(ASTContext* ctx, ID id, hilti::rt::filesystem::path path, const std::string& parse_extension,
-                   ID search_scope, std::vector<hilti::rt::filesystem::path> search_dirs, Meta meta)
+                   ID search_scope, Meta meta)
         : Declaration(ctx, NodeTags, {}, std::move(id), Linkage::Private, std::move(meta)),
           _path(std::move(path)),
           _parse_extension(parse_extension),
-          _scope(std::move(search_scope)),
-          _dirs(std::move(search_dirs)) {}
+          _scope(std::move(search_scope)) {}
 
     HILTI_NODE_1(declaration::ImportedModule, Declaration, final);
 

--- a/hilti/toolchain/include/ast/declarations/local-variable.h
+++ b/hilti/toolchain/include/ast/declarations/local-variable.h
@@ -21,8 +21,8 @@ public:
 
     auto typeArguments() const { return children<hilti::Expression>(2, {}); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t->recreateAsLhs(ctx)); }
-    void setInit(ASTContext* ctx, ExpressionPtr init) { setChild(ctx, 1, std::move(init)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t->recreateAsLhs(ctx)); }
+    void setInit(ASTContext* ctx, hilti::Expression* init) { setChild(ctx, 1, init); }
 
     void setTypeArguments(ASTContext* ctx, Expressions args) {
         removeChildren(2, {});
@@ -31,23 +31,22 @@ public:
 
     std::string_view displayName() const final { return "local variable"; }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, Expressions args,
-                       ExpressionPtr init = nullptr, Meta meta = {}) {
-        return std::shared_ptr<LocalVariable>(
-            new LocalVariable(ctx, node::flatten(type->recreateAsLhs(ctx), std::move(init), std::move(args)),
-                              std::move(id), std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, Expressions args, hilti::Expression* init = nullptr,
+                       Meta meta = {}) {
+        return ctx->make<LocalVariable>(ctx, node::flatten(type->recreateAsLhs(ctx), init, std::move(args)),
+                                        std::move(id), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, ExpressionPtr init, Meta meta = {}) {
-        return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, std::move(init), std::move(meta));
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, hilti::Expression* init, Meta meta = {}) {
+        return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, init, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, Meta meta = {}) {
         return create(ctx, std::move(id), type->recreateAsLhs(ctx), {}, nullptr, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, ExpressionPtr init, const Meta& meta = {}) {
-        return create(ctx, std::move(id), QualifiedType::createAuto(ctx, meta), {}, std::move(init), meta);
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* init, const Meta& meta = {}) {
+        return create(ctx, std::move(id), QualifiedType::createAuto(ctx, meta), {}, init, meta);
     }
 
     static auto create(ASTContext* ctx, ID id, const Meta& meta = {}) {

--- a/hilti/toolchain/include/ast/declarations/module.h
+++ b/hilti/toolchain/include/ast/declarations/module.h
@@ -54,7 +54,7 @@ public:
      *
      * @param id name of the property to return
      */
-    PropertyPtr moduleProperty(const ID& id) const;
+    Property* moduleProperty(const ID& id) const;
 
     /**
      * Returns all of module's property declarations of a given name. If
@@ -68,14 +68,14 @@ public:
      * Adds a declaration to the module. It will be appended to the current
      * list of declarations.
      */
-    void add(ASTContext* ctx, DeclarationPtr d) { addChild(ctx, std::move(d)); }
+    void add(ASTContext* ctx, Declaration* d) { addChild(ctx, d); }
 
     /**
      * Adds a top-level statement to the module. It will be appended to the
      * end of the current list of statements and execute at module initialize
      * time.
      */
-    void add(ASTContext* ctx, StatementPtr s) { child<statement::Block>(0)->add(ctx, std::move(s)); }
+    void add(ASTContext* ctx, Statement* s) { child<statement::Block>(0)->add(ctx, s); }
 
     void addDependency(declaration::module::UID uid) { _dependencies.emplace_back(std::move(uid)); }
     void setScopePath(const ID& scope) { _scope_path = scope; }
@@ -96,22 +96,21 @@ public:
     std::string_view branchTag() const final { return _uid.process_extension.native(); }
 
     static auto create(ASTContext* ctx, const declaration::module::UID& uid, const ID& scope, const Declarations& decls,
-                       Statements stmts, const Meta& meta = {}) {
+                       Statements stmts, Meta meta = {}) {
         Nodes nodes = {statement::Block::create(ctx, std::move(stmts), meta)};
         for ( auto d : decls )
-            nodes.push_back(std::move(d));
+            nodes.push_back(d);
 
-        return std::shared_ptr<Module>(new Module(ctx, std::move(nodes), uid, scope, meta));
+        return ctx->make<Module>(ctx, std::move(nodes), uid, scope, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const declaration::module::UID& uid, const ID& scope = {},
-                       const Meta& meta = {}) {
-        return create(ctx, uid, scope, {}, {}, meta);
+    static auto create(ASTContext* ctx, const declaration::module::UID& uid, const ID& scope = {}, Meta meta = {}) {
+        return create(ctx, uid, scope, {}, {}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, const declaration::module::UID& uid, const ID& scope, const Declarations& decls,
-                       const Meta& meta = {}) {
-        return create(ctx, uid, scope, decls, {}, meta);
+                       Meta meta = {}) {
+        return create(ctx, uid, scope, decls, {}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/declarations/parameter.h
+++ b/hilti/toolchain/include/ast/declarations/parameter.h
@@ -54,9 +54,9 @@ public:
     auto isTypeParameter() const { return _is_type_param; }
     auto isResolved(node::CycleDetector* cd = nullptr) const { return type()->isResolved(cd); }
 
-    void setDefault(ASTContext* ctx, const ExpressionPtr& e) { setChild(ctx, 1, e); }
+    void setDefault(ASTContext* ctx, hilti::Expression* e) { setChild(ctx, 1, e); }
     void setIsTypeParameter() { _is_type_param = true; }
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
     std::string_view displayName() const final { return "parameter"; }
 
@@ -65,23 +65,22 @@ public:
         return Declaration::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, ID id, const UnqualifiedTypePtr& type, parameter::Kind kind,
-                       const hilti::ExpressionPtr& default_, AttributeSetPtr attrs, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, UnqualifiedType* type, parameter::Kind kind, hilti::Expression* default_,
+                       AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Parameter>(new Parameter(ctx, {_qtype(ctx, type, kind), default_, attrs}, std::move(id),
-                                                        kind, false, std::move(meta)));
+        return ctx->make<Parameter>(ctx, {_qtype(ctx, type, kind), default_, attrs}, std::move(id), kind, false,
+                                    std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const UnqualifiedTypePtr& type, parameter::Kind kind,
-                       const hilti::ExpressionPtr& default_, bool is_type_param, AttributeSetPtr attrs,
-                       Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, UnqualifiedType* type, parameter::Kind kind, hilti::Expression* default_,
+                       bool is_type_param, AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return DeclarationPtr(new Parameter(ctx, {_qtype(ctx, type, kind), default_, attrs}, std::move(id), kind,
-                                            is_type_param, std::move(meta)));
+        return ctx->make<Parameter>(ctx, {_qtype(ctx, type, kind), default_, attrs}, std::move(id), kind, is_type_param,
+                                    std::move(meta));
     }
 
 protected:
@@ -95,7 +94,7 @@ protected:
     HILTI_NODE_1(declaration::Parameter, Declaration, final);
 
 private:
-    static QualifiedTypePtr _qtype(ASTContext* ctx, const UnqualifiedTypePtr& t, parameter::Kind kind) {
+    static QualifiedType* _qtype(ASTContext* ctx, UnqualifiedType* t, parameter::Kind kind) {
         switch ( kind ) {
             case parameter::Kind::Copy: return QualifiedType::create(ctx, t, Constness::Mutable, Side::LHS, t->meta());
             case parameter::Kind::In: return QualifiedType::create(ctx, t, Constness::Const, Side::RHS, t->meta());
@@ -109,15 +108,14 @@ private:
     bool _is_type_param = false;
 };
 
-using ParameterPtr = std::shared_ptr<declaration::Parameter>;
-using Parameters = std::vector<ParameterPtr>;
+using Parameters = std::vector<Parameter*>;
 
 } // namespace hilti::declaration
 
 namespace hilti::declaration {
 
 /** Returns true if two parameters are different only by name of their ID. */
-inline bool areEquivalent(const ParameterPtr& p1, const ParameterPtr& p2) {
+inline bool areEquivalent(Parameter* p1, Parameter* p2) {
     if ( p1->kind() != p2->kind() )
         return false;
 

--- a/hilti/toolchain/include/ast/declarations/parameter.h
+++ b/hilti/toolchain/include/ast/declarations/parameter.h
@@ -108,7 +108,7 @@ private:
     bool _is_type_param = false;
 };
 
-using Parameters = std::vector<Parameter*>;
+using Parameters = NodeVector<Parameter>;
 
 } // namespace hilti::declaration
 

--- a/hilti/toolchain/include/ast/declarations/property.h
+++ b/hilti/toolchain/include/ast/declarations/property.h
@@ -20,11 +20,11 @@ public:
     std::string_view displayName() const final { return "property"; }
 
     static auto create(ASTContext* ctx, ID id, Meta meta = {}) {
-        return std::shared_ptr<Property>(new Property(ctx, {}, std::move(id), std::move(meta)));
+        return ctx->make<Property>(ctx, {}, std::move(id), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const ExpressionPtr& expr, Meta meta = {}) {
-        return std::shared_ptr<Property>(new Property(ctx, {expr}, std::move(id), std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* expr, Meta meta = {}) {
+        return ctx->make<Property>(ctx, {expr}, std::move(id), std::move(meta));
     }
 
 protected:
@@ -34,7 +34,6 @@ protected:
     HILTI_NODE_1(declaration::Property, Declaration, final);
 };
 
-using PropertyPtr = std::shared_ptr<Property>;
 using Properties = std::vector<Property>;
 
 } // namespace hilti::declaration

--- a/hilti/toolchain/include/ast/declarations/type.h
+++ b/hilti/toolchain/include/ast/declarations/type.h
@@ -31,9 +31,9 @@ public:
     /** Shortcut to `type::cxxID()` for the declared type. */
     auto cxxID() const { return child<QualifiedType>(0)->type()->cxxID(); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    void addAttribute(ASTContext* ctx, const AttributePtr& a) { attributes()->add(ctx, a); }
+    void addAttribute(ASTContext* ctx, Attribute* a) { attributes()->add(ctx, a); }
 
     node::Properties properties() const final {
         auto p = node::Properties{};
@@ -42,16 +42,16 @@ public:
 
     std::string_view displayName() const final { return "type"; }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, AttributeSetPtr attrs,
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, AttributeSet* attrs,
                        declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Type>(new Type(ctx, {type, attrs}, std::move(id), linkage, std::move(meta)));
+        return ctx->make<Type>(ctx, {type, attrs}, std::move(id), linkage, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type,
-                       declaration::Linkage linkage = Linkage::Private, Meta meta = {}) {
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, declaration::Linkage linkage = Linkage::Private,
+                       Meta meta = {}) {
         return create(ctx, std::move(id), type, AttributeSet::create(ctx), linkage, std::move(meta));
     }
 

--- a/hilti/toolchain/include/ast/expression.h
+++ b/hilti/toolchain/include/ast/expression.h
@@ -21,7 +21,7 @@ public:
     auto isResolved(node::CycleDetector* cd = nullptr) const { return type()->type()->isResolved(cd); }
 
     /** Returns the expression's HILTI type when evaluated. */
-    virtual QualifiedTypePtr type() const = 0;
+    virtual QualifiedType* type() const = 0;
 
 protected:
     Expression(ASTContext* ctx, node::Tags node_tags, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/expressions/assign.h
+++ b/hilti/toolchain/include/ast/expressions/assign.h
@@ -16,12 +16,12 @@ public:
     auto target() const { return child<Expression>(0); }
     auto source() const { return child<Expression>(1); }
 
-    QualifiedTypePtr type() const final { return target()->type(); }
+    QualifiedType* type() const final { return target()->type(); }
 
-    void setSource(ASTContext* ctx, const ExpressionPtr& src) { setChild(ctx, 1, src); }
+    void setSource(ASTContext* ctx, Expression* src) { setChild(ctx, 1, src); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& target, const ExpressionPtr& src, const Meta& meta = {}) {
-        return std::shared_ptr<Assign>(new Assign(ctx, {target, src}, meta));
+    static auto create(ASTContext* ctx, Expression* target, Expression* src, Meta meta = {}) {
+        return ctx->make<Assign>(ctx, {target, src}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/builtin-function.h
+++ b/hilti/toolchain/include/ast/expressions/builtin-function.h
@@ -21,7 +21,7 @@ public:
     const auto& cxxname() const { return _cxxname; }
     const auto& name() const { return _name; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"name", _name}, {"cxxname", _cxxname}};
@@ -42,12 +42,10 @@ public:
      * @param arguments arguments to the function call
      * @param m meta information for the function call
      */
-    static auto create(ASTContext* ctx, const std::string& name, const std::string& cxxname,
-                       const QualifiedTypePtr& type, const type::function::Parameters& parameters,
-                       const Expressions& arguments, const Meta& meta = {}) {
-        return std::shared_ptr<BuiltInFunction>(new BuiltInFunction(ctx, node::flatten(type, parameters, arguments),
-                                                                    name, cxxname, static_cast<int>(parameters.size()),
-                                                                    meta));
+    static auto create(ASTContext* ctx, const std::string& name, const std::string& cxxname, QualifiedType* type,
+                       const type::function::Parameters& parameters, const Expressions& arguments, Meta meta = {}) {
+        return ctx->make<BuiltInFunction>(ctx, node::flatten(type, parameters, arguments), name, cxxname,
+                                          static_cast<int>(parameters.size()), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/coerced.h
+++ b/hilti/toolchain/include/ast/expressions/coerced.h
@@ -15,11 +15,10 @@ class Coerced : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const QualifiedTypePtr& target,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Coerced>(new Coerced(ctx, {expr, target}, meta));
+    static auto create(ASTContext* ctx, Expression* expr, QualifiedType* target, Meta meta = {}) {
+        return ctx->make<Coerced>(ctx, {expr, target}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/ctor.h
+++ b/hilti/toolchain/include/ast/expressions/ctor.h
@@ -16,10 +16,10 @@ class Ctor : public Expression {
 public:
     auto ctor() const { return child<hilti::Ctor>(0); }
 
-    QualifiedTypePtr type() const final { return ctor()->type(); }
+    QualifiedType* type() const final { return ctor()->type(); }
 
-    static auto create(ASTContext* ctx, const CtorPtr& ctor, const Meta& meta = {}) {
-        return std::shared_ptr<Ctor>(new Ctor(ctx, {ctor}, meta));
+    static auto create(ASTContext* ctx, hilti::Ctor* ctor, Meta meta = {}) {
+        return ctx->make<Ctor>(ctx, {ctor}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/deferred.h
+++ b/hilti/toolchain/include/ast/expressions/deferred.h
@@ -21,21 +21,20 @@ public:
     auto expression() const { return child<Expression>(0); }
     bool catchException() const { return _catch_exception; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"catch_exception", _catch_exception}};
         return Expression::properties() + p;
     }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 1, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 1, t); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, bool catch_exception, const Meta& meta = {}) {
-        return std::shared_ptr<Deferred>(
-            new Deferred(ctx, {expr, QualifiedType::createAuto(ctx, meta)}, catch_exception, meta));
+    static auto create(ASTContext* ctx, Expression* expr, bool catch_exception, const Meta& meta = {}) {
+        return ctx->make<Deferred>(ctx, {expr, QualifiedType::createAuto(ctx, meta)}, catch_exception, meta);
     }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expression* expr, const Meta& meta = {}) {
         return create(ctx, expr, false, meta);
     }
 

--- a/hilti/toolchain/include/ast/expressions/grouping.h
+++ b/hilti/toolchain/include/ast/expressions/grouping.h
@@ -15,10 +15,10 @@ class Grouping : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return expression()->type(); }
+    QualifiedType* type() const final { return expression()->type(); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
-        return std::shared_ptr<Grouping>(new Grouping(ctx, {expr}, meta));
+    static auto create(ASTContext* ctx, Expression* expr, Meta meta = {}) {
+        return ctx->make<Grouping>(ctx, {expr}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/keyword.h
+++ b/hilti/toolchain/include/ast/expressions/keyword.h
@@ -41,17 +41,17 @@ constexpr auto to_string(Kind m) { return util::enum_::to_string(m, detail::Kind
 class Keyword : public Expression {
 public:
     keyword::Kind kind() const { return _kind; }
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{{"kind", to_string(_kind)}}};
         return Expression::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, keyword::Kind kind, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return std::shared_ptr<Keyword>(new Keyword(ctx, {type}, kind, meta));
+    static auto create(ASTContext* ctx, keyword::Kind kind, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<Keyword>(ctx, {type}, kind, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, keyword::Kind kind, const Meta& meta = {}) {
@@ -59,9 +59,9 @@ public:
     }
 
     /** Helper to create `$$` a declaration of a given type. */
-    static auto createDollarDollarDeclaration(ASTContext* ctx, const QualifiedTypePtr& type) {
+    static auto createDollarDollarDeclaration(ASTContext* ctx, QualifiedType* type) {
         auto kw = create(ctx, keyword::Kind::DollarDollar, type);
-        return declaration::Expression::create(ctx, "__dd", kw, hilti::declaration::Linkage::Private);
+        return declaration::Expression::create(ctx, ID("__dd"), kw, hilti::declaration::Linkage::Private);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/list-comprehension.h
+++ b/hilti/toolchain/include/ast/expressions/list-comprehension.h
@@ -27,16 +27,16 @@ public:
      */
     auto scope() const { return output()->scope(); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(4); }
+    QualifiedType* type() const final { return child<QualifiedType>(4); }
 
-    void setType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 4, t); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 4, t); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& input, const ExpressionPtr& output, const ID& id,
-                       const ExpressionPtr& cond, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expression* input, Expression* output, const ID& id, Expression* cond,
+                       Meta meta = {}) {
         auto local = declaration::LocalVariable::create(ctx, id, QualifiedType::createAuto(ctx, meta), meta);
         auto list = QualifiedType::create(ctx, type::List::create(ctx, QualifiedType::createAuto(ctx, meta), meta),
                                           Constness::Const);
-        return std::shared_ptr<ListComprehension>(new ListComprehension(ctx, {input, output, local, cond, list}, meta));
+        return ctx->make<ListComprehension>(ctx, {input, output, local, cond, list}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/logical-and.h
+++ b/hilti/toolchain/include/ast/expressions/logical-and.h
@@ -17,15 +17,16 @@ public:
     auto op0() const { return child<Expression>(0); }
     auto op1() const { return child<Expression>(1); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(2); }
+    QualifiedType* type() const final { return child<QualifiedType>(2); }
 
-    void setOp0(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 0, std::move(e)); }
-    void setOp1(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 1, std::move(e)); }
+    void setOp0(ASTContext* ctx, Expression* e) { setChild(ctx, 0, e); }
+    void setOp1(ASTContext* ctx, Expression* e) { setChild(ctx, 1, e); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& meta = {}) {
-        return std::shared_ptr<LogicalAnd>(
-            new LogicalAnd(ctx, {op0, op1, QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
-                           meta));
+    static auto create(ASTContext* ctx, Expression* op0, Expression* op1, const Meta& meta = {}) {
+        return ctx->make<LogicalAnd>(ctx,
+                                     {op0, op1,
+                                      QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
+                                     meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/logical-not.h
+++ b/hilti/toolchain/include/ast/expressions/logical-not.h
@@ -16,15 +16,15 @@ class LogicalNot : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    void setExpression(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 0, std::move(e)); }
+    void setExpression(ASTContext* ctx, Expression* e) { setChild(ctx, 0, e); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expression, const Meta& meta = {}) {
-        return std::shared_ptr<LogicalNot>(
-            new LogicalNot(ctx,
-                           {expression, QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
-                           meta));
+    static auto create(ASTContext* ctx, Expression* expression, const Meta& meta = {}) {
+        return ctx->make<LogicalNot>(ctx,
+                                     {expression,
+                                      QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
+                                     meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/logical-or.h
+++ b/hilti/toolchain/include/ast/expressions/logical-or.h
@@ -17,15 +17,16 @@ public:
     auto op0() const { return child<Expression>(0); }
     auto op1() const { return child<Expression>(1); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(2); }
+    QualifiedType* type() const final { return child<QualifiedType>(2); }
 
-    void setOp0(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 0, std::move(e)); }
-    void setOp1(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 1, std::move(e)); }
+    void setOp0(ASTContext* ctx, Expression* e) { setChild(ctx, 0, e); }
+    void setOp1(ASTContext* ctx, Expression* e) { setChild(ctx, 1, e); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& op0, const ExpressionPtr& op1, const Meta& meta = {}) {
-        return std::shared_ptr<LogicalOr>(
-            new LogicalOr(ctx, {op0, op1, QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
-                          meta));
+    static auto create(ASTContext* ctx, Expression* op0, Expression* op1, const Meta& meta = {}) {
+        return ctx->make<LogicalOr>(ctx,
+                                    {op0, op1,
+                                     QualifiedType::create(ctx, type::Bool::create(ctx, meta), Constness::Const)},
+                                    meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/member.h
+++ b/hilti/toolchain/include/ast/expressions/member.h
@@ -17,16 +17,15 @@ class Member : public Expression {
 public:
     const auto& id() const { return _id; }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     node::Properties properties() const final {
         auto p = node::Properties{{"id", _id}};
         return Expression::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& member_type, const hilti::ID& id,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Member>(new Member(ctx, {member_type}, id, meta));
+    static auto create(ASTContext* ctx, QualifiedType* member_type, const hilti::ID& id, Meta meta = {}) {
+        return ctx->make<Member>(ctx, {member_type}, id, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, const hilti::ID& id, const Meta& meta = {}) {

--- a/hilti/toolchain/include/ast/expressions/move.h
+++ b/hilti/toolchain/include/ast/expressions/move.h
@@ -16,10 +16,10 @@ class Move : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return expression()->type(); }
+    QualifiedType* type() const final { return expression()->type(); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expression, const Meta& meta = {}) {
-        return std::shared_ptr<Move>(new Move(ctx, {expression}, meta));
+    static auto create(ASTContext* ctx, Expression* expression, Meta meta = {}) {
+        return ctx->make<Move>(ctx, {expression}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/name.h
+++ b/hilti/toolchain/include/ast/expressions/name.h
@@ -24,7 +24,7 @@ public:
     const auto& fullyQualifiedID() const { return _fqid; }
 
     /** If the resolver has resolved the name to a declaration, returns it. */
-    DeclarationPtr resolvedDeclaration() {
+    Declaration* resolvedDeclaration() {
         if ( ! _resolved_declaration_index )
             return nullptr;
 
@@ -40,7 +40,7 @@ public:
      * declaration. If it has been resolved to a type, the type will bewrapped
      * into `type::Type()`.
      */
-    QualifiedTypePtr type() const final;
+    QualifiedType* type() const final;
 
     /**
      * Sets the declaration that the name has been resolved to. This then lets
@@ -73,7 +73,7 @@ public:
     node::Properties properties() const final;
 
     static auto create(ASTContext* ctx, const hilti::ID& id, const Meta& meta = {}) {
-        return std::shared_ptr<Name>(new Name(ctx, {QualifiedType::createAuto(ctx, meta)}, id, meta));
+        return ctx->make<Name>(ctx, {QualifiedType::createAuto(ctx, meta)}, id, meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/pending-coerced.h
+++ b/hilti/toolchain/include/ast/expressions/pending-coerced.h
@@ -18,11 +18,10 @@ class PendingCoerced : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const QualifiedTypePtr& type,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<PendingCoerced>(new PendingCoerced(ctx, {expr, type}, meta));
+    static auto create(ASTContext* ctx, Expression* expr, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<PendingCoerced>(ctx, {expr, type}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/resolved-operator.h
+++ b/hilti/toolchain/include/ast/expressions/resolved-operator.h
@@ -32,11 +32,11 @@ public:
     auto hasOp1() const { return children().size() >= 3; }
     auto hasOp2() const { return children().size() >= 4; }
 
-    void setOp0(ASTContext* ctx, const ExpressionPtr& e) { setChild(ctx, 1, e); }
-    void setOp1(ASTContext* ctx, const ExpressionPtr& e) { setChild(ctx, 2, e); }
-    void setOp2(ASTContext* ctx, const ExpressionPtr& e) { setChild(ctx, 3, e); }
+    void setOp0(ASTContext* ctx, Expression* e) { setChild(ctx, 1, e); }
+    void setOp1(ASTContext* ctx, Expression* e) { setChild(ctx, 2, e); }
+    void setOp2(ASTContext* ctx, Expression* e) { setChild(ctx, 3, e); }
 
-    QualifiedTypePtr type() const final { return result(); }
+    QualifiedType* type() const final { return result(); }
 
     std::string printSignature() const { return operator_::detail::printSignature(kind(), operands(), meta()); }
 
@@ -48,7 +48,7 @@ public:
     HILTI_NODE_1(expression::ResolvedOperator, Expression, override);
 
 protected:
-    ResolvedOperator(ASTContext* ctx, node::Tags node_tags, const Operator* op, const QualifiedTypePtr& result,
+    ResolvedOperator(ASTContext* ctx, node::Tags node_tags, const Operator* op, QualifiedType* result,
                      const Expressions& operands, Meta meta)
         : Expression(ctx, node_tags, node::flatten(result, operands), std::move(meta)), _operator(op) {}
 

--- a/hilti/toolchain/include/ast/expressions/ternary.h
+++ b/hilti/toolchain/include/ast/expressions/ternary.h
@@ -17,18 +17,17 @@ public:
     auto true_() const { return child<Expression>(1); }
     auto false_() const { return child<Expression>(2); }
 
-    QualifiedTypePtr type() const final {
+    QualifiedType* type() const final {
         // TODO(robin): Currently we enforce both having the same type; we
         // might need to coerce to target type though.
         return true_()->type();
     }
 
-    void setTrue(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 1, std::move(e)); }
-    void setFalse(ASTContext* ctx, ExpressionPtr e) { setChild(ctx, 2, std::move(e)); }
+    void setTrue(ASTContext* ctx, Expression* e) { setChild(ctx, 1, e); }
+    void setFalse(ASTContext* ctx, Expression* e) { setChild(ctx, 2, e); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& cond, const ExpressionPtr& true_,
-                       const ExpressionPtr& false_, const Meta& meta = {}) {
-        return std::shared_ptr<Ternary>(new Ternary(ctx, {cond, true_, false_}, meta));
+    static auto create(ASTContext* ctx, Expression* cond, Expression* true_, Expression* false_, Meta meta = {}) {
+        return ctx->make<Ternary>(ctx, {cond, true_, false_}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/type-wrapped.h
+++ b/hilti/toolchain/include/ast/expressions/type-wrapped.h
@@ -15,11 +15,10 @@ class TypeWrapped : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const QualifiedTypePtr& type,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<TypeWrapped>(new TypeWrapped(ctx, {expr, type}, meta));
+    static auto create(ASTContext* ctx, Expression* expr, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<TypeWrapped>(ctx, {expr, type}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/type.h
+++ b/hilti/toolchain/include/ast/expressions/type.h
@@ -16,12 +16,13 @@ class Type_ : public Expression {
 public:
     auto typeValue() const { return type()->type()->as<type::Type_>()->typeValue(); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, const Meta& meta = {}) {
-        return std::shared_ptr<Type_>(
-            new Type_(ctx, {QualifiedType::create(ctx, type::Type_::create(ctx, type, meta), Constness::Const, meta)},
-                      meta));
+    static auto create(ASTContext* ctx, QualifiedType* type, const Meta& meta = {}) {
+        return ctx->make<Type_>(ctx,
+                                {QualifiedType::create(ctx, type::Type_::create(ctx, type, meta), Constness::Const,
+                                                       meta)},
+                                meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/typeinfo.h
+++ b/hilti/toolchain/include/ast/expressions/typeinfo.h
@@ -16,12 +16,12 @@ class TypeInfo : public Expression {
 public:
     auto expression() const { return child<Expression>(0); }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(1); }
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expression* expr, Meta meta = {}) {
         auto ti =
             QualifiedType::create(ctx, type::Library::create(ctx, "hilti::rt::TypeInfo const*"), Constness::Const);
-        return std::shared_ptr<TypeInfo>(new TypeInfo(ctx, {expr, ti}, meta));
+        return ctx->make<TypeInfo>(ctx, {expr, ti}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/unresolved-operator.h
+++ b/hilti/toolchain/include/ast/expressions/unresolved-operator.h
@@ -32,15 +32,15 @@ public:
     }
 
     // Accelerated accessors for the first three operands, returning raw pointers.
-    const Expression* op0() const { return static_cast<Expression*>(children()[1].get()); }
-    const Expression* op1() const { return static_cast<Expression*>(children()[2].get()); }
-    const Expression* op2() const { return static_cast<Expression*>(children()[3].get()); }
+    Expression* op0() const { return static_cast<Expression*>(children()[1]); }
+    Expression* op1() const { return static_cast<Expression*>(children()[2]); }
+    Expression* op2() const { return static_cast<Expression*>(children()[3]); }
 
     /** Implements interface for use with `OverloadRegistry`. */
     hilti::node::Range<Expression> operands() const { return children<Expression>(1, {}); }
 
     // Dummy implementations as the node will be rejected in validation anyway.
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     std::string printSignature() const { return operator_::detail::printSignature(kind(), operands(), Meta()); }
 
@@ -50,15 +50,15 @@ public:
     }
 
     static auto create(ASTContext* ctx, operator_::Kind kind, Expressions operands, const Meta& meta = {}) {
-        return ExpressionPtr(
-            new UnresolvedOperator(ctx, node::flatten(QualifiedType::createAuto(ctx, meta), std::move(operands)), kind,
-                                   meta));
+        return ctx->make<UnresolvedOperator>(ctx,
+                                             node::flatten(QualifiedType::createAuto(ctx, meta), std::move(operands)),
+                                             kind, meta);
     }
 
     static auto create(ASTContext* ctx, operator_::Kind kind, hilti::node::Range<Expression> operands,
                        const Meta& meta = {}) {
-        return ExpressionPtr(
-            new UnresolvedOperator(ctx, node::flatten(QualifiedType::createAuto(ctx, meta), operands), kind, meta));
+        return ctx->make<UnresolvedOperator>(ctx, node::flatten(QualifiedType::createAuto(ctx, meta), operands), kind,
+                                             meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/expressions/void.h
+++ b/hilti/toolchain/include/ast/expressions/void.h
@@ -14,11 +14,11 @@ namespace hilti::expression {
 /** AST node for a void expression. */
 class Void : public Expression {
 public:
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
     static auto create(ASTContext* ctx, const Meta& meta = {}) {
-        return std::shared_ptr<Void>(
-            new Void(ctx, {QualifiedType::create(ctx, type::Void::create(ctx, meta), Constness::Const)}, meta));
+        return ctx->make<Void>(ctx, {QualifiedType::create(ctx, type::Void::create(ctx, meta), Constness::Const)},
+                               meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/forward.h
+++ b/hilti/toolchain/include/ast/forward.h
@@ -86,8 +86,6 @@ class Parameter;
 class Property;
 class Type;
 
-using ParameterPtr = std::shared_ptr<Parameter>;
-
 } // namespace declaration
 
 namespace expression {
@@ -710,7 +708,6 @@ class Iterator;
 
 namespace function {
 using Parameter = declaration::Parameter;
-using ParameterPtr = declaration::ParameterPtr;
 } // namespace function
 
 namespace tuple {
@@ -727,29 +724,12 @@ class Operand;
 
 } // namespace type
 
-using ASTRootPtr = std::shared_ptr<ASTRoot>;
-using AttributePtr = std::shared_ptr<Attribute>;
-using AttributeSetPtr = std::shared_ptr<AttributeSet>;
-using CtorPtr = std::shared_ptr<Ctor>;
-using DeclarationPtr = std::shared_ptr<Declaration>;
-using ExpressionPtr = std::shared_ptr<Expression>;
-using FunctionPtr = std::shared_ptr<Function>;
-using ModulePtr = std::shared_ptr<declaration::Module>;
-using NodePtr = std::shared_ptr<Node>;
-using StatementPtr = std::shared_ptr<Statement>;
-using UnqualifiedTypePtr = std::shared_ptr<UnqualifiedType>;
-using QualifiedTypePtr = std::shared_ptr<QualifiedType>;
-using ResolvedOperatorPtr = std::shared_ptr<expression::ResolvedOperator>;
-using UnresolvedOperatorPtr = std::shared_ptr<expression::UnresolvedOperator>;
-using OperandListPtr = std::shared_ptr<type::OperandList>;
-using OperandPtr = std::shared_ptr<type::operand_list::Operand>;
-
-using Attributes = std::vector<AttributePtr>;
-using Declarations = std::vector<DeclarationPtr>;
-using Expressions = std::vector<ExpressionPtr>;
-using Statements = std::vector<StatementPtr>;
-using QualifiedTypes = std::vector<QualifiedTypePtr>;
-using UnqualifiedTypes = std::vector<UnqualifiedTypePtr>;
+using Attributes = std::vector<Attribute*>;
+using Declarations = std::vector<Declaration*>;
+using Expressions = std::vector<Expression*>;
+using Statements = std::vector<Statement*>;
+using QualifiedTypes = std::vector<QualifiedType*>;
+using UnqualifiedTypes = std::vector<UnqualifiedType*>;
 
 class Builder;
 using BuilderPtr = std::shared_ptr<Builder>;

--- a/hilti/toolchain/include/ast/forward.h
+++ b/hilti/toolchain/include/ast/forward.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace hilti {
@@ -724,18 +725,40 @@ class Operand;
 
 } // namespace type
 
-using Attributes = std::vector<Attribute*>;
-using Declarations = std::vector<Declaration*>;
-using Expressions = std::vector<Expression*>;
-using Statements = std::vector<Statement*>;
-using QualifiedTypes = std::vector<QualifiedType*>;
-using UnqualifiedTypes = std::vector<UnqualifiedType*>;
+template<typename T>
+using NodeVector = std::vector<T*>;
+
+using Attributes = NodeVector<Attribute>;
+using Declarations = NodeVector<Declaration>;
+using Expressions = NodeVector<Expression>;
+using Statements = NodeVector<Statement>;
+using QualifiedTypes = NodeVector<QualifiedType>;
+using UnqualifiedTypes = NodeVector<UnqualifiedType>;
 
 class Builder;
 using BuilderPtr = std::shared_ptr<Builder>;
 
 class ASTContext;
-class Nodes;
 
+/**
+ * Container storing a set of nodes. This is just our standard vector with an
+ * additional constructor.
+ */
+class Nodes : public NodeVector<Node> {
+public:
+    using NodeVector<Node>::NodeVector;
+
+    /** Constructor accepting a vector of pointers to a derived class. */
+    template<typename T>
+    Nodes(NodeVector<T> m) {
+        reserve(m.size());
+        for ( auto* x : m )
+            emplace_back(x);
+    }
+
+    Nodes() = default;
+    Nodes(const Nodes&) = default;
+    Nodes(Nodes&&) = default;
+};
 
 } // namespace hilti

--- a/hilti/toolchain/include/ast/function.h
+++ b/hilti/toolchain/include/ast/function.h
@@ -52,23 +52,23 @@ public:
     auto callingConvention() const { return _cc; }
     auto isStatic() const { return attributes()->find("&static") != nullptr; }
 
-    void setBody(ASTContext* ctx, const StatementPtr& b) { setChild(ctx, 1, b); }
+    void setBody(ASTContext* ctx, Statement* b) { setChild(ctx, 1, b); }
     void setID(ID id) { _id = std::move(id); }
-    void setResultType(ASTContext* ctx, const QualifiedTypePtr& t) { ftype()->setResultType(ctx, t); }
+    void setResultType(ASTContext* ctx, QualifiedType* t) { ftype()->setResultType(ctx, t); }
 
     node::Properties properties() const override {
         auto p = node::Properties{{"id", _id}, {"cc", to_string(_cc)}};
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, const ID& id, const type::FunctionPtr& ftype, const StatementPtr& body,
+    static auto create(ASTContext* ctx, const ID& id, type::Function* ftype, Statement* body,
                        function::CallingConvention cc = function::CallingConvention::Standard,
-                       AttributeSetPtr attrs = nullptr, const Meta& meta = {}) {
+                       AttributeSet* attrs = nullptr, const Meta& meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Function>(
-            new Function(ctx, {QualifiedType::create(ctx, ftype, Constness::Const, meta), body, attrs}, id, cc, meta));
+        return ctx->make<Function>(ctx, {QualifiedType::create(ctx, ftype, Constness::Const, meta), body, attrs}, id,
+                                   cc, meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/node-range.h
+++ b/hilti/toolchain/include/ast/node-range.h
@@ -14,7 +14,7 @@ namespace hilti::node {
  * Container to store a set of node pointers. Retains insertion order of its elements.
  */
 template<typename T>
-using Set = std::vector<std::shared_ptr<T>>;
+using Set = std::vector<T*>;
 
 /**
  * A constant iterator over a range of nodes (`node::Range`). Internally, this
@@ -23,10 +23,10 @@ using Set = std::vector<std::shared_ptr<T>>;
  */
 template<typename T>
 class RangeIterator {
-    using BaseIterator = std::vector<NodePtr>::const_iterator;
+    using BaseIterator = std::vector<Node*>::const_iterator;
 
 public:
-    using value_type = std::shared_ptr<T>;
+    using value_type = T*;
     using difference_type = BaseIterator::difference_type;
     using pointer = BaseIterator::pointer;
     using reference = BaseIterator::reference;
@@ -42,7 +42,7 @@ public:
 
     RangeIterator& operator=(const RangeIterator& other) = default;
     RangeIterator& operator=(RangeIterator&& other) noexcept = default;
-    std::shared_ptr<T> operator*() const { return _value(); }
+    T* operator*() const { return _value(); }
     // T operator->() const { return &value(); }
     bool operator==(const RangeIterator& other) const { return _iter == other._iter; }
     bool operator!=(const RangeIterator& other) const { return ! (*this == other); }
@@ -73,9 +73,9 @@ public:
     auto operator+(difference_type i) const { return RangeIterator(_iter + i); }
 
 private:
-    std::shared_ptr<T> _value() const {
+    T* _value() const {
         if ( *_iter )
-            return std::static_pointer_cast<T>(*_iter);
+            return static_cast<T*>(*_iter);
         else
             return nullptr;
     }
@@ -96,13 +96,12 @@ public:
     using value_type = typename iterator::value_type;
 
     explicit Range() {}
-    Range(typename std::vector<std::shared_ptr<T>>::const_iterator begin,
-          typename std::vector<std::shared_ptr<T>>::const_iterator end)
+    Range(typename std::vector<T*>::const_iterator begin, typename std::vector<T*>::const_iterator end)
         : _begin(begin), _end(end) {}
 
-    explicit Range(const std::vector<std::shared_ptr<T>>& nodes) : Range(nodes.begin(), nodes.end()) {}
+    explicit Range(const std::vector<T*>& nodes) : Range(nodes.begin(), nodes.end()) {}
 
-    Range(std::vector<NodePtr>::const_iterator begin, std::vector<NodePtr>::const_iterator end)
+    Range(std::vector<Node*>::const_iterator begin, std::vector<Node*>::const_iterator end)
         : _begin(begin), _end(end) {}
 
     Range(const Range& other) = default;
@@ -115,15 +114,15 @@ public:
     const T& front() const { return *_begin; }
     bool empty() const { return _begin == _end; }
 
-    operator std::vector<std::shared_ptr<T>>() const {
-        std::vector<std::shared_ptr<T>> x;
+    operator std::vector<T*>() const {
+        std::vector<T*> x;
         for ( auto i = _begin; i != _end; i++ )
             x.push_back(*i);
 
         return x;
     }
 
-    std::shared_ptr<T> operator[](size_t i) const {
+    T* operator[](size_t i) const {
         assert(static_cast<typename RangeIterator<T>::difference_type>(i) < std::distance(_begin, _end));
         return *(_begin + i);
     }

--- a/hilti/toolchain/include/ast/node-range.h
+++ b/hilti/toolchain/include/ast/node-range.h
@@ -14,7 +14,7 @@ namespace hilti::node {
  * Container to store a set of node pointers. Retains insertion order of its elements.
  */
 template<typename T>
-using Set = std::vector<T*>;
+using Set = NodeVector<T>;
 
 /**
  * A constant iterator over a range of nodes (`node::Range`). Internally, this
@@ -23,7 +23,7 @@ using Set = std::vector<T*>;
  */
 template<typename T>
 class RangeIterator {
-    using BaseIterator = std::vector<Node*>::const_iterator;
+    using BaseIterator = Nodes::const_iterator;
 
 public:
     using value_type = T*;
@@ -96,13 +96,12 @@ public:
     using value_type = typename iterator::value_type;
 
     explicit Range() {}
-    Range(typename std::vector<T*>::const_iterator begin, typename std::vector<T*>::const_iterator end)
+    Range(typename NodeVector<T>::const_iterator begin, typename NodeVector<T>::const_iterator end)
         : _begin(begin), _end(end) {}
 
-    explicit Range(const std::vector<T*>& nodes) : Range(nodes.begin(), nodes.end()) {}
+    explicit Range(const NodeVector<T>& nodes) : Range(nodes.begin(), nodes.end()) {}
 
-    Range(std::vector<Node*>::const_iterator begin, std::vector<Node*>::const_iterator end)
-        : _begin(begin), _end(end) {}
+    Range(Nodes::const_iterator begin, Nodes::const_iterator end) : _begin(begin), _end(end) {}
 
     Range(const Range& other) = default;
     Range(Range&& other) noexcept = default;
@@ -114,8 +113,9 @@ public:
     const T& front() const { return *_begin; }
     bool empty() const { return _begin == _end; }
 
-    operator std::vector<T*>() const {
-        std::vector<T*> x;
+    operator NodeVector<T>() const {
+        NodeVector<T> x;
+        x.reserve(size());
         for ( auto i = _begin; i != _end; i++ )
             x.push_back(*i);
 

--- a/hilti/toolchain/include/ast/node-tag.h
+++ b/hilti/toolchain/include/ast/node-tag.h
@@ -21,687 +21,687 @@ extern std::string to_string(const Tags& ti);
 
 namespace tag {
 
-const Tag Node = 1;
+constexpr Tag Node = 1;
 
-const Tag ASTRoot = 100;
-const Tag Attribute = 101;
-const Tag AttributeSet = 102;
-const Tag Ctor = 103;
-const Tag Declaration = 104;
-const Tag Expression = 105;
-const Tag Function = 106;
-const Tag QualifiedType = 107;
-const Tag Statement = 108;
-const Tag UnqualifiedType = 109;
+constexpr Tag ASTRoot = 100;
+constexpr Tag Attribute = 101;
+constexpr Tag AttributeSet = 102;
+constexpr Tag Ctor = 103;
+constexpr Tag Declaration = 104;
+constexpr Tag Expression = 105;
+constexpr Tag Function = 106;
+constexpr Tag QualifiedType = 107;
+constexpr Tag Statement = 108;
+constexpr Tag UnqualifiedType = 109;
 
 namespace ctor::bitfield {
-const Tag BitRange = 110;
+constexpr Tag BitRange = 110;
 }
 
 namespace ctor::map {
-const Tag Element = 111;
+constexpr Tag Element = 111;
 }
 
 namespace ctor::struct_ {
-const Tag Field = 112;
+constexpr Tag Field = 112;
 }
 
 namespace statement::switch_ {
-const Tag Case = 113;
+constexpr Tag Case = 113;
 }
 
 namespace statement::try_ {
-const Tag Catch = 114;
+constexpr Tag Catch = 114;
 }
 
 namespace type::bitfield {
-const Tag BitRange = 115;
+constexpr Tag BitRange = 115;
 }
 
 namespace type::enum_ {
-const Tag Label = 116;
+constexpr Tag Label = 116;
 }
 
 namespace type::operand_list {
-const Tag Operand = 117;
+constexpr Tag Operand = 117;
 }
 
 namespace type::tuple {
-const Tag Element = 118;
+constexpr Tag Element = 118;
 }
 
 namespace ctor {
-const Tag Address = 200;
-const Tag Bitfield = 201;
-const Tag Bool = 202;
-const Tag Bytes = 203;
-const Tag Coerced = 204;
-const Tag Default = 205;
-const Tag Enum = 206;
-const Tag Error = 207;
-const Tag Exception = 208;
-const Tag Interval = 209;
-const Tag Library = 210;
-const Tag List = 211;
-const Tag Map = 212;
-const Tag Network = 213;
-const Tag Null = 214;
-const Tag Optional = 215;
-const Tag Port = 216;
-const Tag Real = 217;
-const Tag RegExp = 218;
-const Tag Result = 219;
-const Tag Set = 220;
-const Tag SignedInteger = 221;
-const Tag Stream = 222;
-const Tag String = 223;
-const Tag StrongReference = 224;
-const Tag Struct = 225;
-const Tag Time = 226;
-const Tag Tuple = 227;
-const Tag Union = 228;
-const Tag UnsignedInteger = 229;
-const Tag ValueReference = 230;
-const Tag Vector = 231;
-const Tag WeakReference = 232;
+constexpr Tag Address = 200;
+constexpr Tag Bitfield = 201;
+constexpr Tag Bool = 202;
+constexpr Tag Bytes = 203;
+constexpr Tag Coerced = 204;
+constexpr Tag Default = 205;
+constexpr Tag Enum = 206;
+constexpr Tag Error = 207;
+constexpr Tag Exception = 208;
+constexpr Tag Interval = 209;
+constexpr Tag Library = 210;
+constexpr Tag List = 211;
+constexpr Tag Map = 212;
+constexpr Tag Network = 213;
+constexpr Tag Null = 214;
+constexpr Tag Optional = 215;
+constexpr Tag Port = 216;
+constexpr Tag Real = 217;
+constexpr Tag RegExp = 218;
+constexpr Tag Result = 219;
+constexpr Tag Set = 220;
+constexpr Tag SignedInteger = 221;
+constexpr Tag Stream = 222;
+constexpr Tag String = 223;
+constexpr Tag StrongReference = 224;
+constexpr Tag Struct = 225;
+constexpr Tag Time = 226;
+constexpr Tag Tuple = 227;
+constexpr Tag Union = 228;
+constexpr Tag UnsignedInteger = 229;
+constexpr Tag ValueReference = 230;
+constexpr Tag Vector = 231;
+constexpr Tag WeakReference = 232;
 } // namespace ctor
 
 namespace declaration {
-const Tag Constant = 300;
-const Tag Expression = 301;
-const Tag Field = 302;
-const Tag Function = 303;
-const Tag GlobalVariable = 304;
-const Tag ImportedModule = 305;
-const Tag LocalVariable = 306;
-const Tag Module = 307;
-const Tag Parameter = 308;
-const Tag Property = 309;
-const Tag Type = 310;
+constexpr Tag Constant = 300;
+constexpr Tag Expression = 301;
+constexpr Tag Field = 302;
+constexpr Tag Function = 303;
+constexpr Tag GlobalVariable = 304;
+constexpr Tag ImportedModule = 305;
+constexpr Tag LocalVariable = 306;
+constexpr Tag Module = 307;
+constexpr Tag Parameter = 308;
+constexpr Tag Property = 309;
+constexpr Tag Type = 310;
 } // namespace declaration
 
 namespace expression {
-const Tag Assign = 400;
-const Tag BuiltInFunction = 401;
-const Tag Coerced = 402;
-const Tag Ctor = 403;
-const Tag Deferred = 404;
-const Tag Grouping = 405;
-const Tag Keyword = 406;
-const Tag ListComprehension = 407;
-const Tag LogicalAnd = 408;
-const Tag LogicalNot = 409;
-const Tag LogicalOr = 410;
-const Tag Member = 411;
-const Tag Move = 412;
-const Tag Name = 413;
-const Tag PendingCoerced = 414;
-const Tag Ternary = 415;
-const Tag TypeInfo = 416;
-const Tag TypeWrapped = 417;
-const Tag Type_ = 418;
-const Tag ResolvedOperator = 419;
-const Tag UnresolvedOperator = 420;
-const Tag Void = 421;
+constexpr Tag Assign = 400;
+constexpr Tag BuiltInFunction = 401;
+constexpr Tag Coerced = 402;
+constexpr Tag Ctor = 403;
+constexpr Tag Deferred = 404;
+constexpr Tag Grouping = 405;
+constexpr Tag Keyword = 406;
+constexpr Tag ListComprehension = 407;
+constexpr Tag LogicalAnd = 408;
+constexpr Tag LogicalNot = 409;
+constexpr Tag LogicalOr = 410;
+constexpr Tag Member = 411;
+constexpr Tag Move = 412;
+constexpr Tag Name = 413;
+constexpr Tag PendingCoerced = 414;
+constexpr Tag Ternary = 415;
+constexpr Tag TypeInfo = 416;
+constexpr Tag TypeWrapped = 417;
+constexpr Tag Type_ = 418;
+constexpr Tag ResolvedOperator = 419;
+constexpr Tag UnresolvedOperator = 420;
+constexpr Tag Void = 421;
 } // namespace expression
 
 namespace operator_ {
 
 namespace address {
-const Tag Equal = 600;
-const Tag Family = 601;
-const Tag Unequal = 602;
+constexpr Tag Equal = 600;
+constexpr Tag Family = 601;
+constexpr Tag Unequal = 602;
 } // namespace address
 
 namespace bitfield {
-const Tag HasMember = 700;
-const Tag Member = 701;
+constexpr Tag HasMember = 700;
+constexpr Tag Member = 701;
 } // namespace bitfield
 
 namespace bool_ {
-const Tag BitAnd = 800;
-const Tag BitOr = 801;
-const Tag BitXor = 802;
-const Tag Equal = 803;
-const Tag Unequal = 804;
+constexpr Tag BitAnd = 800;
+constexpr Tag BitOr = 801;
+constexpr Tag BitXor = 802;
+constexpr Tag Equal = 803;
+constexpr Tag Unequal = 804;
 } // namespace bool_
 
 namespace bytes {
-const Tag At = 900;
-const Tag Decode = 901;
-const Tag Equal = 902;
-const Tag Find = 903;
-const Tag Greater = 904;
-const Tag GreaterEqual = 905;
-const Tag In = 906;
-const Tag Join = 907;
-const Tag Lower = 908;
-const Tag LowerCase = 909;
-const Tag LowerEqual = 910;
-const Tag Match = 911;
-const Tag Size = 912;
-const Tag Split = 913;
-const Tag Split1 = 914;
-const Tag StartsWith = 915;
-const Tag Strip = 916;
-const Tag SubIterator = 917;
-const Tag SubIterators = 918;
-const Tag SubOffsets = 919;
-const Tag Sum = 920;
-const Tag SumAssignBytes = 921;
-const Tag SumAssignStreamView = 922;
-const Tag SumAssignUInt8 = 923;
-const Tag ToIntAscii = 924;
-const Tag ToIntBinary = 925;
-const Tag ToTimeAscii = 926;
-const Tag ToTimeBinary = 927;
-const Tag ToUIntAscii = 928;
-const Tag ToUIntBinary = 929;
-const Tag Unequal = 930;
-const Tag UpperCase = 931;
+constexpr Tag At = 900;
+constexpr Tag Decode = 901;
+constexpr Tag Equal = 902;
+constexpr Tag Find = 903;
+constexpr Tag Greater = 904;
+constexpr Tag GreaterEqual = 905;
+constexpr Tag In = 906;
+constexpr Tag Join = 907;
+constexpr Tag Lower = 908;
+constexpr Tag LowerCase = 909;
+constexpr Tag LowerEqual = 910;
+constexpr Tag Match = 911;
+constexpr Tag Size = 912;
+constexpr Tag Split = 913;
+constexpr Tag Split1 = 914;
+constexpr Tag StartsWith = 915;
+constexpr Tag Strip = 916;
+constexpr Tag SubIterator = 917;
+constexpr Tag SubIterators = 918;
+constexpr Tag SubOffsets = 919;
+constexpr Tag Sum = 920;
+constexpr Tag SumAssignBytes = 921;
+constexpr Tag SumAssignStreamView = 922;
+constexpr Tag SumAssignUInt8 = 923;
+constexpr Tag ToIntAscii = 924;
+constexpr Tag ToIntBinary = 925;
+constexpr Tag ToTimeAscii = 926;
+constexpr Tag ToTimeBinary = 927;
+constexpr Tag ToUIntAscii = 928;
+constexpr Tag ToUIntBinary = 929;
+constexpr Tag Unequal = 930;
+constexpr Tag UpperCase = 931;
 
 namespace iterator {
-const Tag Deref = 1000;
-const Tag Difference = 1001;
-const Tag Equal = 1002;
-const Tag Greater = 1003;
-const Tag GreaterEqual = 1004;
-const Tag IncrPostfix = 1005;
-const Tag IncrPrefix = 1006;
-const Tag Lower = 1007;
-const Tag LowerEqual = 1008;
-const Tag Sum = 1009;
-const Tag SumAssign = 1010;
-const Tag Unequal = 1011;
+constexpr Tag Deref = 1000;
+constexpr Tag Difference = 1001;
+constexpr Tag Equal = 1002;
+constexpr Tag Greater = 1003;
+constexpr Tag GreaterEqual = 1004;
+constexpr Tag IncrPostfix = 1005;
+constexpr Tag IncrPrefix = 1006;
+constexpr Tag Lower = 1007;
+constexpr Tag LowerEqual = 1008;
+constexpr Tag Sum = 1009;
+constexpr Tag SumAssign = 1010;
+constexpr Tag Unequal = 1011;
 } // namespace iterator
 } // namespace bytes
 
 namespace enum_ {
-const Tag CastToSignedInteger = 1100;
-const Tag CastToUnsignedInteger = 1101;
-const Tag CtorSigned = 1102;
-const Tag CtorUnsigned = 1103;
-const Tag Equal = 1104;
-const Tag HasLabel = 1105;
-const Tag Unequal = 1106;
+constexpr Tag CastToSignedInteger = 1100;
+constexpr Tag CastToUnsignedInteger = 1101;
+constexpr Tag CtorSigned = 1102;
+constexpr Tag CtorUnsigned = 1103;
+constexpr Tag Equal = 1104;
+constexpr Tag HasLabel = 1105;
+constexpr Tag Unequal = 1106;
 } // namespace enum_
 
 namespace error {
-const Tag Ctor = 1200;
-const Tag Description = 1201;
+constexpr Tag Ctor = 1200;
+constexpr Tag Description = 1201;
 } // namespace error
 
 namespace exception {
-const Tag Ctor = 1300;
-const Tag Description = 1301;
+constexpr Tag Ctor = 1300;
+constexpr Tag Description = 1301;
 } // namespace exception
 
 namespace function {
-const Tag Call = 1400;
+constexpr Tag Call = 1400;
 }
 
 namespace generic {
-const Tag Begin = 1500;
-const Tag CastedCoercion = 1501;
-const Tag End = 1502;
-const Tag New = 1503;
-const Tag Pack = 1504;
-const Tag Unpack = 1505;
+constexpr Tag Begin = 1500;
+constexpr Tag CastedCoercion = 1501;
+constexpr Tag End = 1502;
+constexpr Tag New = 1503;
+constexpr Tag Pack = 1504;
+constexpr Tag Unpack = 1505;
 } // namespace generic
 
 namespace interval {
-const Tag CtorRealSecs = 1600;
-const Tag CtorSignedIntegerNs = 1601;
-const Tag CtorSignedIntegerSecs = 1602;
-const Tag CtorUnsignedIntegerNs = 1603;
-const Tag CtorUnsignedIntegerSecs = 1604;
-const Tag Difference = 1605;
-const Tag Equal = 1606;
-const Tag Greater = 1607;
-const Tag GreaterEqual = 1608;
-const Tag Lower = 1609;
-const Tag LowerEqual = 1610;
-const Tag MultipleReal = 1611;
-const Tag MultipleUnsignedInteger = 1612;
-const Tag Nanoseconds = 1613;
-const Tag Seconds = 1614;
-const Tag Sum = 1615;
-const Tag Unequal = 1616;
+constexpr Tag CtorRealSecs = 1600;
+constexpr Tag CtorSignedIntegerNs = 1601;
+constexpr Tag CtorSignedIntegerSecs = 1602;
+constexpr Tag CtorUnsignedIntegerNs = 1603;
+constexpr Tag CtorUnsignedIntegerSecs = 1604;
+constexpr Tag Difference = 1605;
+constexpr Tag Equal = 1606;
+constexpr Tag Greater = 1607;
+constexpr Tag GreaterEqual = 1608;
+constexpr Tag Lower = 1609;
+constexpr Tag LowerEqual = 1610;
+constexpr Tag MultipleReal = 1611;
+constexpr Tag MultipleUnsignedInteger = 1612;
+constexpr Tag Nanoseconds = 1613;
+constexpr Tag Seconds = 1614;
+constexpr Tag Sum = 1615;
+constexpr Tag Unequal = 1616;
 } // namespace interval
 
 namespace list {
-const Tag Equal = 1700;
-const Tag Size = 1701;
-const Tag Unequal = 1702;
+constexpr Tag Equal = 1700;
+constexpr Tag Size = 1701;
+constexpr Tag Unequal = 1702;
 
 namespace iterator {
-const Tag Deref = 1800;
-const Tag Equal = 1801;
-const Tag IncrPostfix = 1802;
-const Tag IncrPrefix = 1803;
-const Tag Unequal = 1804;
+constexpr Tag Deref = 1800;
+constexpr Tag Equal = 1801;
+constexpr Tag IncrPostfix = 1802;
+constexpr Tag IncrPrefix = 1803;
+constexpr Tag Unequal = 1804;
 } // namespace iterator
 } // namespace list
 
 namespace map {
-const Tag Clear = 1900;
-const Tag Delete = 1901;
-const Tag Equal = 1902;
-const Tag Get = 1903;
-const Tag In = 1904;
-const Tag IndexAssign = 1905;
-const Tag IndexConst = 1906;
-const Tag IndexNonConst = 1907;
-const Tag Size = 1908;
-const Tag Unequal = 1909;
+constexpr Tag Clear = 1900;
+constexpr Tag Delete = 1901;
+constexpr Tag Equal = 1902;
+constexpr Tag Get = 1903;
+constexpr Tag In = 1904;
+constexpr Tag IndexAssign = 1905;
+constexpr Tag IndexConst = 1906;
+constexpr Tag IndexNonConst = 1907;
+constexpr Tag Size = 1908;
+constexpr Tag Unequal = 1909;
 
 namespace iterator {
-const Tag Deref = 2000;
-const Tag Equal = 2001;
-const Tag IncrPostfix = 2002;
-const Tag IncrPrefix = 2003;
-const Tag Unequal = 2004;
+constexpr Tag Deref = 2000;
+constexpr Tag Equal = 2001;
+constexpr Tag IncrPostfix = 2002;
+constexpr Tag IncrPrefix = 2003;
+constexpr Tag Unequal = 2004;
 } // namespace iterator
 } // namespace map
 
 namespace network {
-const Tag Equal = 2100;
-const Tag Family = 2101;
-const Tag In = 2102;
-const Tag Length = 2103;
-const Tag Prefix = 2104;
-const Tag Unequal = 2105;
+constexpr Tag Equal = 2100;
+constexpr Tag Family = 2101;
+constexpr Tag In = 2102;
+constexpr Tag Length = 2103;
+constexpr Tag Prefix = 2104;
+constexpr Tag Unequal = 2105;
 } // namespace network
 
 namespace optional {
-const Tag Deref = 2200;
+constexpr Tag Deref = 2200;
 }
 
 namespace port {
-const Tag Ctor = 2300;
-const Tag Equal = 2301;
-const Tag Protocol = 2302;
-const Tag Unequal = 2303;
+constexpr Tag Ctor = 2300;
+constexpr Tag Equal = 2301;
+constexpr Tag Protocol = 2302;
+constexpr Tag Unequal = 2303;
 } // namespace port
 
 namespace real {
-const Tag CastToInterval = 2400;
-const Tag CastToSignedInteger = 2401;
-const Tag CastToTime = 2402;
-const Tag CastToUnsignedInteger = 2403;
-const Tag Difference = 2404;
-const Tag DifferenceAssign = 2405;
-const Tag Division = 2406;
-const Tag DivisionAssign = 2407;
-const Tag Equal = 2408;
-const Tag Greater = 2409;
-const Tag GreaterEqual = 2410;
-const Tag Lower = 2411;
-const Tag LowerEqual = 2412;
-const Tag Modulo = 2413;
-const Tag Multiple = 2414;
-const Tag MultipleAssign = 2415;
-const Tag Power = 2416;
-const Tag SignNeg = 2417;
-const Tag Sum = 2418;
-const Tag SumAssign = 2419;
-const Tag Unequal = 2420;
+constexpr Tag CastToInterval = 2400;
+constexpr Tag CastToSignedInteger = 2401;
+constexpr Tag CastToTime = 2402;
+constexpr Tag CastToUnsignedInteger = 2403;
+constexpr Tag Difference = 2404;
+constexpr Tag DifferenceAssign = 2405;
+constexpr Tag Division = 2406;
+constexpr Tag DivisionAssign = 2407;
+constexpr Tag Equal = 2408;
+constexpr Tag Greater = 2409;
+constexpr Tag GreaterEqual = 2410;
+constexpr Tag Lower = 2411;
+constexpr Tag LowerEqual = 2412;
+constexpr Tag Modulo = 2413;
+constexpr Tag Multiple = 2414;
+constexpr Tag MultipleAssign = 2415;
+constexpr Tag Power = 2416;
+constexpr Tag SignNeg = 2417;
+constexpr Tag Sum = 2418;
+constexpr Tag SumAssign = 2419;
+constexpr Tag Unequal = 2420;
 } // namespace real
 
 namespace regexp {
-const Tag Find = 2500;
-const Tag Match = 2501;
-const Tag MatchGroups = 2502;
-const Tag TokenMatcher = 2503;
+constexpr Tag Find = 2500;
+constexpr Tag Match = 2501;
+constexpr Tag MatchGroups = 2502;
+constexpr Tag TokenMatcher = 2503;
 } // namespace regexp
 
 namespace regexp_match_state {
-const Tag AdvanceBytes = 2600;
-const Tag AdvanceView = 2601;
+constexpr Tag AdvanceBytes = 2600;
+constexpr Tag AdvanceView = 2601;
 } // namespace regexp_match_state
 
 namespace result {
-const Tag Deref = 2700;
-const Tag Error = 2701;
+constexpr Tag Deref = 2700;
+constexpr Tag Error = 2701;
 } // namespace result
 
 namespace set {
-const Tag Add = 2800;
-const Tag Clear = 2801;
-const Tag Delete = 2802;
-const Tag Equal = 2803;
-const Tag In = 2804;
-const Tag Size = 2805;
-const Tag Unequal = 2806;
+constexpr Tag Add = 2800;
+constexpr Tag Clear = 2801;
+constexpr Tag Delete = 2802;
+constexpr Tag Equal = 2803;
+constexpr Tag In = 2804;
+constexpr Tag Size = 2805;
+constexpr Tag Unequal = 2806;
 
 namespace iterator {
-const Tag Deref = 2900;
-const Tag Equal = 2901;
-const Tag IncrPostfix = 2902;
-const Tag IncrPrefix = 2903;
-const Tag Unequal = 2904;
+constexpr Tag Deref = 2900;
+constexpr Tag Equal = 2901;
+constexpr Tag IncrPostfix = 2902;
+constexpr Tag IncrPrefix = 2903;
+constexpr Tag Unequal = 2904;
 } // namespace iterator
 } // namespace set
 
 namespace signed_integer {
-const Tag CastToBool = 3000;
-const Tag CastToEnum = 3001;
-const Tag CastToInterval = 3002;
-const Tag CastToReal = 3003;
-const Tag CastToSigned = 3004;
-const Tag CastToUnsigned = 3005;
-const Tag CtorSigned16 = 3006;
-const Tag CtorSigned32 = 3007;
-const Tag CtorSigned64 = 3008;
-const Tag CtorSigned8 = 3009;
-const Tag CtorUnsigned16 = 3010;
-const Tag CtorUnsigned32 = 3011;
-const Tag CtorUnsigned64 = 3012;
-const Tag CtorUnsigned8 = 3013;
-const Tag DecrPostfix = 3014;
-const Tag DecrPrefix = 3015;
-const Tag Difference = 3016;
-const Tag DifferenceAssign = 3017;
-const Tag Division = 3018;
-const Tag DivisionAssign = 3019;
-const Tag Equal = 3020;
-const Tag Greater = 3021;
-const Tag GreaterEqual = 3022;
-const Tag IncrPostfix = 3023;
-const Tag IncrPrefix = 3024;
-const Tag Lower = 3025;
-const Tag LowerEqual = 3026;
-const Tag Modulo = 3027;
-const Tag Multiple = 3028;
-const Tag MultipleAssign = 3029;
-const Tag Power = 3030;
-const Tag SignNeg = 3031;
-const Tag Sum = 3032;
-const Tag SumAssign = 3033;
-const Tag Unequal = 3034;
+constexpr Tag CastToBool = 3000;
+constexpr Tag CastToEnum = 3001;
+constexpr Tag CastToInterval = 3002;
+constexpr Tag CastToReal = 3003;
+constexpr Tag CastToSigned = 3004;
+constexpr Tag CastToUnsigned = 3005;
+constexpr Tag CtorSigned16 = 3006;
+constexpr Tag CtorSigned32 = 3007;
+constexpr Tag CtorSigned64 = 3008;
+constexpr Tag CtorSigned8 = 3009;
+constexpr Tag CtorUnsigned16 = 3010;
+constexpr Tag CtorUnsigned32 = 3011;
+constexpr Tag CtorUnsigned64 = 3012;
+constexpr Tag CtorUnsigned8 = 3013;
+constexpr Tag DecrPostfix = 3014;
+constexpr Tag DecrPrefix = 3015;
+constexpr Tag Difference = 3016;
+constexpr Tag DifferenceAssign = 3017;
+constexpr Tag Division = 3018;
+constexpr Tag DivisionAssign = 3019;
+constexpr Tag Equal = 3020;
+constexpr Tag Greater = 3021;
+constexpr Tag GreaterEqual = 3022;
+constexpr Tag IncrPostfix = 3023;
+constexpr Tag IncrPrefix = 3024;
+constexpr Tag Lower = 3025;
+constexpr Tag LowerEqual = 3026;
+constexpr Tag Modulo = 3027;
+constexpr Tag Multiple = 3028;
+constexpr Tag MultipleAssign = 3029;
+constexpr Tag Power = 3030;
+constexpr Tag SignNeg = 3031;
+constexpr Tag Sum = 3032;
+constexpr Tag SumAssign = 3033;
+constexpr Tag Unequal = 3034;
 } // namespace signed_integer
 
 namespace stream {
-const Tag At = 3100;
-const Tag Ctor = 3101;
-const Tag Freeze = 3102;
-const Tag IsFrozen = 3103;
-const Tag Size = 3104;
-const Tag SumAssignBytes = 3105;
-const Tag SumAssignView = 3106;
-const Tag Trim = 3107;
-const Tag Unequal = 3108;
-const Tag Unfreeze = 3109;
+constexpr Tag At = 3100;
+constexpr Tag Ctor = 3101;
+constexpr Tag Freeze = 3102;
+constexpr Tag IsFrozen = 3103;
+constexpr Tag Size = 3104;
+constexpr Tag SumAssignBytes = 3105;
+constexpr Tag SumAssignView = 3106;
+constexpr Tag Trim = 3107;
+constexpr Tag Unequal = 3108;
+constexpr Tag Unfreeze = 3109;
 
 namespace iterator {
-const Tag Deref = 3200;
-const Tag Difference = 3201;
-const Tag Equal = 3202;
-const Tag Greater = 3203;
-const Tag GreaterEqual = 3204;
-const Tag IncrPostfix = 3205;
-const Tag IncrPrefix = 3206;
-const Tag IsFrozen = 3207;
-const Tag Lower = 3208;
-const Tag LowerEqual = 3209;
-const Tag Offset = 3210;
-const Tag Sum = 3211;
-const Tag SumAssign = 3212;
-const Tag Unequal = 3213;
+constexpr Tag Deref = 3200;
+constexpr Tag Difference = 3201;
+constexpr Tag Equal = 3202;
+constexpr Tag Greater = 3203;
+constexpr Tag GreaterEqual = 3204;
+constexpr Tag IncrPostfix = 3205;
+constexpr Tag IncrPrefix = 3206;
+constexpr Tag IsFrozen = 3207;
+constexpr Tag Lower = 3208;
+constexpr Tag LowerEqual = 3209;
+constexpr Tag Offset = 3210;
+constexpr Tag Sum = 3211;
+constexpr Tag SumAssign = 3212;
+constexpr Tag Unequal = 3213;
 } // namespace iterator
 
 namespace view {
-const Tag AdvanceBy = 3300;
-const Tag AdvanceTo = 3301;
-const Tag AdvanceToNextData = 3302;
-const Tag At = 3303;
-const Tag EqualBytes = 3304;
-const Tag EqualView = 3305;
-const Tag Find = 3306;
-const Tag InBytes = 3307;
-const Tag InView = 3308;
-const Tag Limit = 3309;
-const Tag Offset = 3310;
-const Tag Size = 3311;
-const Tag StartsWith = 3312;
-const Tag SubIterator = 3313;
-const Tag SubIterators = 3314;
-const Tag SubOffsets = 3315;
-const Tag UnequalBytes = 3316;
-const Tag UnequalView = 3317;
+constexpr Tag AdvanceBy = 3300;
+constexpr Tag AdvanceTo = 3301;
+constexpr Tag AdvanceToNextData = 3302;
+constexpr Tag At = 3303;
+constexpr Tag EqualBytes = 3304;
+constexpr Tag EqualView = 3305;
+constexpr Tag Find = 3306;
+constexpr Tag InBytes = 3307;
+constexpr Tag InView = 3308;
+constexpr Tag Limit = 3309;
+constexpr Tag Offset = 3310;
+constexpr Tag Size = 3311;
+constexpr Tag StartsWith = 3312;
+constexpr Tag SubIterator = 3313;
+constexpr Tag SubIterators = 3314;
+constexpr Tag SubOffsets = 3315;
+constexpr Tag UnequalBytes = 3316;
+constexpr Tag UnequalView = 3317;
 } // namespace view
 
 } // namespace stream
 
 namespace string {
-const Tag Encode = 3400;
-const Tag Equal = 3401;
-const Tag Modulo = 3402;
-const Tag Size = 3403;
-const Tag Sum = 3404;
-const Tag SumAssign = 3405;
-const Tag Unequal = 3406;
+constexpr Tag Encode = 3400;
+constexpr Tag Equal = 3401;
+constexpr Tag Modulo = 3402;
+constexpr Tag Size = 3403;
+constexpr Tag Sum = 3404;
+constexpr Tag SumAssign = 3405;
+constexpr Tag Unequal = 3406;
 } // namespace string
 
 namespace strong_reference {
-const Tag Deref = 3500;
-const Tag Equal = 3501;
-const Tag Unequal = 3502;
+constexpr Tag Deref = 3500;
+constexpr Tag Equal = 3501;
+constexpr Tag Unequal = 3502;
 } // namespace strong_reference
 
 namespace struct_ {
-const Tag HasMember = 3600;
-const Tag MemberCall = 3601;
-const Tag MemberConst = 3602;
-const Tag MemberNonConst = 3603;
-const Tag TryMember = 3604;
-const Tag Unset = 3605;
+constexpr Tag HasMember = 3600;
+constexpr Tag MemberCall = 3601;
+constexpr Tag MemberConst = 3602;
+constexpr Tag MemberNonConst = 3603;
+constexpr Tag TryMember = 3604;
+constexpr Tag Unset = 3605;
 } // namespace struct_
 
 namespace time {
-const Tag CtorRealSecs = 3700;
-const Tag CtorSignedIntegerNs = 3701;
-const Tag CtorSignedIntegerSecs = 3702;
-const Tag CtorUnsignedIntegerNs = 3703;
-const Tag CtorUnsignedIntegerSecs = 3704;
-const Tag DifferenceInterval = 3705;
-const Tag DifferenceTime = 3706;
-const Tag Equal = 3707;
-const Tag Greater = 3708;
-const Tag GreaterEqual = 3709;
-const Tag Lower = 3710;
-const Tag LowerEqual = 3711;
-const Tag Nanoseconds = 3712;
-const Tag Seconds = 3713;
-const Tag SumInterval = 3714;
-const Tag Unequal = 3715;
+constexpr Tag CtorRealSecs = 3700;
+constexpr Tag CtorSignedIntegerNs = 3701;
+constexpr Tag CtorSignedIntegerSecs = 3702;
+constexpr Tag CtorUnsignedIntegerNs = 3703;
+constexpr Tag CtorUnsignedIntegerSecs = 3704;
+constexpr Tag DifferenceInterval = 3705;
+constexpr Tag DifferenceTime = 3706;
+constexpr Tag Equal = 3707;
+constexpr Tag Greater = 3708;
+constexpr Tag GreaterEqual = 3709;
+constexpr Tag Lower = 3710;
+constexpr Tag LowerEqual = 3711;
+constexpr Tag Nanoseconds = 3712;
+constexpr Tag Seconds = 3713;
+constexpr Tag SumInterval = 3714;
+constexpr Tag Unequal = 3715;
 } // namespace time
 
 namespace tuple {
-const Tag CustomAssign = 3800;
-const Tag Equal = 3801;
-const Tag Index = 3802;
-const Tag Member = 3803;
-const Tag Unequal = 3804;
+constexpr Tag CustomAssign = 3800;
+constexpr Tag Equal = 3801;
+constexpr Tag Index = 3802;
+constexpr Tag Member = 3803;
+constexpr Tag Unequal = 3804;
 } // namespace tuple
 
 namespace union_ {
-const Tag Equal = 3900;
-const Tag HasMember = 3901;
-const Tag MemberConst = 3902;
-const Tag MemberNonConst = 3903;
-const Tag Unequal = 3904;
+constexpr Tag Equal = 3900;
+constexpr Tag HasMember = 3901;
+constexpr Tag MemberConst = 3902;
+constexpr Tag MemberNonConst = 3903;
+constexpr Tag Unequal = 3904;
 } // namespace union_
 
 namespace unsigned_integer {
-const Tag BitAnd = 4000;
-const Tag BitOr = 4001;
-const Tag BitXor = 4002;
-const Tag CastToBool = 4003;
-const Tag CastToEnum = 4004;
-const Tag CastToInterval = 4005;
-const Tag CastToReal = 4006;
-const Tag CastToSigned = 4007;
-const Tag CastToTime = 4008;
-const Tag CastToUnsigned = 4009;
-const Tag CtorSigned16 = 4010;
-const Tag CtorSigned32 = 4011;
-const Tag CtorSigned64 = 4012;
-const Tag CtorSigned8 = 4013;
-const Tag CtorUnsigned16 = 4014;
-const Tag CtorUnsigned32 = 4015;
-const Tag CtorUnsigned64 = 4016;
-const Tag CtorUnsigned8 = 4017;
-const Tag DecrPostfix = 4018;
-const Tag DecrPrefix = 4019;
-const Tag Difference = 4020;
-const Tag DifferenceAssign = 4021;
-const Tag Division = 4022;
-const Tag DivisionAssign = 4023;
-const Tag Equal = 4024;
-const Tag Greater = 4025;
-const Tag GreaterEqual = 4026;
-const Tag IncrPostfix = 4027;
-const Tag IncrPrefix = 4028;
-const Tag Lower = 4029;
-const Tag LowerEqual = 4030;
-const Tag Modulo = 4031;
-const Tag Multiple = 4032;
-const Tag MultipleAssign = 4033;
-const Tag Negate = 4034;
-const Tag Power = 4035;
-const Tag ShiftLeft = 4036;
-const Tag ShiftRight = 4037;
-const Tag SignNeg = 4038;
-const Tag Sum = 4039;
-const Tag SumAssign = 4040;
-const Tag Unequal = 4041;
+constexpr Tag BitAnd = 4000;
+constexpr Tag BitOr = 4001;
+constexpr Tag BitXor = 4002;
+constexpr Tag CastToBool = 4003;
+constexpr Tag CastToEnum = 4004;
+constexpr Tag CastToInterval = 4005;
+constexpr Tag CastToReal = 4006;
+constexpr Tag CastToSigned = 4007;
+constexpr Tag CastToTime = 4008;
+constexpr Tag CastToUnsigned = 4009;
+constexpr Tag CtorSigned16 = 4010;
+constexpr Tag CtorSigned32 = 4011;
+constexpr Tag CtorSigned64 = 4012;
+constexpr Tag CtorSigned8 = 4013;
+constexpr Tag CtorUnsigned16 = 4014;
+constexpr Tag CtorUnsigned32 = 4015;
+constexpr Tag CtorUnsigned64 = 4016;
+constexpr Tag CtorUnsigned8 = 4017;
+constexpr Tag DecrPostfix = 4018;
+constexpr Tag DecrPrefix = 4019;
+constexpr Tag Difference = 4020;
+constexpr Tag DifferenceAssign = 4021;
+constexpr Tag Division = 4022;
+constexpr Tag DivisionAssign = 4023;
+constexpr Tag Equal = 4024;
+constexpr Tag Greater = 4025;
+constexpr Tag GreaterEqual = 4026;
+constexpr Tag IncrPostfix = 4027;
+constexpr Tag IncrPrefix = 4028;
+constexpr Tag Lower = 4029;
+constexpr Tag LowerEqual = 4030;
+constexpr Tag Modulo = 4031;
+constexpr Tag Multiple = 4032;
+constexpr Tag MultipleAssign = 4033;
+constexpr Tag Negate = 4034;
+constexpr Tag Power = 4035;
+constexpr Tag ShiftLeft = 4036;
+constexpr Tag ShiftRight = 4037;
+constexpr Tag SignNeg = 4038;
+constexpr Tag Sum = 4039;
+constexpr Tag SumAssign = 4040;
+constexpr Tag Unequal = 4041;
 } // namespace unsigned_integer
 
 namespace value_reference {
-const Tag Deref = 4100;
-const Tag Equal = 4101;
-const Tag Unequal = 4102;
+constexpr Tag Deref = 4100;
+constexpr Tag Equal = 4101;
+constexpr Tag Unequal = 4102;
 } // namespace value_reference
 
 namespace vector {
-const Tag Assign = 4200;
-const Tag At = 4201;
-const Tag Back = 4202;
-const Tag Equal = 4203;
-const Tag Front = 4204;
-const Tag IndexConst = 4205;
-const Tag IndexNonConst = 4206;
-const Tag PopBack = 4207;
-const Tag PushBack = 4208;
-const Tag Reserve = 4209;
-const Tag Resize = 4210;
-const Tag Size = 4211;
-const Tag SubEnd = 4212;
-const Tag SubRange = 4213;
-const Tag Sum = 4214;
-const Tag SumAssign = 4215;
-const Tag Unequal = 4216;
+constexpr Tag Assign = 4200;
+constexpr Tag At = 4201;
+constexpr Tag Back = 4202;
+constexpr Tag Equal = 4203;
+constexpr Tag Front = 4204;
+constexpr Tag IndexConst = 4205;
+constexpr Tag IndexNonConst = 4206;
+constexpr Tag PopBack = 4207;
+constexpr Tag PushBack = 4208;
+constexpr Tag Reserve = 4209;
+constexpr Tag Resize = 4210;
+constexpr Tag Size = 4211;
+constexpr Tag SubEnd = 4212;
+constexpr Tag SubRange = 4213;
+constexpr Tag Sum = 4214;
+constexpr Tag SumAssign = 4215;
+constexpr Tag Unequal = 4216;
 
 namespace iterator {
-const Tag Deref = 4300;
-const Tag Equal = 4301;
-const Tag IncrPostfix = 4302;
-const Tag IncrPrefix = 4303;
-const Tag Unequal = 4304;
+constexpr Tag Deref = 4300;
+constexpr Tag Equal = 4301;
+constexpr Tag IncrPostfix = 4302;
+constexpr Tag IncrPrefix = 4303;
+constexpr Tag Unequal = 4304;
 } // namespace iterator
 } // namespace vector
 
 namespace weak_reference {
-const Tag Deref = 4400;
-const Tag Equal = 4401;
-const Tag Unequal = 4402;
+constexpr Tag Deref = 4400;
+constexpr Tag Equal = 4401;
+constexpr Tag Unequal = 4402;
 } // namespace weak_reference
 
 } // namespace operator_
 
 namespace statement {
-const Tag Assert = 4500;
-const Tag Block = 4501;
-const Tag Break = 4502;
-const Tag Comment = 4503;
-const Tag Continue = 4504;
-const Tag Declaration = 4505;
-const Tag Expression = 4506;
-const Tag For = 4507;
-const Tag If = 4508;
-const Tag Return = 4509;
-const Tag SetLocation = 4510;
-const Tag Switch = 4511;
-const Tag Throw = 4512;
-const Tag Try = 4513;
-const Tag While = 4514;
-const Tag Yield = 4515;
+constexpr Tag Assert = 4500;
+constexpr Tag Block = 4501;
+constexpr Tag Break = 4502;
+constexpr Tag Comment = 4503;
+constexpr Tag Continue = 4504;
+constexpr Tag Declaration = 4505;
+constexpr Tag Expression = 4506;
+constexpr Tag For = 4507;
+constexpr Tag If = 4508;
+constexpr Tag Return = 4509;
+constexpr Tag SetLocation = 4510;
+constexpr Tag Switch = 4511;
+constexpr Tag Throw = 4512;
+constexpr Tag Try = 4513;
+constexpr Tag While = 4514;
+constexpr Tag Yield = 4515;
 } // namespace statement
 
 namespace type {
-const Tag Address = 4600;
-const Tag Any = 4601;
-const Tag Auto = 4602;
-const Tag Bitfield = 4603;
-const Tag Bool = 4604;
-const Tag Bytes = 4605;
-const Tag DocOnly = 4606;
-const Tag Enum = 4607;
-const Tag Error = 4608;
-const Tag Exception = 4609;
-const Tag Function = 4610;
-const Tag Interval = 4611;
-const Tag Library = 4612;
-const Tag List = 4613;
-const Tag Map = 4614;
-const Tag Member = 4615;
-const Tag Name = 4616;
-const Tag Network = 4617;
-const Tag Null = 4618;
-const Tag OperandList = 4619;
-const Tag Optional = 4620;
-const Tag Port = 4621;
-const Tag Real = 4622;
-const Tag RegExp = 4623;
-const Tag Result = 4624;
-const Tag Set = 4625;
-const Tag SignedInteger = 4626;
-const Tag Stream = 4627;
-const Tag String = 4628;
-const Tag StrongReference = 4629;
-const Tag Struct = 4630;
-const Tag Time = 4631;
-const Tag Tuple = 4632;
-const Tag Type_ = 4633;
-const Tag Union = 4634;
-const Tag Unknown = 4635;
-const Tag UnsignedInteger = 4636;
-const Tag ValueReference = 4637;
-const Tag Vector = 4638;
-const Tag Void = 4639;
-const Tag WeakReference = 4640;
+constexpr Tag Address = 4600;
+constexpr Tag Any = 4601;
+constexpr Tag Auto = 4602;
+constexpr Tag Bitfield = 4603;
+constexpr Tag Bool = 4604;
+constexpr Tag Bytes = 4605;
+constexpr Tag DocOnly = 4606;
+constexpr Tag Enum = 4607;
+constexpr Tag Error = 4608;
+constexpr Tag Exception = 4609;
+constexpr Tag Function = 4610;
+constexpr Tag Interval = 4611;
+constexpr Tag Library = 4612;
+constexpr Tag List = 4613;
+constexpr Tag Map = 4614;
+constexpr Tag Member = 4615;
+constexpr Tag Name = 4616;
+constexpr Tag Network = 4617;
+constexpr Tag Null = 4618;
+constexpr Tag OperandList = 4619;
+constexpr Tag Optional = 4620;
+constexpr Tag Port = 4621;
+constexpr Tag Real = 4622;
+constexpr Tag RegExp = 4623;
+constexpr Tag Result = 4624;
+constexpr Tag Set = 4625;
+constexpr Tag SignedInteger = 4626;
+constexpr Tag Stream = 4627;
+constexpr Tag String = 4628;
+constexpr Tag StrongReference = 4629;
+constexpr Tag Struct = 4630;
+constexpr Tag Time = 4631;
+constexpr Tag Tuple = 4632;
+constexpr Tag Type_ = 4633;
+constexpr Tag Union = 4634;
+constexpr Tag Unknown = 4635;
+constexpr Tag UnsignedInteger = 4636;
+constexpr Tag ValueReference = 4637;
+constexpr Tag Vector = 4638;
+constexpr Tag Void = 4639;
+constexpr Tag WeakReference = 4640;
 
 namespace bytes {
-const Tag Iterator = 4700;
+constexpr Tag Iterator = 4700;
 }
 namespace list {
-const Tag Iterator = 4800;
+constexpr Tag Iterator = 4800;
 }
 namespace map {
-const Tag Iterator = 4900;
+constexpr Tag Iterator = 4900;
 }
 namespace set {
-const Tag Iterator = 5000;
+constexpr Tag Iterator = 5000;
 }
 namespace stream {
-const Tag Iterator = 5100;
+constexpr Tag Iterator = 5100;
 }
 namespace stream {
-const Tag View = 5200;
+constexpr Tag View = 5200;
 }
 namespace vector {
-const Tag Iterator = 5300;
+constexpr Tag Iterator = 5300;
 }
 } // namespace type
 

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -90,22 +90,6 @@ namespace builder {
 class NodeBuilder;
 }
 
-/**
- * Container storing a set of nodes. This is just a `std::vector` with an
- * additional constructor.
- */
-class Nodes : public std::vector<Node*> {
-public:
-    using std::vector<Node*>::vector;
-
-    /** Constructor accepting a vector of pointers to a derived class. */
-    template<typename T>
-    Nodes(std::vector<T*> m) {
-        for ( auto&& x : m )
-            emplace_back(std::move(x));
-    }
-};
-
 namespace node {
 
 namespace detail {

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -24,12 +24,13 @@
 #include <hilti/ast/visitor-dispatcher.h>
 
 #define __HILTI_NODE_COMMON_final(NS, CLASS)                                                                           \
-    ::hilti::NodePtr _clone(::hilti::ASTContext* ctx) const final { return std::shared_ptr<CLASS>(new CLASS(*this)); }
+    ::hilti::Node* _clone(::hilti::ASTContext* ctx) const final { return ctx->make<CLASS>(*this); }
 
 #define __HILTI_NODE_COMMON_override(NS, CLASS)
 
 #define __HILTI_NODE_COMMON(NS, CLASS, override_)                                                                      \
     friend class ::NS::builder::NodeBuilder;                                                                           \
+    friend class hilti::ASTContext;                                                                                    \
     friend class hilti::Node;                                                                                          \
     std::string _typename() const override { return hilti::util::typename_(*this); }                                   \
     __HILTI_NODE_COMMON_##override_(NS, CLASS)
@@ -93,13 +94,13 @@ class NodeBuilder;
  * Container storing a set of nodes. This is just a `std::vector` with an
  * additional constructor.
  */
-class Nodes : public std::vector<NodePtr> {
+class Nodes : public std::vector<Node*> {
 public:
-    using std::vector<NodePtr>::vector;
+    using std::vector<Node*>::vector;
 
     /** Constructor accepting a vector of pointers to a derived class. */
     template<typename T>
-    Nodes(std::vector<std::shared_ptr<T>> m) {
+    Nodes(std::vector<T*> m) {
         for ( auto&& x : m )
             emplace_back(std::move(x));
     }
@@ -109,7 +110,7 @@ namespace node {
 
 namespace detail {
 /** Backend for `node::deepcopy()`, see there. */
-NodePtr deepcopy(ASTContext* ctx, const NodePtr& n, bool force);
+Node* deepcopy(ASTContext* ctx, Node* n, bool force);
 } // namespace detail
 
 /**
@@ -122,7 +123,7 @@ NodePtr deepcopy(ASTContext* ctx, const NodePtr& n, bool force);
  * it performs the copy only if then adding the node to an AST.
  */
 template<typename T>
-std::shared_ptr<T> deepcopy(ASTContext* ctx, const std::shared_ptr<T>& n, bool force = false) {
+T* deepcopy(ASTContext* ctx, T* n, bool force = false) {
     if ( ! n )
         return nullptr;
 
@@ -188,7 +189,7 @@ using Properties = std::map<std::string, node::PropertyValue>;
 } // namespace node
 
 /** Base class for all AST nodes. */
-class Node : public std::enable_shared_from_this<Node> {
+class Node {
 public:
     virtual ~Node();
 
@@ -286,7 +287,7 @@ public:
      * @return if found, a pair of the declaration the ID refers to plus the declarations canonical ID; if not found an
      * error message appropriate for reporting to the user
      */
-    Result<std::pair<DeclarationPtr, ID>> lookupID(const ID& id, const std::string_view& what) const;
+    Result<std::pair<Declaration*, ID>> lookupID(const ID& id, const std::string_view& what) const;
 
     /**
      * Returns a flag indicating whether a scope lookup passing this node
@@ -322,15 +323,22 @@ public:
      * @return child casted to type `T`, or null if there's no child node at that index
      */
     template<typename T>
-    std::shared_ptr<T> child(unsigned int i) const {
+    T* child(unsigned int i) const {
         if ( i >= _children.size() )
             return nullptr;
 
         return _children[i] ? _children[i]->as<T>() : nullptr;
     }
 
+    /**
+     * Returns a child.
+     *
+     * @tparam T type that the child nodes are assumed to (and must) have
+     * @param i zero-based index of the child, in the order they were passed into the constructor and/or added
+     * @return child casted to type `T`, or null if there's no child node at that index
+     */
     template<typename T>
-    std::shared_ptr<T> childTryAs(unsigned int i) const {
+    T* childTryAs(unsigned int i) const {
         if ( i >= _children.size() )
             return nullptr;
 
@@ -344,7 +352,7 @@ public:
      * @param i index of the child, with zero being the first
      * @return child at given index, or null if there's no child at that index
      **/
-    NodePtr child(unsigned int i) const {
+    Node* child(unsigned int i) const {
         if ( i >= _children.size() )
             return nullptr;
 
@@ -418,18 +426,18 @@ public:
      * @param ctx current context in use
      * @param n child node to add; it's ok for this to be null to leave a child slot unset
      */
-    void addChild(ASTContext* ctx, NodePtr n) {
+    void addChild(ASTContext* ctx, Node* n) {
         if ( ! n ) {
             _children.emplace_back(nullptr);
             return;
         }
 
-        n = _newChild(ctx, std::move(n));
+        n = _newChild(ctx, n);
 
         if ( ! n->location() && _meta.location() )
             n->setMeta(_meta);
 
-        _children.emplace_back(std::move(n));
+        _children.emplace_back(n);
         _children.back()->_parent = this;
     }
 
@@ -440,9 +448,9 @@ public:
      * @param ctx current context in use
      * @param children nodes to add
      */
-    void addChildren(ASTContext* ctx, Nodes children) {
+    void addChildren(ASTContext* ctx, const Nodes& children) {
         for ( auto&& n : children )
-            addChild(ctx, std::move(n));
+            addChild(ctx, n);
     }
 
     /**
@@ -451,7 +459,7 @@ public:
      *
      * @param n child node to remove
      */
-    void removeChild(const NodePtr& n) {
+    void removeChild(Node* n) {
         if ( ! n )
             return;
 
@@ -494,9 +502,9 @@ public:
      * @param idx index of child to set
      * @param n child node to set; this may be null to unset the particular index
      */
-    void setChild(ASTContext* ctx, size_t idx, NodePtr n) {
+    void setChild(ASTContext* ctx, size_t idx, Node* n) {
         if ( n ) {
-            n = _newChild(ctx, std::move(n));
+            n = _newChild(ctx, n);
 
             if ( ! n->location() && _meta.location() )
                 n->setMeta(_meta);
@@ -505,7 +513,7 @@ public:
         if ( _children[idx] )
             _children[idx]->_parent = nullptr;
 
-        _children[idx] = std::move(n);
+        _children[idx] = n;
 
         if ( _children[idx] )
             _children[idx]->_parent = this;
@@ -520,7 +528,7 @@ public:
      * @param ctx current context in use
      * @param children new children to set
      */
-    void replaceChildren(ASTContext* ctx, Nodes children);
+    void replaceChildren(ASTContext* ctx, const Nodes& children);
 
     /**
      * Replaces a single child with a new one. The old one is removed, and the
@@ -532,7 +540,7 @@ public:
      * @param old child to replace, which must exist (otherwise the method will abort with an internal error)
      * @param new_ new child to replace *old* with
      */
-    void replaceChild(ASTContext* ctx, const Node* old, NodePtr new_);
+    void replaceChild(ASTContext* ctx, Node* old, Node* new_);
 
     /** Returns true if a node is of a particular type (class). */
     template<typename T>
@@ -548,11 +556,11 @@ public:
      * dynamic pointer cast, otherwise execution will abort with an internal error.
      */
     template<typename T>
-    auto as() const {
+    T* as() const {
 #ifndef NDEBUG
         _checkCast<T>(true);
 #endif
-        return std::static_pointer_cast<const T>(shared_from_this());
+        return static_cast<const T*>(this);
     }
 
     /**
@@ -562,11 +570,11 @@ public:
      * we'll catch invalid cases and abort with an internal error.
      */
     template<typename T>
-    auto as() {
+    T* as() {
 #ifndef NDEBUG
         _checkCast<T>(true);
 #endif
-        return std::static_pointer_cast<T>(shared_from_this());
+        return static_cast<T*>(this);
     }
 
     /**
@@ -574,15 +582,15 @@ public:
      * the cast failed.
      */
     template<typename T>
-    auto tryAs() const {
+    const T* tryAs() const {
 #ifndef NDEBUG
         _checkCast<T>(false);
 #endif
 
         if ( isA<T>() )
-            return std::static_pointer_cast<const T>(shared_from_this());
+            return static_cast<const T*>(this);
         else
-            return std::shared_ptr<const T>();
+            return nullptr;
     }
 
     /**
@@ -590,14 +598,14 @@ public:
      * the cast failed.
      */
     template<typename T>
-    auto tryAs() {
+    T* tryAs() {
 #ifndef NDEBUG
         _checkCast<T>(false);
 #endif
         if ( isA<T>() )
-            return std::static_pointer_cast<T>(shared_from_this());
+            return static_cast<T*>(this);
         else
-            return std::shared_ptr<T>();
+            return nullptr;
     }
 
     /**
@@ -608,11 +616,11 @@ public:
      * necessary.
      */
     template<typename T>
-    auto tryAs_() {
+    const T* tryAs_() {
         if ( isA<T>() )
-            return std::static_pointer_cast<T>(shared_from_this());
+            return static_cast<const T*>(this);
         else
-            return std::shared_ptr<T>();
+            return nullptr;
     }
 
     /**
@@ -715,15 +723,12 @@ public:
     /** Clears any error message associated with the node. */
     void clearErrors() { _errors.clear(); }
 
-    /** Removes all children. */
+    /**
+     * Removes all children from the node. It doesn't destroy the children,
+     * pointers remain valid, it just unlinks them from their current parent.
+     */
     void clearChildren();
 
-    /**
-     * Recursively clears all child nodes and then deletes them from this node.
-     * This helps to break reference cycles.
-     */
-
-    void destroyChildren();
     /**
      * Returns any instance properties associated with the node. These are used
      * (only) for debug logging. Derived classes should override this to add
@@ -763,14 +768,15 @@ protected:
     Node(ASTContext* ctx, node::Tags node_tags, Nodes children, Meta meta)
         : _node_tags(node_tags), _meta(std::move(meta)) {
         assert(! _node_tags.empty());
+        _children.reserve(children.size());
         for ( auto&& c : children ) {
             if ( c ) {
-                c = _newChild(ctx, std::move(c));
+                c = _newChild(ctx, c);
                 assert(! c->_parent);
                 c->_parent = this;
             }
 
-            _children.push_back(std::move(c));
+            _children.push_back(c);
         }
     }
 
@@ -788,7 +794,7 @@ protected:
      * Use `node::deepcopy()` to fully copy a node.
      *
      */
-    Node(const Node& other) : enable_shared_from_this(other), _node_tags(other._node_tags) {
+    Node(const Node& other) : _node_tags(other._node_tags) {
         _meta = other._meta;
         _inherit_scope = other._inherit_scope;
         _parent = nullptr;
@@ -813,7 +819,7 @@ protected:
      * latter being copied just by reference. This is for internal use only,
      * use node::deepcopy() to fully clone nodes.
      */
-    virtual NodePtr _clone(ASTContext* ctx) const = 0; // shallow copy
+    virtual Node* _clone(ASTContext* ctx) const = 0; // shallow copy
 
     /**
      * Returns additional information to include into the node's `dump()`
@@ -822,11 +828,11 @@ protected:
     virtual std::string _dump() const { return ""; }
 
 private:
-    friend NodePtr node::detail::deepcopy(ASTContext* ctx, const NodePtr& n, bool force);
+    friend Node* node::detail::deepcopy(ASTContext* ctx, Node* n, bool force);
 
     // Prepares a node for being added as a child, deep-copying it if it
     // already has a parent.
-    static NodePtr _newChild(ASTContext* ctx, NodePtr child);
+    static Node* _newChild(ASTContext* ctx, Node* child);
 
     // Clears the node's parent pointer.
     void _clearParent() { _parent = nullptr; }
@@ -1005,14 +1011,14 @@ Nodes flatten(hilti::node::Range<T> t) {
 }
 
 /** Create a 1-element vector of nodes for an object implementing the `Node` API. */
-template<typename T = NodePtr>
-inline Nodes flatten(NodePtr n) {
-    return {std::move(n)};
+template<typename T = Node*>
+inline Nodes flatten(Node* n) {
+    return {n};
 }
 
 /** Create a 1-element vector of nodes for an object implementing the `Node` API. */
 template<typename T>
-inline Nodes flatten(std::shared_ptr<T> n) {
+inline Nodes flatten(T* n) {
     return {std::move(n)};
 }
 
@@ -1070,7 +1076,7 @@ auto filter(const hilti::node::Set<X>& x, F f) {
  */
 template<typename X, typename F>
 auto transform(const hilti::node::Range<X>& x, F f) {
-    using Y = std::invoke_result_t<F, std::shared_ptr<X>&>;
+    using Y = std::invoke_result_t<F, X*>;
     std::vector<Y> y;
     y.reserve(x.size());
     for ( const auto& i : x )
@@ -1085,7 +1091,7 @@ auto transform(const hilti::node::Range<X>& x, F f) {
  */
 template<typename X, typename F>
 auto transform(const hilti::node::Set<X>& x, F f) {
-    using Y = std::invoke_result_t<F, std::shared_ptr<X>&>;
+    using Y = std::invoke_result_t<F, X*>;
     std::vector<Y> y;
     y.reserve(x.size());
     for ( const auto& i : x )

--- a/hilti/toolchain/include/ast/operator-registry.h
+++ b/hilti/toolchain/include/ast/operator-registry.h
@@ -12,7 +12,7 @@
 #include <hilti/ast/operator.h>
 
 #define HILTI_OPERATOR(ns, cls)                                                                                        \
-    Result<hilti::ResolvedOperatorPtr> instantiate(hilti::Builder* builder, Expressions operands, const Meta& meta)    \
+    Result<hilti::expression::ResolvedOperator*> instantiate(hilti::Builder* builder, Expressions operands, Meta meta) \
         const final {                                                                                                  \
         return {ns::operator_::cls::create(builder->context(), this, result(builder, operands, meta),                  \
                                            std::move(operands), meta)};                                                \

--- a/hilti/toolchain/include/ast/operators/common.h
+++ b/hilti/toolchain/include/ast/operators/common.h
@@ -14,17 +14,15 @@
     namespace ns {                                                                                                     \
     class cls : public hilti::expression::ResolvedOperator {                                                           \
     public:                                                                                                            \
-        static std::shared_ptr<cls> create(hilti::ASTContext* ctx, const hilti::Operator* op,                          \
-                                           const hilti::QualifiedTypePtr& result, const hilti::Expressions& operands,  \
-                                           const hilti::Meta& meta) {                                                  \
-            return std::shared_ptr<cls>(new cls(ctx, op, result, operands, meta));                                     \
+        static cls* create(hilti::ASTContext* ctx, const hilti::Operator* op, hilti::QualifiedType* result,            \
+                           const hilti::Expressions& operands, hilti::Meta meta) {                                     \
+            return ctx->make<cls>(ctx, op, result, operands, std::move(meta));                                         \
         }                                                                                                              \
                                                                                                                        \
         HILTI_NODE_2(operator_::ns::cls, expression::ResolvedOperator, Expression, final);                             \
                                                                                                                        \
     private:                                                                                                           \
-        cls(ASTContext* ctx, const hilti::Operator* op, const QualifiedTypePtr& result, const Expressions& operands,   \
-            Meta meta)                                                                                                 \
+        cls(ASTContext* ctx, const hilti::Operator* op, QualifiedType* result, const Expressions& operands, Meta meta) \
             : ResolvedOperator(ctx, NodeTags, op, result, operands, std::move(meta)) {}                                \
     };                                                                                                                 \
     } // namespace ns

--- a/hilti/toolchain/include/ast/operators/function.h
+++ b/hilti/toolchain/include/ast/operators/function.h
@@ -19,18 +19,18 @@ namespace function {
 
 class Call final : public Operator {
 public:
-    Call(const std::shared_ptr<declaration::Function>& f) : Operator(f->meta(), false), _fdecl(f) {}
+    Call(declaration::Function* f) : Operator(f->meta(), false), _fdecl(f) {}
 
     operator_::Signature signature(Builder* builder) const final;
 
-    Result<ResolvedOperatorPtr> instantiate(Builder* builder, Expressions operands, const Meta& meta) const final;
+    Result<expression::ResolvedOperator*> instantiate(Builder* builder, Expressions operands, Meta meta) const final;
 
     std::string name() const final { return "function::Call"; }
 
 private:
     friend class declaration::Function;
 
-    std::weak_ptr<declaration::Function> _fdecl;
+    declaration::Function* _fdecl = nullptr;
 };
 
 } // namespace function

--- a/hilti/toolchain/include/ast/operators/generic.h
+++ b/hilti/toolchain/include/ast/operators/generic.h
@@ -30,8 +30,8 @@ public:
     ~CastedCoercion() final;
 
     operator_::Signature signature(Builder* builder) const final;
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final;
-    Result<ResolvedOperatorPtr> instantiate(Builder* builder, Expressions operands, const Meta& meta) const final;
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final;
+    Result<expression::ResolvedOperator*> instantiate(Builder* builder, Expressions operands, Meta meta) const final;
 
     std::string name() const final { return "generic::CastedCoercion"; }
 };

--- a/hilti/toolchain/include/ast/operators/struct.h
+++ b/hilti/toolchain/include/ast/operators/struct.h
@@ -22,18 +22,18 @@ namespace struct_ {
 
 class MemberCall final : public Operator {
 public:
-    MemberCall(const std::shared_ptr<declaration::Field>& fdecl);
+    MemberCall(declaration::Field* fdecl);
     ~MemberCall() final;
 
-    auto declaration() const { return _fdecl.lock(); }
+    auto declaration() const { return _fdecl; }
 
     operator_::Signature signature(Builder* builder) const final;
-    Result<ResolvedOperatorPtr> instantiate(Builder* builder, Expressions operands, const Meta& meta) const final;
+    Result<expression::ResolvedOperator*> instantiate(Builder* builder, Expressions operands, Meta meta) const final;
 
     std::string name() const final { return "struct::MemberCall"; }
 
 private:
-    std::weak_ptr<declaration::Field> _fdecl;
+    declaration::Field* _fdecl = nullptr;
 };
 
 } // namespace struct_

--- a/hilti/toolchain/include/ast/scope-lookup.h
+++ b/hilti/toolchain/include/ast/scope-lookup.h
@@ -17,7 +17,7 @@
 namespace hilti::scope {
 namespace detail {
 /** Internal backend to `hilti::lookupID()`. */
-std::pair<bool, Result<std::pair<DeclarationPtr, ID>>> lookupID(const ID& id, const Node* n);
+std::pair<bool, Result<std::pair<Declaration*, ID>>> lookupID(const ID& id, const Node* n);
 } // namespace detail
 
 /**
@@ -32,7 +32,7 @@ std::pair<bool, Result<std::pair<DeclarationPtr, ID>>> lookupID(const ID& id, co
  * @return node if resolved, or an appropriate error if not
  */
 template<typename D>
-Result<std::pair<std::shared_ptr<D>, ID>> lookupID(ID id, Node* n, const std::string_view& what) {
+Result<std::pair<D*, ID>> lookupID(ID id, Node* n, const std::string_view& what) {
     if ( id.empty() )
         logger().internalError("lookupID() called with empty ID");
 

--- a/hilti/toolchain/include/ast/scope.h
+++ b/hilti/toolchain/include/ast/scope.h
@@ -29,7 +29,7 @@ public:
      *
      * @param d declaration to insert
      */
-    void insert(const DeclarationPtr& d);
+    void insert(Declaration* d);
 
     /**
      * Inserts a declaration into it's scope under a given ID.
@@ -37,7 +37,7 @@ public:
      * @param id ID to insert the declaration under, which does not need to match the declaration's own ID
      * @param d declaration to insert
      */
-    void insert(const ID& id, DeclarationPtr d);
+    void insert(const ID& id, Declaration* d);
 
     /**
      * Inserts a place-holder into the scope that let's lookup fail here if it
@@ -52,9 +52,9 @@ public:
 
     /** Result type for the lookup methods. */
     struct Referee {
-        DeclarationPtr node;   /**< node that ID maps to */
-        std::string qualified; /**< qualified ID with full path used to find it */
-        bool external{};       /**< true if found in a different (imported) module  */
+        Declaration* node = nullptr; /**< node that ID maps to */
+        std::string qualified;       /**< qualified ID with full path used to find it */
+        bool external{};             /**< true if found in a different (imported) module  */
     };
 
     /** Returns all mappings for an ID. */
@@ -90,7 +90,7 @@ public:
     Scope& operator=(Scope&& other) = delete;
 
 private:
-    using ItemMap = std::map<std::string, std::unordered_set<DeclarationPtr>>;
+    using ItemMap = std::map<std::string, std::unordered_set<Declaration*>>;
 
     std::vector<Referee> _findID(const ID& id, bool external = false) const;
     std::vector<Referee> _findID(const Scope* scope, const ID& id, bool external = false) const;

--- a/hilti/toolchain/include/ast/statement.h
+++ b/hilti/toolchain/include/ast/statement.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include <hilti/ast/ast-context.h>
 #include <hilti/ast/forward.h>
 #include <hilti/ast/node.h>
 

--- a/hilti/toolchain/include/ast/statements/assert.h
+++ b/hilti/toolchain/include/ast/statements/assert.h
@@ -32,7 +32,7 @@ public:
         return Statement::properties() + p;
     }
 
-    void setExpression(ASTContext* ctx, const ExpressionPtr& c) { setChild(ctx, 0, c); }
+    void setExpression(ASTContext* ctx, hilti::Expression* c) { setChild(ctx, 0, c); }
 
     /**
      * Creates an assert statement that expects an expression to evaluate to true at runtime.
@@ -41,8 +41,8 @@ public:
      * @param msg optional message to report an runtime if assertions fails
      * @param m meta information for AST node
      */
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const ExpressionPtr& msg = nullptr, Meta meta = {}) {
-        return std::shared_ptr<Assert>(new Assert(ctx, {expr, nullptr, msg}, false, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* expr, hilti::Expression* msg = nullptr, Meta meta = {}) {
+        return ctx->make<Assert>(ctx, {expr, nullptr, msg}, false, std::move(meta));
     }
 
     /**
@@ -55,9 +55,9 @@ public:
      * @param msg optional message to report an runtime if assertions fails
      * @param m meta information for AST node
      */
-    static auto create(ASTContext* ctx, assert::Exception /*unused*/, const ExpressionPtr& expr,
-                       const UnqualifiedTypePtr& excpt, const ExpressionPtr& msg = nullptr, const Meta& meta = {}) {
-        return std::shared_ptr<Assert>(new Assert(ctx, {expr, excpt, msg}, true, meta));
+    static auto create(ASTContext* ctx, assert::Exception /*unused*/, hilti::Expression* expr, UnqualifiedType* excpt,
+                       hilti::Expression* msg = nullptr, Meta meta = {}) {
+        return ctx->make<Assert>(ctx, {expr, excpt, msg}, true, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/block.h
+++ b/hilti/toolchain/include/ast/statements/block.h
@@ -14,19 +14,19 @@ class Block : public Statement {
 public:
     auto statements() const { return childrenOfType<Statement>(); }
 
-    void add(ASTContext* ctx, StatementPtr s) { addChild(ctx, std::move(s)); }
+    void add(ASTContext* ctx, Statement* s) { addChild(ctx, s); }
 
     /** Internal method for use by builder API only. */
-    void _add(ASTContext* ctx, const StatementPtr& s) { addChild(ctx, s); }
+    void _add(ASTContext* ctx, Statement* s) { addChild(ctx, s); }
 
     /** Internal method for use by builder API only. */
     auto _lastStatement() { return children().back()->as<Statement>(); }
 
     static auto create(ASTContext* ctx, Statements stmts, Meta meta = {}) {
-        return std::shared_ptr<Block>(new Block(ctx, std::move(stmts), std::move(meta)));
+        return ctx->make<Block>(ctx, std::move(stmts), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) { return create(ctx, {}, std::move(meta)); }
+    static auto create(ASTContext* ctx, const Meta& meta = {}) { return create(ctx, {}, meta); }
 
 protected:
     Block(ASTContext* ctx, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/statements/break.h
+++ b/hilti/toolchain/include/ast/statements/break.h
@@ -12,9 +12,7 @@ namespace hilti::statement {
 /** AST node for a `break` statement. */
 class Break : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Break>(new Break(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Break>(ctx, {}, std::move(meta)); }
 
 protected:
     Break(ASTContext* ctx, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/statements/comment.h
+++ b/hilti/toolchain/include/ast/statements/comment.h
@@ -38,7 +38,7 @@ public:
 
     static auto create(ASTContext* ctx, std::string comment, comment::Separator separator = comment::Separator::Before,
                        Meta meta = {}) {
-        return std::shared_ptr<Comment>(new Comment(ctx, {}, std::move(comment), separator, std::move(meta)));
+        return ctx->make<Comment>(ctx, {}, std::move(comment), separator, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/continue.h
+++ b/hilti/toolchain/include/ast/statements/continue.h
@@ -13,9 +13,7 @@ namespace hilti::statement {
 /** AST node for a `continue` statement. */
 class Continue : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Continue>(new Continue(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Continue>(ctx, {}, std::move(meta)); }
 
 protected:
     Continue(ASTContext* ctx, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/statements/declaration.h
+++ b/hilti/toolchain/include/ast/statements/declaration.h
@@ -15,8 +15,8 @@ class Declaration : public Statement {
 public:
     auto declaration() const { return child<::hilti::Declaration>(0); }
 
-    static auto create(ASTContext* ctx, const hilti::DeclarationPtr& d, Meta meta = {}) {
-        return std::shared_ptr<Declaration>(new Declaration(ctx, {d}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Declaration* d, Meta meta = {}) {
+        return ctx->make<Declaration>(ctx, {d}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/expression.h
+++ b/hilti/toolchain/include/ast/statements/expression.h
@@ -15,8 +15,8 @@ class Expression : public Statement {
 public:
     auto expression() const { return child<hilti::Expression>(0); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& e, Meta meta = {}) {
-        return std::shared_ptr<Expression>(new Expression(ctx, {e}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* e, Meta meta = {}) {
+        return ctx->make<Expression>(ctx, {e}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/for.h
+++ b/hilti/toolchain/include/ast/statements/for.h
@@ -18,10 +18,9 @@ public:
     auto sequence() const { return child<::hilti::Expression>(1); }
     auto body() const { return child<hilti::Statement>(2); }
 
-    static auto create(ASTContext* ctx, const hilti::ID& id, const ExpressionPtr& seq, const StatementPtr& body,
-                       Meta meta = {}) {
+    static auto create(ASTContext* ctx, const hilti::ID& id, hilti::Expression* seq, Statement* body, Meta meta = {}) {
         auto local = declaration::LocalVariable::create(ctx, id, meta);
-        return std::shared_ptr<For>(new For(ctx, {local, seq, body}, std::move(meta)));
+        return ctx->make<For>(ctx, {local, seq, body}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/if.h
+++ b/hilti/toolchain/include/ast/statements/if.h
@@ -20,16 +20,15 @@ public:
     auto true_() const { return child<hilti::Statement>(2); }
     auto false_() const { return child<Statement>(3); }
 
-    void setCondition(ASTContext* ctx, const ExpressionPtr& c) { setChild(ctx, 1, c); }
+    void setCondition(ASTContext* ctx, hilti::Expression* c) { setChild(ctx, 1, c); }
 
-    static auto create(ASTContext* ctx, const DeclarationPtr& init, const ExpressionPtr& cond,
-                       const StatementPtr& true_, const StatementPtr& false_, Meta meta = {}) {
-        return std::shared_ptr<If>(new If(ctx, {init, cond, true_, false_}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Declaration* init, hilti::Expression* cond, Statement* true_,
+                       Statement* false_, Meta meta = {}) {
+        return ctx->make<If>(ctx, {init, cond, true_, false_}, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& cond, const StatementPtr& true_,
-                       const StatementPtr& false_, Meta meta = {}) {
-        return std::shared_ptr<If>(new If(ctx, {nullptr, cond, true_, false_}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* cond, Statement* true_, Statement* false_, Meta meta = {}) {
+        return ctx->make<If>(ctx, {nullptr, cond, true_, false_}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/return.h
+++ b/hilti/toolchain/include/ast/statements/return.h
@@ -15,10 +15,10 @@ class Return : public Statement {
 public:
     auto expression() const { return child<::hilti::Expression>(0); }
 
-    void setExpression(ASTContext* ctx, const ExpressionPtr& c) { setChild(ctx, 0, c); }
+    void setExpression(ASTContext* ctx, hilti::Expression* c) { setChild(ctx, 0, c); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, Meta meta = {}) {
-        return std::shared_ptr<Return>(new Return(ctx, {expr}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* expr, Meta meta = {}) {
+        return ctx->make<Return>(ctx, {expr}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Meta meta = {}) { return create(ctx, nullptr, std::move(meta)); }

--- a/hilti/toolchain/include/ast/statements/set_location.h
+++ b/hilti/toolchain/include/ast/statements/set_location.h
@@ -14,8 +14,8 @@ class SetLocation : public Statement {
 public:
     auto expression() const { return child<::hilti::Expression>(0); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, Meta meta = {}) {
-        return std::shared_ptr<SetLocation>(new SetLocation(ctx, {expr}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* expr, Meta meta = {}) {
+        return ctx->make<SetLocation>(ctx, {expr}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/switch.h
+++ b/hilti/toolchain/include/ast/statements/switch.h
@@ -84,7 +84,7 @@ private:
     int _end_exprs;
 };
 
-using Cases = std::vector<Case*>;
+using Cases = NodeVector<Case>;
 
 } // namespace switch_
 

--- a/hilti/toolchain/include/ast/statements/switch.h
+++ b/hilti/toolchain/include/ast/statements/switch.h
@@ -43,15 +43,15 @@ public:
 
     auto preprocessedExpressions() const { return children<hilti::Expression>(_end_exprs, {}); }
 
-    static auto create(ASTContext* ctx, const Expressions& exprs, const StatementPtr& body, Meta meta = {}) {
-        return std::shared_ptr<Case>(new Case(ctx, node::flatten(body, exprs), std::move(meta)));
+    static auto create(ASTContext* ctx, const Expressions& exprs, Statement* body, Meta meta = {}) {
+        return ctx->make<Case>(ctx, node::flatten(body, exprs), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, const StatementPtr& body, Meta meta = {}) {
+    static auto create(ASTContext* ctx, hilti::Expression* expr, Statement* body, Meta meta = {}) {
         return create(ctx, Expressions{expr}, body, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, switch_::Default /*unused*/, const StatementPtr& body, Meta meta = {}) {
+    static auto create(ASTContext* ctx, switch_::Default /*unused*/, Statement* body, Meta meta = {}) {
         return create(ctx, Expressions{}, body, std::move(meta));
     }
 
@@ -84,8 +84,7 @@ private:
     int _end_exprs;
 };
 
-using CasePtr = std::shared_ptr<Case>;
-using Cases = std::vector<CasePtr>;
+using Cases = std::vector<Case*>;
 
 } // namespace switch_
 
@@ -95,7 +94,7 @@ public:
     auto condition() const { return child<declaration::LocalVariable>(0); }
     auto cases() const { return children<switch_::Case>(1, {}); }
 
-    switch_::CasePtr default_() const {
+    switch_::Case* default_() const {
         for ( const auto& c : cases() ) {
             if ( c->isDefault() )
                 return c;
@@ -115,16 +114,16 @@ public:
     }
 
 
-    void addCase(ASTContext* ctx, const switch_::CasePtr& c) {
+    void addCase(ASTContext* ctx, switch_::Case* c) {
         addChild(ctx, c);
         _preprocessed = false;
     }
 
-    static auto create(ASTContext* ctx, DeclarationPtr cond, const switch_::Cases& cases, Meta meta = {}) {
-        return std::shared_ptr<Switch>(new Switch(ctx, node::flatten(std::move(cond), cases), std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Declaration* cond, const switch_::Cases& cases, Meta meta = {}) {
+        return ctx->make<Switch>(ctx, node::flatten(cond, cases), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& cond, const switch_::Cases& cases, Meta meta = {}) {
+    static auto create(ASTContext* ctx, hilti::Expression* cond, const switch_::Cases& cases, Meta meta = {}) {
         return create(ctx, declaration::LocalVariable::create(ctx, ID("__x"), cond), cases, std::move(meta));
     }
 

--- a/hilti/toolchain/include/ast/statements/throw.h
+++ b/hilti/toolchain/include/ast/statements/throw.h
@@ -15,13 +15,11 @@ class Throw : public Statement {
 public:
     auto expression() const { return child<::hilti::Expression>(0); }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& expr, Meta meta = {}) {
-        return std::shared_ptr<Throw>(new Throw(ctx, {expr}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Expression* expr, Meta meta = {}) {
+        return ctx->make<Throw>(ctx, {expr}, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Throw>(new Throw(ctx, {nullptr}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Throw>(ctx, {nullptr}, std::move(meta)); }
 
 protected:
     Throw(ASTContext* ctx, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/statements/try.h
+++ b/hilti/toolchain/include/ast/statements/try.h
@@ -22,12 +22,12 @@ public:
     auto parameter() const { return child<declaration::Parameter>(0); }
     auto body() const { return child<hilti::Statement>(1); }
 
-    static auto create(ASTContext* ctx, const DeclarationPtr& param, const StatementPtr& body, Meta meta = {}) {
-        return std::shared_ptr<Catch>(new Catch(ctx, {param, body}, std::move(meta)));
+    static auto create(ASTContext* ctx, hilti::Declaration* param, Statement* body, Meta meta = {}) {
+        return ctx->make<Catch>(ctx, {param, body}, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const StatementPtr& body, Meta meta = {}) {
-        return std::shared_ptr<Catch>(new Catch(ctx, {nullptr, body}, std::move(meta)));
+    static auto create(ASTContext* ctx, Statement* body, Meta meta = {}) {
+        return ctx->make<Catch>(ctx, {nullptr, body}, std::move(meta));
     }
 
 protected:
@@ -41,8 +41,7 @@ protected:
     HILTI_NODE_0(statement::try_::Catch, final);
 };
 
-using CatchPtr = std::shared_ptr<Catch>;
-using Catches = std::vector<CatchPtr>;
+using Catches = std::vector<Catch*>;
 
 } // namespace try_
 
@@ -52,10 +51,10 @@ public:
     auto body() const { return child<hilti::Statement>(0); }
     auto catches() const { return children<try_::Catch>(1, {}); }
 
-    void addCatch(ASTContext* ctx, const try_::CatchPtr& c) { addChild(ctx, c); }
+    void addCatch(ASTContext* ctx, try_::Catch* c) { addChild(ctx, c); }
 
-    static auto create(ASTContext* ctx, StatementPtr body, const try_::Catches& catches, Meta meta = {}) {
-        return std::shared_ptr<Try>(new Try(ctx, node::flatten(std::move(body), catches), std::move(meta)));
+    static auto create(ASTContext* ctx, Statement* body, const try_::Catches& catches, Meta meta = {}) {
+        return ctx->make<Try>(ctx, node::flatten(body, catches), std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/try.h
+++ b/hilti/toolchain/include/ast/statements/try.h
@@ -41,7 +41,7 @@ protected:
     HILTI_NODE_0(statement::try_::Catch, final);
 };
 
-using Catches = std::vector<Catch*>;
+using Catches = NodeVector<Catch>;
 
 } // namespace try_
 

--- a/hilti/toolchain/include/ast/statements/while.h
+++ b/hilti/toolchain/include/ast/statements/while.h
@@ -20,20 +20,20 @@ public:
     auto body() const { return child<hilti::Statement>(2); }
     auto else_() const { return child<Statement>(3); }
 
-    void setCondition(ASTContext* ctx, const ExpressionPtr& c) { setChild(ctx, 1, c); }
+    void setCondition(ASTContext* ctx, hilti::Expression* c) { setChild(ctx, 1, c); }
     void removeElse(ASTContext* ctx) { setChild(ctx, 3, nullptr); }
 
-    static auto create(ASTContext* ctx, const DeclarationPtr& init, const ExpressionPtr& cond, const StatementPtr& body,
-                       const StatementPtr& else_ = nullptr, const Meta& meta = {}) {
-        return std::shared_ptr<While>(new While(ctx, {init, cond, body, else_}, meta));
+    static auto create(ASTContext* ctx, hilti::Declaration* init, hilti::Expression* cond, Statement* body,
+                       Statement* else_ = nullptr, Meta meta = {}) {
+        return ctx->make<While>(ctx, {init, cond, body, else_}, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ExpressionPtr& cond, const StatementPtr& body, const Meta& meta = {}) {
-        return create(ctx, nullptr, cond, body, nullptr, meta);
+    static auto create(ASTContext* ctx, hilti::Expression* cond, Statement* body, Meta meta = {}) {
+        return create(ctx, nullptr, cond, body, nullptr, std::move(meta));
     }
-    static auto create(ASTContext* ctx, const ExpressionPtr& cond, const StatementPtr& body,
-                       const StatementPtr& else_ = nullptr, const Meta& meta = {}) {
-        return create(ctx, nullptr, cond, body, else_, meta);
+    static auto create(ASTContext* ctx, hilti::Expression* cond, Statement* body, Statement* else_ = nullptr,
+                       Meta meta = {}) {
+        return create(ctx, nullptr, cond, body, else_, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/statements/yield.h
+++ b/hilti/toolchain/include/ast/statements/yield.h
@@ -12,9 +12,7 @@ namespace hilti::statement {
 /** AST node for a `yield` statement. */
 class Yield : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Yield>(new Yield(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Yield>(ctx, {}, std::move(meta)); }
 
 protected:
     Yield(ASTContext* ctx, Nodes children, Meta meta)

--- a/hilti/toolchain/include/ast/types/address.h
+++ b/hilti/toolchain/include/ast/types/address.h
@@ -12,9 +12,7 @@ namespace hilti::type {
 /** AST node for an `addr` type. */
 class Address : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, const Meta& m = Meta()) {
-        return std::shared_ptr<Address>(new Address(ctx, m));
-    }
+    static auto create(ASTContext* ctx, const Meta& m = Meta()) { return ctx->make<Address>(ctx, m); }
 
     std::string_view typeClass() const final { return "address"; }
 
@@ -22,7 +20,7 @@ public:
     bool isSortable() const final { return true; }
 
 protected:
-    Address(ASTContext* ctx, const Meta& meta) : UnqualifiedType(ctx, NodeTags, {"address"}, meta) {}
+    Address(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"address"}, std::move(meta)) {}
 
     HILTI_NODE_1(type::Address, UnqualifiedType, final);
 };

--- a/hilti/toolchain/include/ast/types/any.h
+++ b/hilti/toolchain/include/ast/types/any.h
@@ -12,7 +12,7 @@ namespace hilti::type {
 /** AST node for an `any` type. */
 class Any : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, Meta m = Meta()) { return std::shared_ptr<Any>(new Any(ctx, std::move(m))); }
+    static auto create(ASTContext* ctx, Meta m = Meta()) { return ctx->make<Any>(ctx, std::move(m)); }
 
     std::string_view typeClass() const final { return "any"; }
 

--- a/hilti/toolchain/include/ast/types/auto.h
+++ b/hilti/toolchain/include/ast/types/auto.h
@@ -12,14 +12,14 @@ namespace hilti::type {
 /** AST node for an `auto` type. */
 class Auto : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, const Meta& m = Meta()) { return std::shared_ptr<Auto>(new Auto(ctx, m)); }
+    static auto create(ASTContext* ctx, const Meta& m = Meta()) { return ctx->make<Auto>(ctx, m); }
 
     std::string_view typeClass() const final { return "auto"; }
 
     bool isResolved(node::CycleDetector* cd) const final { return false; }
 
 protected:
-    Auto(ASTContext* ctx, const Meta& meta) : UnqualifiedType(ctx, NodeTags, {}, meta) {}
+    Auto(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {}, std::move(meta)) {}
 
 
     HILTI_NODE_1(type::Auto, UnqualifiedType, final);

--- a/hilti/toolchain/include/ast/types/bitfield.h
+++ b/hilti/toolchain/include/ast/types/bitfield.h
@@ -47,30 +47,28 @@ public:
         return Declaration::properties() + p;
     }
 
-    void setItemType(ASTContext* ctx, const QualifiedTypePtr& t) { setChild(ctx, 0, t); }
-    void setAttributes(ASTContext* ctx, const AttributeSetPtr& attrs) { setChild(ctx, 1, attrs); }
-    void setCtorValue(ASTContext* ctx, const ExpressionPtr& e) { setChild(ctx, 2, e); }
+    void setItemType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
+    void setAttributes(ASTContext* ctx, AttributeSet* attrs) { setChild(ctx, 1, attrs); }
+    void setCtorValue(ASTContext* ctx, Expression* e) { setChild(ctx, 2, e); }
 
     static auto create(ASTContext* ctx, const ID& id, unsigned int lower, unsigned int upper, unsigned int field_width,
-                       AttributeSetPtr attrs = {}, const ExpressionPtr& ctor_value = nullptr,
-                       const Meta& meta = Meta()) {
+                       AttributeSet* attrs = {}, Expression* ctor_value = nullptr, Meta meta = Meta()) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
         auto dd = expression::Keyword::createDollarDollarDeclaration(
             ctx, QualifiedType::create(ctx, type::UnsignedInteger::create(ctx, field_width), Constness::Const));
 
-        return std::shared_ptr<BitRange>(
-            new BitRange(ctx, node::flatten(QualifiedType::createAuto(ctx), attrs, ctor_value, dd), id, lower, upper,
-                         field_width, meta));
+        return ctx->make<BitRange>(ctx, node::flatten(QualifiedType::createAuto(ctx), attrs, ctor_value, dd), id, lower,
+                                   upper, field_width, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, const ID& id, unsigned int lower, unsigned int upper, unsigned int field_width,
-                       AttributeSetPtr attrs = {}, const Meta& meta = Meta()) {
+                       AttributeSet* attrs = {}, Meta meta = Meta()) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return create(ctx, id, lower, upper, field_width, attrs, nullptr, meta);
+        return create(ctx, id, lower, upper, field_width, attrs, nullptr, std::move(meta));
     }
 
 protected:
@@ -92,8 +90,7 @@ private:
     unsigned int _field_width = 0;
 };
 
-using BitRangePtr = std::shared_ptr<BitRange>;
-using BitRanges = std::vector<BitRangePtr>;
+using BitRanges = std::vector<BitRange*>;
 
 } // namespace bitfield
 
@@ -110,7 +107,7 @@ public:
             return children<bitfield::BitRange>(1, -1);
     }
 
-    bitfield::BitRangePtr bits(const ID& id) const;
+    bitfield::BitRange* bits(const ID& id) const;
     std::optional<unsigned int> bitsIndex(const ID& id) const;
 
     /**
@@ -118,9 +115,9 @@ public:
      * a bitfield ctor value that corresponds to all values defined by any of
      * the bits. If none does, return nothing.
      */
-    CtorPtr ctorValue(ASTContext* ctx);
+    Ctor* ctorValue(ASTContext* ctx);
 
-    void addField(ASTContext* ctx, const bitfield::BitRangePtr& f) { addChild(ctx, f); }
+    void addField(ASTContext* ctx, bitfield::BitRange* f) { addChild(ctx, f); }
 
     std::string_view typeClass() const final { return "bitfield"; }
 
@@ -136,17 +133,17 @@ public:
         return UnqualifiedType::properties() + node::WithUniqueID::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, unsigned int width, type::bitfield::BitRanges bits, AttributeSetPtr attrs,
+    static auto create(ASTContext* ctx, unsigned int width, type::bitfield::BitRanges bits, AttributeSet* attrs,
                        const Meta& m = Meta()) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
         auto value = bitfield::BitRange::create(ctx, ID("__value__"), 0, width - 1, width, {}, m);
-        return std::shared_ptr<Bitfield>(new Bitfield(ctx, node::flatten(attrs, std::move(bits), value), width, m));
+        return ctx->make<Bitfield>(ctx, node::flatten(attrs, std::move(bits), value), width, m);
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Bitfield>(new Bitfield(ctx, Wildcard(), m));
+        return ctx->make<Bitfield>(ctx, Wildcard(), m);
     }
 
 protected:
@@ -155,8 +152,8 @@ protected:
           WithUniqueID("bitfield"),
           _width(width) {}
 
-    Bitfield(ASTContext* ctx, Wildcard _, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"bitfield(*)"}, meta), WithUniqueID("bitfield") {}
+    Bitfield(ASTContext* ctx, Wildcard _, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"bitfield(*)"}, std::move(meta)), WithUniqueID("bitfield") {}
 
     HILTI_NODE_1(type::Bitfield, UnqualifiedType, final);
 

--- a/hilti/toolchain/include/ast/types/bitfield.h
+++ b/hilti/toolchain/include/ast/types/bitfield.h
@@ -90,7 +90,7 @@ private:
     unsigned int _field_width = 0;
 };
 
-using BitRanges = std::vector<BitRange*>;
+using BitRanges = NodeVector<BitRange>;
 
 } // namespace bitfield
 

--- a/hilti/toolchain/include/ast/types/bool.h
+++ b/hilti/toolchain/include/ast/types/bool.h
@@ -12,7 +12,7 @@ namespace hilti::type {
 /** AST node for a `bool` type. */
 class Bool : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, const Meta& meta = {}) { return std::shared_ptr<Bool>(new Bool(ctx, meta)); }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Bool>(ctx, std::move(meta)); }
 
     std::string_view typeClass() const final { return "bool"; }
 
@@ -20,7 +20,7 @@ public:
     bool isSortable() const final { return true; }
 
 protected:
-    Bool(ASTContext* ctx, const Meta& meta) : UnqualifiedType(ctx, NodeTags, {"bool"}, meta) {}
+    Bool(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"bool"}, std::move(meta)) {}
 
     HILTI_NODE_1(type::Bool, UnqualifiedType, final);
 };

--- a/hilti/toolchain/include/ast/types/bytes.h
+++ b/hilti/toolchain/include/ast/types/bytes.h
@@ -15,11 +15,11 @@ namespace bytes {
 /** AST node for a bytes iterator type. */
 class Iterator : public UnqualifiedType {
 public:
-    QualifiedTypePtr dereferencedType() const final { return child<QualifiedType>(0); }
+    QualifiedType* dereferencedType() const final { return child<QualifiedType>(0); }
 
-    static auto create(ASTContext* ctx, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Meta meta = {}) {
         auto etype = QualifiedType::create(ctx, type::UnsignedInteger::create(ctx, 8, meta), Constness::Const, meta);
-        return std::shared_ptr<Iterator>(new Iterator(ctx, {etype}, meta));
+        return ctx->make<Iterator>(ctx, {etype}, std::move(meta));
     }
 
     std::string_view typeClass() const final { return "iterator<bytes>"; }
@@ -39,12 +39,13 @@ protected:
 /** AST node for a `bytes` type. */
 class Bytes : public UnqualifiedType {
 public:
-    QualifiedTypePtr elementType() const final { return iteratorType()->type()->dereferencedType(); }
-    QualifiedTypePtr iteratorType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return iteratorType()->type()->dereferencedType(); }
+    QualifiedType* iteratorType() const final { return child<QualifiedType>(0); }
 
     static auto create(ASTContext* ctx, const Meta& meta = {}) {
-        return std::shared_ptr<Bytes>(
-            new Bytes(ctx, {QualifiedType::create(ctx, bytes::Iterator::create(ctx, meta), Constness::Mutable)}, meta));
+        return ctx->make<Bytes>(ctx,
+                                {QualifiedType::create(ctx, bytes::Iterator::create(ctx, meta), Constness::Mutable)},
+                                meta);
     }
 
     std::string_view typeClass() const final { return "bytes"; }

--- a/hilti/toolchain/include/ast/types/doc-only.h
+++ b/hilti/toolchain/include/ast/types/doc-only.h
@@ -20,9 +20,9 @@ class DocOnly : public UnqualifiedType {
 public:
     auto description() const { return _description; }
 
-    static auto create(ASTContext* ctx, const std::string& description, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, const std::string& description, Meta meta = {}) {
         // Note: We allow (i.e., must support) `ctx` being null.
-        return std::shared_ptr<DocOnly>(new DocOnly(ctx, description, meta));
+        return ctx->make<DocOnly>(ctx, description, std::move(meta));
     }
 
     std::string_view typeClass() const final { return "doc-only"; }

--- a/hilti/toolchain/include/ast/types/enum.h
+++ b/hilti/toolchain/include/ast/types/enum.h
@@ -57,7 +57,7 @@ private:
     int _value = -1;
 };
 
-using Labels = std::vector<Label*>;
+using Labels = NodeVector<Label>;
 
 } // namespace enum_
 

--- a/hilti/toolchain/include/ast/types/enum.h
+++ b/hilti/toolchain/include/ast/types/enum.h
@@ -33,12 +33,12 @@ public:
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, const ID& id, int value, const Meta& meta = {}) {
-        return std::shared_ptr<Label>(new Label(ctx, {nullptr}, id, value, meta));
+    static auto create(ASTContext* ctx, const ID& id, int value, Meta meta = {}) {
+        return ctx->make<Label>(ctx, {nullptr}, id, value, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const ID& id, const Meta& meta = {}) {
-        return std::shared_ptr<Label>(new Label(ctx, {nullptr}, id, -1, meta));
+    static auto create(ASTContext* ctx, const ID& id, Meta meta = {}) {
+        return ctx->make<Label>(ctx, {nullptr}, id, -1, std::move(meta));
     }
 
 protected:
@@ -48,7 +48,7 @@ protected:
         : Node(ctx, NodeTags, std::move(children), std::move(meta)), _id(std::move(id)), _value(value) {}
 
     void setValue(int value) { _value = value; }
-    void setEnumType(ASTContext* ctx, const QualifiedTypePtr& type) { setChild(ctx, 0, type); }
+    void setEnumType(ASTContext* ctx, QualifiedType* type) { setChild(ctx, 0, type); }
 
     HILTI_NODE_0(type::enum_::Label, final);
 
@@ -57,8 +57,7 @@ private:
     int _value = -1;
 };
 
-using LabelPtr = std::shared_ptr<Label>;
-using Labels = std::vector<LabelPtr>;
+using Labels = std::vector<Label*>;
 
 } // namespace enum_
 
@@ -74,7 +73,7 @@ public:
      */
     enum_::Labels uniqueLabels() const;
 
-    enum_::LabelPtr label(const ID& id) const {
+    enum_::Label* label(const ID& id) const {
         for ( const auto& l : labels() ) {
             if ( l->id() == id )
                 return l;
@@ -90,20 +89,20 @@ public:
     bool isNameType() const final { return true; }
 
     static auto create(ASTContext* ctx, enum_::Labels labels, Meta meta = {}) {
-        auto t = std::shared_ptr<Enum>(new Enum(ctx, Nodes(), std::move(meta)));
+        auto t = ctx->make<Enum>(ctx, Nodes(), std::move(meta));
         t->_setLabels(ctx, std::move(labels));
         return t;
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Enum>(new Enum(ctx, Wildcard(), m));
+        return ctx->make<Enum>(ctx, Wildcard(), m);
     }
 
 protected:
     Enum(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    Enum(ASTContext* ctx, Wildcard _, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"enum(*)"}, meta) {}
+    Enum(ASTContext* ctx, Wildcard _, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"enum(*)"}, std::move(meta)) {}
 
     HILTI_NODE_1(type::Enum, UnqualifiedType, final);
 

--- a/hilti/toolchain/include/ast/types/error.h
+++ b/hilti/toolchain/include/ast/types/error.h
@@ -12,9 +12,7 @@ namespace hilti::type {
 /** AST node for a error type. */
 class Error : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Error>(new Error(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Error>(ctx, std::move(meta)); }
 
     std::string_view typeClass() const final { return "error"; }
 

--- a/hilti/toolchain/include/ast/types/exception.h
+++ b/hilti/toolchain/include/ast/types/exception.h
@@ -20,21 +20,21 @@ public:
     bool isAllocable() const final { return true; }
     bool isNameType() const final { return true; }
 
-    static auto create(ASTContext* ctx, const UnqualifiedTypePtr& base, Meta meta = {}) {
-        return std::shared_ptr<Exception>(new Exception(ctx, {base}, std::move(meta)));
+    static auto create(ASTContext* ctx, UnqualifiedType* base, Meta meta = {}) {
+        return ctx->make<Exception>(ctx, {base}, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const Meta& meta = {}) { return create(ctx, nullptr, meta); }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return create(ctx, nullptr, std::move(meta)); }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Exception>(new Exception(ctx, Wildcard(), {type::Unknown::create(ctx, m)}, m));
+        return ctx->make<Exception>(ctx, Wildcard(), {type::Unknown::create(ctx, m)}, m);
     }
 
 protected:
     Exception(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    Exception(ASTContext* ctx, Wildcard _, const Nodes& children, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"exception(*)"}, children, meta) {}
+    Exception(ASTContext* ctx, Wildcard _, const Nodes& children, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"exception(*)"}, children, std::move(meta)) {}
 
     bool isResolved(node::CycleDetector* cd) const final { return baseType() ? baseType()->isResolved(cd) : true; }
 

--- a/hilti/toolchain/include/ast/types/integer.h
+++ b/hilti/toolchain/include/ast/types/integer.h
@@ -43,10 +43,10 @@ class SignedInteger : public detail::IntegerBase {
 public:
     std::string_view typeClass() const final { return "int"; }
 
-    static std::shared_ptr<SignedInteger> create(ASTContext* ctx, unsigned int width, const Meta& m = Meta());
+    static SignedInteger* create(ASTContext* ctx, unsigned int width, const Meta& m = Meta());
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<SignedInteger>(new SignedInteger(ctx, Wildcard(), m));
+        return ctx->make<SignedInteger>(ctx, Wildcard(), m);
     }
 
 protected:
@@ -63,10 +63,10 @@ class UnsignedInteger : public detail::IntegerBase {
 public:
     std::string_view typeClass() const final { return "uint"; }
 
-    static std::shared_ptr<UnsignedInteger> create(ASTContext* ctx, unsigned int width, const Meta& m = Meta());
+    static UnsignedInteger* create(ASTContext* ctx, unsigned int width, const Meta& m = Meta());
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<UnsignedInteger>(new UnsignedInteger(ctx, Wildcard(), m));
+        return ctx->make<UnsignedInteger>(ctx, Wildcard(), m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/interval.h
+++ b/hilti/toolchain/include/ast/types/interval.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Interval>(new Interval(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Interval>(ctx, std::move(meta)); }
 
 protected:
     Interval(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"interval"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/library.h
+++ b/hilti/toolchain/include/ast/types/library.h
@@ -32,7 +32,7 @@ public:
     }
 
     static auto create(ASTContext* ctx, const std::string& cxx_name, Meta meta = {}) {
-        return std::shared_ptr<Library>(new Library(ctx, cxx_name, std::move(meta)));
+        return ctx->make<Library>(ctx, cxx_name, std::move(meta));
     }
 
 private:

--- a/hilti/toolchain/include/ast/types/list.h
+++ b/hilti/toolchain/include/ast/types/list.h
@@ -17,27 +17,26 @@ class Iterator : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "iterator<list>"; }
 
-    QualifiedTypePtr dereferencedType() const final { return child<QualifiedType>(0); }
+    QualifiedType* dereferencedType() const final { return child<QualifiedType>(0); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return dereferencedType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& etype, Meta meta = {}) {
-        return std::shared_ptr<Iterator>(new Iterator(ctx, {etype}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* etype, Meta meta = {}) {
+        return ctx->make<Iterator>(ctx, {etype}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Iterator>(
-            new Iterator(ctx, Wildcard(), {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)},
-                         m));
+        return ctx->make<Iterator>(ctx, Wildcard(),
+                                   {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:
     Iterator(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    Iterator(ASTContext* ctx, Wildcard _, const Nodes& children, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"iterator(list(*))"}, children, meta) {}
+    Iterator(ASTContext* ctx, Wildcard _, const Nodes& children, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"iterator(list(*))"}, children, std::move(meta)) {}
 
     HILTI_NODE_1(type::list::Iterator, UnqualifiedType, final);
 };
@@ -49,30 +48,31 @@ class List : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "list"; }
 
-    QualifiedTypePtr elementType() const final { return iteratorType()->type()->dereferencedType(); }
-    QualifiedTypePtr iteratorType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return iteratorType()->type()->dereferencedType(); }
+    QualifiedType* iteratorType() const final { return child<QualifiedType>(0); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return iteratorType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return std::shared_ptr<List>(
-            new List(ctx, {QualifiedType::create(ctx, list::Iterator::create(ctx, t, meta), Constness::Mutable)},
-                     meta));
+    static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
+        return ctx->make<List>(ctx,
+                               {QualifiedType::create(ctx, list::Iterator::create(ctx, t, meta), Constness::Mutable)},
+                               meta);
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<List>(
-            new List(ctx, Wildcard(),
-                     {QualifiedType::create(ctx, list::Iterator::create(ctx, Wildcard(), m), Constness::Mutable)}, m));
+        return ctx->make<List>(ctx, Wildcard(),
+                               {QualifiedType::create(ctx, list::Iterator::create(ctx, Wildcard(), m),
+                                                      Constness::Mutable)},
+                               m);
     }
 
 protected:
     List(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    List(ASTContext* ctx, Wildcard _, const Nodes& children, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"list(*)"}, children, meta) {}
+    List(ASTContext* ctx, Wildcard _, const Nodes& children, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"list(*)"}, children, std::move(meta)) {}
 
     void newlyQualified(const QualifiedType* qtype) const final { elementType()->setConst(qtype->constness()); }
 

--- a/hilti/toolchain/include/ast/types/map.h
+++ b/hilti/toolchain/include/ast/types/map.h
@@ -19,31 +19,31 @@ class Iterator : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "iterator<map>"; }
 
-    QualifiedTypePtr keyType() const { return dereferencedType()->type()->as<type::Tuple>()->elements()[0]->type(); }
-    QualifiedTypePtr valueType() const { return dereferencedType()->type()->as<type::Tuple>()->elements()[1]->type(); }
-    QualifiedTypePtr dereferencedType() const final { return child<QualifiedType>(0); }
+    QualifiedType* keyType() const { return dereferencedType()->type()->as<type::Tuple>()->elements()[0]->type(); }
+    QualifiedType* valueType() const { return dereferencedType()->type()->as<type::Tuple>()->elements()[1]->type(); }
+    QualifiedType* dereferencedType() const final { return child<QualifiedType>(0); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& ktype, const QualifiedTypePtr& vtype,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Iterator>(
-            new Iterator(ctx, {QualifiedType::create(ctx, type::Tuple::create(ctx, {ktype, vtype}), Constness::Const)},
-                         meta));
+    static auto create(ASTContext* ctx, QualifiedType* ktype, QualifiedType* vtype, const Meta& meta = {}) {
+        return ctx->make<Iterator>(ctx,
+                                   {QualifiedType::create(ctx, type::Tuple::create(ctx, QualifiedTypes{ktype, vtype}),
+                                                          Constness::Const)},
+                                   meta);
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& meta = Meta()) {
-        return std::shared_ptr<Iterator>(
-            new Iterator(ctx, Wildcard(),
-                         {QualifiedType::create(
-                             ctx,
-                             type::Tuple::create(ctx, {QualifiedType::create(ctx, type::Unknown::create(ctx, meta),
-                                                                             Constness::Const),
-                                                       QualifiedType::create(ctx, type::Unknown::create(ctx, meta),
-                                                                             Constness::Const)}),
-                             Constness::Const)},
-                         meta));
+        return ctx->make<Iterator>(
+            ctx, Wildcard(),
+            {QualifiedType::create(
+                ctx,
+                type::Tuple::create(ctx, QualifiedTypes{QualifiedType::create(ctx, type::Unknown::create(ctx, meta),
+                                                                              Constness::Const),
+                                                        QualifiedType::create(ctx, type::Unknown::create(ctx, meta),
+                                                                              Constness::Const)}),
+                Constness::Const)},
+            meta);
     }
 
 protected:
@@ -64,30 +64,30 @@ protected:
 /** AST node for a `map` type. */
 class Map : public UnqualifiedType {
 public:
-    QualifiedTypePtr keyType() const { return iteratorType()->type()->as<map::Iterator>()->keyType(); }
-    QualifiedTypePtr valueType() const { return iteratorType()->type()->as<map::Iterator>()->valueType(); }
+    QualifiedType* keyType() const { return iteratorType()->type()->as<map::Iterator>()->keyType(); }
+    QualifiedType* valueType() const { return iteratorType()->type()->as<map::Iterator>()->valueType(); }
 
     std::string_view typeClass() const final { return "map"; }
 
-    QualifiedTypePtr iteratorType() const final { return child<QualifiedType>(0); }
-    QualifiedTypePtr elementType() const final { return valueType(); }
+    QualifiedType* iteratorType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return valueType(); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return iteratorType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& ktype, const QualifiedTypePtr& vtype,
-                       const Meta& meta = {}) {
-        return std::shared_ptr<Map>(
-            new Map(ctx,
-                    {QualifiedType::create(ctx, map::Iterator::create(ctx, ktype, vtype, meta), Constness::Mutable)},
-                    meta));
+    static auto create(ASTContext* ctx, QualifiedType* ktype, QualifiedType* vtype, const Meta& meta = {}) {
+        return ctx->make<Map>(ctx,
+                              {QualifiedType::create(ctx, map::Iterator::create(ctx, ktype, vtype, meta),
+                                                     Constness::Mutable)},
+                              meta);
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Map>(
-            new Map(ctx, Wildcard(),
-                    {QualifiedType::create(ctx, map::Iterator::create(ctx, Wildcard(), m), Constness::Mutable)}, m));
+        return ctx->make<Map>(ctx, Wildcard(),
+                              {QualifiedType::create(ctx, map::Iterator::create(ctx, Wildcard(), m),
+                                                     Constness::Mutable)},
+                              m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/member.h
+++ b/hilti/toolchain/include/ast/types/member.h
@@ -22,11 +22,11 @@ public:
     }
 
     static auto create(ASTContext* ctx, const ID& id, Meta meta = {}) {
-        return std::shared_ptr<Member>(new Member(ctx, id, std::move(meta)));
+        return ctx->make<Member>(ctx, id, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Member>(new Member(ctx, Wildcard(), m));
+        return ctx->make<Member>(ctx, Wildcard(), m);
     }
 
 protected:
@@ -35,8 +35,8 @@ protected:
         assert(_id);
     }
 
-    Member(ASTContext* ctx, Wildcard _, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"member(*)"}, meta), _id("<wildcard>") {}
+    Member(ASTContext* ctx, Wildcard _, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"member(*)"}, std::move(meta)), _id("<wildcard>") {}
 
     HILTI_NODE_1(type::Member, UnqualifiedType, final);
 

--- a/hilti/toolchain/include/ast/types/name.h
+++ b/hilti/toolchain/include/ast/types/name.h
@@ -19,7 +19,7 @@ public:
     bool isBuiltIn() const { return _builtin; }
 
     // resolves recursively
-    UnqualifiedTypePtr resolvedType() const {
+    UnqualifiedType* resolvedType() const {
         if ( ! _resolved_type_index )
             return nullptr;
 
@@ -31,7 +31,7 @@ public:
     }
 
     // resolves recursively
-    std::shared_ptr<declaration::Type> resolvedDeclaration() {
+    declaration::Type* resolvedDeclaration() {
         if ( _resolved_type_index )
             return resolvedType()->typeDeclaration();
         else
@@ -53,8 +53,8 @@ public:
         return UnqualifiedType::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, const ID& id, const Meta& meta = {}) {
-        return std::shared_ptr<Name>(new Name(ctx, id, false, meta));
+    static auto create(ASTContext* ctx, const ID& id, Meta meta = {}) {
+        return ctx->make<Name>(ctx, id, false, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/network.h
+++ b/hilti/toolchain/include/ast/types/network.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Network>(new Network(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Network>(ctx, std::move(meta)); }
 
 protected:
     Network(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"network"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/null.h
+++ b/hilti/toolchain/include/ast/types/null.h
@@ -14,9 +14,7 @@ class Null : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "null"; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Null>(new Null(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Null>(ctx, std::move(meta)); }
 
 protected:
     Null(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"null"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/operand-list.h
+++ b/hilti/toolchain/include/ast/types/operand-list.h
@@ -30,28 +30,28 @@ public:
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, parameter::Kind kind, const UnqualifiedTypePtr& type, bool optional = false,
+    static auto create(ASTContext* ctx, parameter::Kind kind, UnqualifiedType* type, bool optional = false,
                        std::string doc = "", Meta meta = {}) {
-        return std::shared_ptr<Operand>(new Operand(ctx, {_makeOperandType(ctx, kind, type), nullptr}, {}, kind,
-                                                    optional, std::move(doc), std::move(meta)));
+        return ctx->make<Operand>(ctx, {_makeOperandType(ctx, kind, type), nullptr}, ID(), kind, optional,
+                                  std::move(doc), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, const UnqualifiedTypePtr& type,
-                       bool optional = false, std::string doc = "", Meta meta = {}) {
-        return std::shared_ptr<Operand>(new Operand(ctx, {_makeOperandType(ctx, kind, type), nullptr}, std::move(id),
-                                                    kind, optional, std::move(doc), std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, UnqualifiedType* type, bool optional = false,
+                       std::string doc = "", Meta meta = {}) {
+        return ctx->make<Operand>(ctx, {_makeOperandType(ctx, kind, type), nullptr}, std::move(id), kind, optional,
+                                  std::move(doc), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, const UnqualifiedTypePtr& type,
-                       const ExpressionPtr& default_, std::string doc = "", const Meta& meta = {}) {
-        return std::shared_ptr<Operand>(new Operand(ctx, {_makeOperandType(ctx, kind, type), default_}, std::move(id),
-                                                    kind, (default_ != nullptr), std::move(doc), meta));
+    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, UnqualifiedType* type, Expression* default_,
+                       std::string doc = "", Meta meta = {}) {
+        return ctx->make<Operand>(ctx, {_makeOperandType(ctx, kind, type), default_}, std::move(id), kind,
+                                  (default_ != nullptr), std::move(doc), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, const UnqualifiedTypePtr& type,
-                       const ExpressionPtr& default_, bool optional, std::string doc = "", const Meta& meta = {}) {
-        return std::shared_ptr<Operand>(new Operand(ctx, {_makeOperandType(ctx, kind, type), default_}, std::move(id),
-                                                    kind, optional, std::move(doc), meta));
+    static auto create(ASTContext* ctx, ID id, parameter::Kind kind, UnqualifiedType* type, Expression* default_,
+                       bool optional, std::string doc = "", Meta meta = {}) {
+        return ctx->make<Operand>(ctx, {_makeOperandType(ctx, kind, type), default_}, std::move(id), kind, optional,
+                                  std::move(doc), std::move(meta));
     }
 
 protected:
@@ -66,7 +66,7 @@ protected:
     HILTI_NODE_0(type::operand_list::Operand, final);
 
 private:
-    static QualifiedTypePtr _makeOperandType(ASTContext* ctx, parameter::Kind _kind, const UnqualifiedTypePtr& type);
+    static QualifiedType* _makeOperandType(ASTContext* ctx, parameter::Kind _kind, UnqualifiedType* type);
 
     ID _id;
     parameter::Kind _kind = parameter::Kind::Unknown;
@@ -74,8 +74,7 @@ private:
     std::string _doc;
 };
 
-using OperandPtr = std::shared_ptr<Operand>;
-using Operands = std::vector<OperandPtr>;
+using Operands = std::vector<Operand*>;
 } // namespace operand_list
 
 /**
@@ -103,15 +102,15 @@ public:
     std::string_view typeClass() const final { return "operand-list"; }
 
     static auto create(ASTContext* ctx, operand_list::Operands operands, Meta meta = {}) {
-        return std::shared_ptr<OperandList>(new OperandList(ctx, node::flatten(std::move(operands)), std::move(meta)));
+        return ctx->make<OperandList>(ctx, node::flatten(std::move(operands)), std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<OperandList>(new OperandList(ctx, Wildcard(), m));
+        return ctx->make<OperandList>(ctx, Wildcard(), m);
     }
 
     template<typename Container>
-    static UnqualifiedTypePtr fromParameters(ASTContext* ctx, const Container& params) {
+    static UnqualifiedType* fromParameters(ASTContext* ctx, const Container& params) {
         operand_list::Operands ops;
 
         for ( const auto& p : params )
@@ -124,8 +123,8 @@ public:
 protected:
     OperandList(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    OperandList(ASTContext* ctx, Wildcard _, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"operand-list(*)"}, meta) {}
+    OperandList(ASTContext* ctx, Wildcard _, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"operand-list(*)"}, std::move(meta)) {}
 
     HILTI_NODE_1(type::OperandList, UnqualifiedType, final);
 };

--- a/hilti/toolchain/include/ast/types/operand-list.h
+++ b/hilti/toolchain/include/ast/types/operand-list.h
@@ -74,7 +74,7 @@ private:
     std::string _doc;
 };
 
-using Operands = std::vector<Operand*>;
+using Operands = NodeVector<Operand>;
 } // namespace operand_list
 
 /**

--- a/hilti/toolchain/include/ast/types/optional.h
+++ b/hilti/toolchain/include/ast/types/optional.h
@@ -14,21 +14,20 @@ namespace hilti::type {
 /** AST node for an `optional<T>` type. */
 class Optional : public UnqualifiedType {
 public:
-    QualifiedTypePtr dereferencedType() const final { return child(0)->as<QualifiedType>(); }
+    QualifiedType* dereferencedType() const final { return child(0)->as<QualifiedType>(); }
 
     std::string_view typeClass() const final { return "optional"; }
 
     bool isAllocable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return dereferencedType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, Meta m = Meta()) {
-        return std::shared_ptr<Optional>(new Optional(ctx, {t}, std::move(m)));
+    static auto create(ASTContext* ctx, QualifiedType* t, Meta m = Meta()) {
+        return ctx->make<Optional>(ctx, {t}, std::move(m));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Optional>(
-            new Optional(ctx, Wildcard(), {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)},
-                         m));
+        return ctx->make<Optional>(ctx, Wildcard(),
+                                   {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/port.h
+++ b/hilti/toolchain/include/ast/types/port.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Port>(new Port(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Port>(ctx, std::move(meta)); }
 
 protected:
     Port(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"port"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/real.h
+++ b/hilti/toolchain/include/ast/types/real.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Real>(new Real(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Real>(ctx, std::move(meta)); }
 
 protected:
     Real(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"real"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/reference.h
+++ b/hilti/toolchain/include/ast/types/reference.h
@@ -17,20 +17,20 @@ class StrongReference : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "strong_ref"; }
 
-    QualifiedTypePtr dereferencedType() const final { return child(0)->as<QualifiedType>(); }
+    QualifiedType* dereferencedType() const final { return child(0)->as<QualifiedType>(); }
 
     bool isAllocable() const final { return true; }
     bool isReferenceType() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return dereferencedType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<StrongReference>(new StrongReference(ctx, {type}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<StrongReference>(ctx, {type}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<StrongReference>(
-            new StrongReference(ctx, Wildcard(),
-                                {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)}, m));
+        return ctx->make<StrongReference>(ctx, Wildcard(),
+                                          {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)},
+                                          m);
     }
 
 protected:
@@ -47,19 +47,18 @@ class WeakReference : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "weak_ref"; }
 
-    QualifiedTypePtr dereferencedType() const final { return child(0)->as<QualifiedType>(); }
+    QualifiedType* dereferencedType() const final { return child(0)->as<QualifiedType>(); }
 
     bool isAllocable() const final { return true; }
     bool isReferenceType() const final { return true; }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<WeakReference>(new WeakReference(ctx, {type}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<WeakReference>(ctx, {type}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<WeakReference>(
-            new WeakReference(ctx, Wildcard(),
-                              {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)}, m));
+        return ctx->make<WeakReference>(ctx, Wildcard(),
+                                        {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:
@@ -78,19 +77,18 @@ class ValueReference : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "value_ref"; }
 
-    QualifiedTypePtr dereferencedType() const final { return child(0)->as<QualifiedType>(); }
+    QualifiedType* dereferencedType() const final { return child(0)->as<QualifiedType>(); }
 
     bool isAllocable() const final { return true; }
     bool isReferenceType() const final { return true; }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<ValueReference>(new ValueReference(ctx, {type}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<ValueReference>(ctx, {type}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<ValueReference>(
-            new ValueReference(ctx, Wildcard(),
-                               {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)}, m));
+        return ctx->make<ValueReference>(ctx, Wildcard(),
+                                         {QualifiedType::create(ctx, type::Null::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/regexp.h
+++ b/hilti/toolchain/include/ast/types/regexp.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<RegExp>(new RegExp(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<RegExp>(ctx, std::move(meta)); }
 
 protected:
     RegExp(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"regexp"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/result.h
+++ b/hilti/toolchain/include/ast/types/result.h
@@ -16,19 +16,18 @@ class Result : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "result"; }
 
-    QualifiedTypePtr dereferencedType() const final { return child(0)->as<QualifiedType>(); }
+    QualifiedType* dereferencedType() const final { return child(0)->as<QualifiedType>(); }
 
     bool isAllocable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return dereferencedType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, Meta m = Meta()) {
-        return std::shared_ptr<Result>(new Result(ctx, {t}, std::move(m)));
+    static auto create(ASTContext* ctx, QualifiedType* t, Meta m = Meta()) {
+        return ctx->make<Result>(ctx, {t}, std::move(m));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Result>(
-            new Result(ctx, Wildcard(), {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)},
-                       m));
+        return ctx->make<Result>(ctx, Wildcard(),
+                                 {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/set.h
+++ b/hilti/toolchain/include/ast/types/set.h
@@ -18,20 +18,19 @@ class Iterator : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "iterator<set>"; }
 
-    QualifiedTypePtr dereferencedType() const override { return child<QualifiedType>(0); }
+    QualifiedType* dereferencedType() const override { return child<QualifiedType>(0); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return dereferencedType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& etype, Meta meta = {}) {
-        return std::shared_ptr<Iterator>(new Iterator(ctx, {etype}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* etype, Meta meta = {}) {
+        return ctx->make<Iterator>(ctx, {etype}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Iterator>(
-            new Iterator(ctx, Wildcard(), {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)},
-                         m));
+        return ctx->make<Iterator>(ctx, Wildcard(),
+                                   {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:
@@ -51,22 +50,24 @@ class Set : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "set"; }
 
-    QualifiedTypePtr elementType() const final { return iteratorType()->type()->dereferencedType(); }
-    QualifiedTypePtr iteratorType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return iteratorType()->type()->dereferencedType(); }
+    QualifiedType* iteratorType() const final { return child<QualifiedType>(0); }
 
     bool isAllocable() const override { return true; }
     bool isMutable() const override { return true; }
     bool isResolved(node::CycleDetector* cd) const final { return iteratorType()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& t, const Meta& meta = {}) {
-        return std::shared_ptr<Set>(
-            new Set(ctx, {QualifiedType::create(ctx, set::Iterator::create(ctx, t, meta), Constness::Mutable)}, meta));
+    static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
+        return ctx->make<Set>(ctx,
+                              {QualifiedType::create(ctx, set::Iterator::create(ctx, t, meta), Constness::Mutable)},
+                              meta);
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Set>(
-            new Set(ctx, Wildcard(),
-                    {QualifiedType::create(ctx, set::Iterator::create(ctx, Wildcard(), m), Constness::Mutable)}, m));
+        return ctx->make<Set>(ctx, Wildcard(),
+                              {QualifiedType::create(ctx, set::Iterator::create(ctx, Wildcard(), m),
+                                                     Constness::Mutable)},
+                              m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/stream.h
+++ b/hilti/toolchain/include/ast/types/stream.h
@@ -17,14 +17,14 @@ namespace stream {
 class Iterator : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "iterator<stream>"; }
-    QualifiedTypePtr dereferencedType() const final { return child<QualifiedType>(0); }
+    QualifiedType* dereferencedType() const final { return child<QualifiedType>(0); }
 
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
 
-    static auto create(ASTContext* ctx, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Meta meta = {}) {
         auto etype = QualifiedType::create(ctx, type::UnsignedInteger::create(ctx, 8, meta), Constness::Mutable, meta);
-        return std::shared_ptr<Iterator>(new Iterator(ctx, {etype}, meta));
+        return ctx->make<Iterator>(ctx, {etype}, std::move(meta));
     }
 
 protected:
@@ -42,12 +42,12 @@ public:
     bool isAllocable() const final { return true; }
     bool isMutable() const final { return true; }
 
-    QualifiedTypePtr elementType() const final { return iteratorType()->type()->dereferencedType(); }
-    QualifiedTypePtr iteratorType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return iteratorType()->type()->dereferencedType(); }
+    QualifiedType* iteratorType() const final { return child<QualifiedType>(0); }
 
     static auto create(ASTContext* ctx, const Meta& meta = {}) {
-        return std::shared_ptr<View>(
-            new View(ctx, {QualifiedType::create(ctx, Iterator::create(ctx, meta), Constness::Mutable)}, meta));
+        return ctx->make<View>(ctx, {QualifiedType::create(ctx, Iterator::create(ctx, meta), Constness::Mutable)},
+                               meta);
     }
 
 protected:
@@ -68,13 +68,13 @@ public:
     bool isMutable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    QualifiedTypePtr elementType() const final { return iteratorType()->type()->dereferencedType(); }
-    QualifiedTypePtr iteratorType() const final { return viewType()->type()->iteratorType(); }
-    QualifiedTypePtr viewType() const final { return child<QualifiedType>(0); }
+    QualifiedType* elementType() const final { return iteratorType()->type()->dereferencedType(); }
+    QualifiedType* iteratorType() const final { return viewType()->type()->iteratorType(); }
+    QualifiedType* viewType() const final { return child<QualifiedType>(0); }
 
     static auto create(ASTContext* ctx, const Meta& meta = {}) {
-        return std::shared_ptr<Stream>(
-            new Stream(ctx, {QualifiedType::create(ctx, stream::View::create(ctx, meta), Constness::Mutable)}, meta));
+        return ctx->make<Stream>(ctx, {QualifiedType::create(ctx, stream::View::create(ctx, meta), Constness::Mutable)},
+                                 meta);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/string.h
+++ b/hilti/toolchain/include/ast/types/string.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<String>(new String(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<String>(ctx, std::move(meta)); }
 
 protected:
     String(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"string"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/time.h
+++ b/hilti/toolchain/include/ast/types/time.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return true; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Time>(new Time(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Time>(ctx, std::move(meta)); }
 
 protected:
     Time(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"time"}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/tuple.h
+++ b/hilti/toolchain/include/ast/types/tuple.h
@@ -47,7 +47,7 @@ private:
     ID _id;
 };
 
-using Elements = std::vector<Element*>;
+using Elements = NodeVector<Element>;
 
 } // namespace tuple
 

--- a/hilti/toolchain/include/ast/types/tuple.h
+++ b/hilti/toolchain/include/ast/types/tuple.h
@@ -29,12 +29,12 @@ public:
         return Node::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, ID id, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<Element>(new Element(ctx, {type}, std::move(id), std::move(meta)));
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<Element>(ctx, {type}, std::move(id), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<Element>(new Element(ctx, {type}, ID(), std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<Element>(ctx, {type}, ID(), std::move(meta));
     }
 
 protected:
@@ -47,8 +47,7 @@ private:
     ID _id;
 };
 
-using ElementPtr = std::shared_ptr<Element>;
-using Elements = std::vector<std::shared_ptr<Element>>;
+using Elements = std::vector<Element*>;
 
 } // namespace tuple
 
@@ -56,7 +55,7 @@ using Elements = std::vector<std::shared_ptr<Element>>;
 class Tuple : public UnqualifiedType {
 public:
     auto elements() const { return children<tuple::Element>(0, {}); }
-    std::optional<std::pair<int, type::tuple::ElementPtr>> elementByID(const ID& id) const;
+    std::optional<std::pair<int, type::tuple::Element*>> elementByID(const ID& id) const;
 
     std::string_view typeClass() const final { return "tuple"; }
 
@@ -65,23 +64,23 @@ public:
     bool isSortable() const final { return true; }
 
     static auto create(ASTContext* ctx, type::tuple::Elements elements, Meta meta = {}) {
-        return std::shared_ptr<Tuple>(new Tuple(ctx, std::move(elements), std::move(meta)));
+        return ctx->make<Tuple>(ctx, std::move(elements), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, const QualifiedTypes& types, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, const QualifiedTypes& types, Meta meta = {}) {
         auto elements = util::transform(types, [&](const auto& t) { return tuple::Element::create(ctx, t, meta); });
-        return std::shared_ptr<Tuple>(new Tuple(ctx, std::move(elements), meta));
+        return ctx->make<Tuple>(ctx, std::move(elements), std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Tuple>(new Tuple(ctx, Wildcard(), m));
+        return ctx->make<Tuple>(ctx, Wildcard(), m);
     }
 
 protected:
     Tuple(ASTContext* ctx, Nodes children, Meta meta)
         : UnqualifiedType(ctx, NodeTags, {}, std::move(children), std::move(meta)) {}
-    Tuple(ASTContext* ctx, Wildcard _, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"tuple(*)"}, meta) {}
+    Tuple(ASTContext* ctx, Wildcard _, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, Wildcard(), {"tuple(*)"}, std::move(meta)) {}
 
 
     HILTI_NODE_1(type::Tuple, UnqualifiedType, final);

--- a/hilti/toolchain/include/ast/types/type.h
+++ b/hilti/toolchain/include/ast/types/type.h
@@ -19,14 +19,13 @@ public:
 
     bool isResolved(node::CycleDetector* cd) const final { return typeValue()->isResolved(cd); }
 
-    static auto create(ASTContext* ctx, const QualifiedTypePtr& type, Meta meta = {}) {
-        return std::shared_ptr<Type_>(new Type_(ctx, {type}, std::move(meta)));
+    static auto create(ASTContext* ctx, QualifiedType* type, Meta meta = {}) {
+        return ctx->make<Type_>(ctx, {type}, std::move(meta));
     }
 
     static auto create(ASTContext* ctx, Wildcard _, const Meta& m = Meta()) {
-        return std::shared_ptr<Type_>(
-            new Type_(ctx, Wildcard(), {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)},
-                      m));
+        return ctx->make<Type_>(ctx, Wildcard(),
+                                {QualifiedType::create(ctx, type::Unknown::create(ctx, m), Constness::Const)}, m);
     }
 
 protected:

--- a/hilti/toolchain/include/ast/types/unknown.h
+++ b/hilti/toolchain/include/ast/types/unknown.h
@@ -14,9 +14,7 @@ class Unknown : public UnqualifiedType {
 public:
     std::string_view typeClass() const final { return "unknown"; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Unknown>(new Unknown(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Unknown>(ctx, std::move(meta)); }
 
 protected:
     Unknown(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {type::NeverMatch()}, std::move(meta)) {}

--- a/hilti/toolchain/include/ast/types/void.h
+++ b/hilti/toolchain/include/ast/types/void.h
@@ -17,9 +17,7 @@ public:
     bool isAllocable() const final { return false; }
     bool isSortable() const final { return true; }
 
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Void>(new Void(ctx, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Void>(ctx, std::move(meta)); }
 
 protected:
     Void(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"void"}, std::move(meta)) {}

--- a/hilti/toolchain/include/base/monotonic_buffer_resource.h
+++ b/hilti/toolchain/include/base/monotonic_buffer_resource.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-2024 by the Zeek Project. See LICENSE for details.
+//
+// This code is copied and adapted from Broker, Zeek's communication framework.
+// The original version can be found at
+// https://github.com/zeek/broker/blob/master/libbroker/broker/detail/monotonic_buffer_resource.hh
+//
+// TODO: Drop this class once the PMR API is available on all supported platforms.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <utility>
+
+namespace hilti::detail {
+
+// Drop-in replacement for std::pmr::monotonic_buffer_resource.
+class monotonic_buffer_resource {
+public:
+    monotonic_buffer_resource() { allocate_block(nullptr, 0); }
+
+    monotonic_buffer_resource(const monotonic_buffer_resource&) = delete;
+
+    monotonic_buffer_resource& operator=(const monotonic_buffer_resource&) = delete;
+
+    ~monotonic_buffer_resource() noexcept { destroy(); }
+
+    // Allocates memory.
+    [[nodiscard]] void* allocate(size_t bytes, size_t alignment = alignof(max_align_t));
+
+    // Fancy no-op.
+    void deallocate(void*, size_t, size_t = alignof(std::max_align_t)) {
+        // nop
+    }
+
+    template<class T>
+    class allocator {
+    public:
+        using value_type = T;
+
+        template<class U>
+        struct rebind {
+            using other = allocator<U>;
+        };
+
+        constexpr explicit allocator(monotonic_buffer_resource* mbr) : mbr_(mbr) {
+            // nop
+        }
+
+        constexpr allocator() : mbr_(nullptr) {
+            // nop
+        }
+
+        constexpr allocator(const allocator&) = default;
+
+        constexpr allocator& operator=(const allocator&) = default;
+
+        template<class U>
+        constexpr allocator(const allocator<U>& other) : mbr_(other.resource()) {
+            // nop
+        }
+
+        template<class U>
+        allocator& operator=(const allocator<U>& other) {
+            mbr_ = other.resource();
+            return *this;
+        }
+
+        T* allocate(size_t n) { return static_cast<T*>(mbr_->allocate(sizeof(T) * n, alignof(T))); }
+
+        constexpr void deallocate(void*, size_t) noexcept {
+            // nop
+        }
+
+        constexpr auto resource() const noexcept { return mbr_; }
+
+        friend bool operator==(allocator& lhs, allocator& rhs) { return lhs.mbr_ == rhs.mbr_; }
+
+    private:
+        monotonic_buffer_resource* mbr_;
+    };
+
+private:
+    struct block {
+        block* next;
+        void* bytes;
+    };
+
+    void allocate_block(block* prev_block, size_t min_size);
+
+    void destroy() noexcept;
+
+    size_t remaining_ = 0;
+    size_t previous_size_ = 0; // [Spicy] New member to track the size of the last block.
+    block* current_;
+};
+
+// Non-standard convenience function to avoid having to implement a drop-in
+// replacement for polymorphic_allocator.
+template<class T, class... Args>
+T* new_instance(monotonic_buffer_resource& buf, Args&&... args) {
+    auto ptr = buf.allocate(sizeof(T), alignof(T));
+    return new (ptr) T(std::forward<Args>(args)...);
+}
+
+} // namespace hilti::detail

--- a/hilti/toolchain/include/compiler/coercer.h
+++ b/hilti/toolchain/include/compiler/coercer.h
@@ -123,13 +123,13 @@ struct CoercedExpression {
      * even if the coerced expression ends up being identical to the source
      * expression.
      */
-    Result<ExpressionPtr> coerced = {};
+    Result<Expression*> coerced = {};
 
     /**
      * Coerced expression if successful and the coerced expression is not
      * identical to original one; unset otherwise.
      */
-    ExpressionPtr nexpr = {};
+    Expression* nexpr = {};
 
     /**
      * If coerced is set, true if type of new expression's type is to be
@@ -151,7 +151,7 @@ struct CoercedExpression {
      *
      * @param src the original source expression
      */
-    CoercedExpression(const ExpressionPtr& src) : coerced(src) {}
+    CoercedExpression(Expression* src) : coerced(src) {}
 
     /**
      * Represents a successful coercion that led to a new expression
@@ -160,7 +160,7 @@ struct CoercedExpression {
      * @param src the original source expression's type
      * @param coerced the resulting expression that *src* was coerced to
      */
-    CoercedExpression(const QualifiedTypePtr& src, const ExpressionPtr& coerced)
+    CoercedExpression(QualifiedType* src, Expression* coerced)
         : coerced(coerced),
           nexpr(coerced),
           consider_type_changed(src->type()->typeClass() != coerced->type()->type()->typeClass()) {}
@@ -194,7 +194,7 @@ struct CoercedExpression {
  * @return the *result* will evaluate to true if coercion was successful; if
  * so, the contained fields will provide more information
  */
-CoercedExpression coerceExpression(Builder* builder, const ExpressionPtr& e, const QualifiedTypePtr& dst,
+CoercedExpression coerceExpression(Builder* builder, Expression* e, QualifiedType* dst,
                                    bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment, bool lhs = false);
 
 /**
@@ -218,8 +218,7 @@ CoercedExpression coerceExpression(Builder* builder, const ExpressionPtr& e, con
  * @return the *result* will evaluate to true if coercion was successful; if
  * so, the contained fields will provide more information
  */
-CoercedExpression coerceExpression(Builder* builder, const ExpressionPtr& e, const QualifiedTypePtr& src_,
-                                   const QualifiedTypePtr& dst_,
+CoercedExpression coerceExpression(Builder* builder, Expression* e, QualifiedType* src_, QualifiedType* dst_,
                                    bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment, bool lhs = false);
 
 /**
@@ -255,8 +254,8 @@ Result<std::pair<bool, Expressions>> coerceOperands(Builder* builder, operator_:
  * @param style coercion style to use
  * @return if the coercion was successful, the returned new value (which may be the same as the old)
  */
-Result<CtorPtr> coerceCtor(Builder* builder, CtorPtr c, const QualifiedTypePtr& dst,
-                           bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment);
+Result<Ctor*> coerceCtor(Builder* builder, Ctor* c, QualifiedType* dst,
+                         bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment);
 
 /**
  * Coerces a source type to a given target type. This returns the coerced
@@ -269,18 +268,17 @@ Result<CtorPtr> coerceCtor(Builder* builder, CtorPtr c, const QualifiedTypePtr& 
  * @param style coercion style to use
  * @return if the coercion was successful, the returned new value (which may be the same as the old)
  */
-Result<QualifiedTypePtr> coerceType(Builder* builder, const QualifiedTypePtr& src_, const QualifiedTypePtr& dst_,
-                                    bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment);
+Result<QualifiedType*> coerceType(Builder* builder, QualifiedType* src_, QualifiedType* dst_,
+                                  bitmask<CoercionStyle> style = CoercionStyle::TryAllForAssignment);
 
 
 namespace coercer::detail {
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-CtorPtr coerceCtor(Builder* builder, const CtorPtr& c, const QualifiedTypePtr& dst, bitmask<CoercionStyle> style);
+Ctor* coerceCtor(Builder* builder, Ctor* c, QualifiedType* dst, bitmask<CoercionStyle> style);
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-QualifiedTypePtr coerceType(Builder* builder, const QualifiedTypePtr& t, const QualifiedTypePtr& dst,
-                            bitmask<CoercionStyle> style);
+QualifiedType* coerceType(Builder* builder, QualifiedType* t, QualifiedType* dst, bitmask<CoercionStyle> style);
 
 } // namespace coercer::detail
 

--- a/hilti/toolchain/include/compiler/detail/ast-dumper.h
+++ b/hilti/toolchain/include/compiler/detail/ast-dumper.h
@@ -16,7 +16,7 @@ namespace hilti::detail::ast_dumper {
  * @param include_scopes if true, include a dump of each node's identifier
  *        scope
  */
-void dump(std::ostream& out, const NodePtr& node, bool include_scopes = false);
+void dump(std::ostream& out, Node* node, bool include_scopes = false);
 
 /**
  * Log a debug representation of an AST node to a debug stream. The output
@@ -27,6 +27,6 @@ void dump(std::ostream& out, const NodePtr& node, bool include_scopes = false);
  * @param include_scopes if true, include a dump of each node's identifier
  *        scope
  */
-void dump(logging::DebugStream stream, const NodePtr& node, bool include_scopes = false);
+void dump(logging::DebugStream stream, Node* node, bool include_scopes = false);
 
 } // namespace hilti::detail::ast_dumper

--- a/hilti/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/hilti/toolchain/include/compiler/detail/codegen/codegen.h
@@ -162,7 +162,7 @@ private:
     std::vector<detail::cxx::Block*> _cxx_blocks;
     std::vector<detail::cxx::declaration::Local> _tmps;
     std::map<std::string, int> _tmp_counters;
-    std::vector<QualifiedType*> _need_decls;
+    QualifiedTypes _need_decls;
     hilti::util::Cache<cxx::ID, codegen::CxxTypes> _cache_types_storage;
     hilti::util::Cache<cxx::ID, codegen::CxxTypeInfo> _cache_type_info;
     hilti::util::Cache<cxx::ID, cxx::declaration::Type> _cache_types_declarations;

--- a/hilti/toolchain/include/compiler/detail/constant-folder.h
+++ b/hilti/toolchain/include/compiler/detail/constant-folder.h
@@ -14,6 +14,6 @@ namespace hilti::detail::constant_folder {
  * expression is not represeneting a constant value, but only that we aren't
  * able to compute it.
  */
-Result<CtorPtr> fold(Builder* builder, const ExpressionPtr& expr);
+Result<Ctor*> fold(Builder* builder, Expression* expr);
 
 } // namespace hilti::detail::constant_folder

--- a/hilti/toolchain/include/compiler/detail/optimizer.h
+++ b/hilti/toolchain/include/compiler/detail/optimizer.h
@@ -10,6 +10,6 @@ namespace hilti::detail::optimizer {
  * Applies optimizations to an AST. The AST must have been fully processed
  * before running optimization.
  */
-void optimize(Builder* builder, const ASTRootPtr& root);
+void optimize(Builder* builder, ASTRoot* root);
 
 } // namespace hilti::detail::optimizer

--- a/hilti/toolchain/include/compiler/detail/parser/driver.h
+++ b/hilti/toolchain/include/compiler/detail/parser/driver.h
@@ -42,7 +42,7 @@ inline const DebugStream Parser("parser");
 
 namespace detail::parser {
 
-extern Result<ModulePtr> parseSource(Builder* builder, std::istream& in, const std::string& filename);
+extern Result<declaration::Module*> parseSource(Builder* builder, std::istream& in, const std::string& filename);
 
 class Parser;
 class Scanner;
@@ -50,7 +50,7 @@ class Scanner;
 /** Driver for flex/bison. */
 class Driver {
 public:
-    Result<ModulePtr> parse(Builder* builder, std::istream& in, const std::string& filename);
+    Result<declaration::Module*> parse(Builder* builder, std::istream& in, const std::string& filename);
 
     Scanner* scanner() const { return _scanner; }
     Parser* parser() const { return _parser; }
@@ -67,7 +67,7 @@ public:
     void enableDottedIDMode();
     void disableDottedIDMode();
 
-    void setDestinationModule(const ModulePtr& m) { _module = m; }
+    void setDestinationModule(declaration::Module* m) { _module = m; }
 
 private:
     Builder* _builder = nullptr;
@@ -75,7 +75,7 @@ private:
     Parser* _parser = nullptr;
     Scanner* _scanner = nullptr;
 
-    ModulePtr _module;
+    declaration::Module* _module = nullptr;
     int _expression_mode = 0;
 };
 

--- a/hilti/toolchain/include/compiler/detail/resolver.h
+++ b/hilti/toolchain/include/compiler/detail/resolver.h
@@ -8,6 +8,6 @@
 namespace hilti::detail::resolver {
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-bool resolve(Builder* builder, const NodePtr& root);
+bool resolve(Builder* builder, Node* root);
 
 } // namespace hilti::detail::resolver

--- a/hilti/toolchain/include/compiler/detail/scope-builder.h
+++ b/hilti/toolchain/include/compiler/detail/scope-builder.h
@@ -8,6 +8,6 @@
 namespace hilti::detail::scope_builder {
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-void build(Builder* builder, const ASTRootPtr& root);
+void build(Builder* builder, ASTRoot* root);
 
 } // namespace hilti::detail::scope_builder

--- a/hilti/toolchain/include/compiler/driver.h
+++ b/hilti/toolchain/include/compiler/driver.h
@@ -433,7 +433,7 @@ protected:
      * been initially set up for processing by a plugin. This hook will run
      * before the AST has been processed any further by that plugin.
      */
-    virtual void hookNewASTPreCompilation(const Plugin& plugin, const std::shared_ptr<ASTRoot>& root) {}
+    virtual void hookNewASTPreCompilation(const Plugin& plugin, ASTRoot* root) {}
 
     /**
      * Hook for derived classes to execute custom code when an HILTI AST been
@@ -450,13 +450,13 @@ protected:
      * @param root the AST that has been processed
      * @return true if the AST has been modified and needs to be reprocessed
      */
-    virtual bool hookNewASTPostCompilation(const Plugin& plugin, const std::shared_ptr<ASTRoot>& root) { return false; }
+    virtual bool hookNewASTPostCompilation(const Plugin& plugin, ASTRoot* root) { return false; }
 
     /**
      * Hook for derived classes to execute custom code when the AST has been
      * fully processed and transformed to its final state.
      */
-    virtual Result<Nothing> hookCompilationFinished(const std::shared_ptr<ASTRoot>& root) { return Nothing(); }
+    virtual Result<Nothing> hookCompilationFinished(ASTRoot* root) { return Nothing(); }
 
     /**
      * Hook for derived classes to execute custom code when the HILTI runtime

--- a/hilti/toolchain/include/compiler/plugin.h
+++ b/hilti/toolchain/include/compiler/plugin.h
@@ -101,7 +101,7 @@ struct Plugin {
      * @param arg3 file associated with the input stream
      * @return module AST if parsing succeeded
      */
-    Hook<Result<ModulePtr>, hilti::Builder*, std::istream&, hilti::rt::filesystem::path> parse;
+    Hook<Result<declaration::Module*>, hilti::Builder*, std::istream&, hilti::rt::filesystem::path> parse;
 
     /**
      * Hook called to perform coercion of a `Ctor` into another of a given target type.
@@ -115,14 +115,14 @@ struct Plugin {
      * @param arg4 coercion style to use
      * @return new ctor if plugin performed coercion, or nullptr otherwise
      */
-    Hook<CtorPtr, Builder*, const CtorPtr&, const QualifiedTypePtr&, bitmask<CoercionStyle>> coerce_ctor;
+    Hook<Ctor*, Builder*, Ctor*, QualifiedType*, bitmask<CoercionStyle>> coerce_ctor;
 
     /**
      * Hook called to approved coercion of an expression into a different
      * type.
      *
      * If the plugin knows it can handle the coercion, it returns the
-     * resulting coerced `QualifiedTypePtr`. If so, it must then also provide an
+     * resulting coerced `QualifiedType*`. If so, it must then also provide an
      * `apply_coercions` hook that will later be called to perform the actual
      * coercion during code generation.
      *
@@ -132,8 +132,7 @@ struct Plugin {
      * @param arg4 coercion style to use
      * @return new type if plugin can handle this coercion
      */
-    Hook<QualifiedTypePtr, Builder*, const QualifiedTypePtr&, const QualifiedTypePtr&, bitmask<CoercionStyle>>
-        coerce_type;
+    Hook<QualifiedType*, Builder*, QualifiedType*, QualifiedType*, bitmask<CoercionStyle>> coerce_type;
 
     /**
      * Hook called once before any other AST processing takes place.
@@ -141,7 +140,7 @@ struct Plugin {
      * @param arg1 builder to use
      * @param arg2 root node of AST; the hook may modify the AST
      */
-    Hook<void, Builder*, const ASTRootPtr&> ast_init;
+    Hook<void, Builder*, ASTRoot*> ast_init;
 
     /**
      * Hook called to build the scopes in a module's AST.
@@ -150,7 +149,7 @@ struct Plugin {
      * @param arg2 root node of AST; the hook may modify the AST
      * @return true if the hook modified the AST in a substantial way
      */
-    Hook<bool, Builder*, const ASTRootPtr&> ast_build_scopes;
+    Hook<bool, Builder*, ASTRoot*> ast_build_scopes;
 
     /**
      * Hook called to resolve unknown types and other entities.
@@ -159,7 +158,7 @@ struct Plugin {
      * @param arg2 root node of AST; the hook may modify the AST
      * @return true if the hook modified the AST in a substantial way
      */
-    Hook<bool, Builder*, const NodePtr&> ast_resolve;
+    Hook<bool, Builder*, Node*> ast_resolve;
 
     /**
      * Hook called to validate correctness of an AST before resolving starts
@@ -169,7 +168,7 @@ struct Plugin {
      * @param arg1 builder to use
      * @param arg2 root node of AST; the hook may not modify the AST
      */
-    Hook<bool, Builder*, const ASTRootPtr&> ast_validate_pre;
+    Hook<bool, Builder*, ASTRoot*> ast_validate_pre;
 
     /**
      * Hook called to validate correctness of an AST once fully resolved. Any
@@ -178,7 +177,7 @@ struct Plugin {
      * @param arg1 builder to use
      * @param arg2 root node of AST; the hook may not modify the AST
      */
-    Hook<bool, Builder*, const ASTRootPtr&> ast_validate_post;
+    Hook<bool, Builder*, ASTRoot*> ast_validate_post;
 
     /**
      * Hook called to print an AST back as source code. The hook gets to choose
@@ -189,7 +188,7 @@ struct Plugin {
      * @param arg2 stream to print to
      * @return true if the hook printed the AST, false to fall back to default
      */
-    Hook<bool, const NodePtr&, printer::Stream&> ast_print;
+    Hook<bool, Node*, printer::Stream&> ast_print;
 
     /**
      * Hook called to replace AST nodes of one language (plugin) with nodes
@@ -199,7 +198,7 @@ struct Plugin {
      * @param arg2 root node of AST; the hook may modify the AST
      * @return true if the hook modified the AST in a substantial way
      */
-    Hook<bool, Builder*, const ASTRootPtr&> ast_transform;
+    Hook<bool, Builder*, ASTRoot*> ast_transform;
 };
 
 class PluginRegistry;

--- a/hilti/toolchain/include/compiler/printer.h
+++ b/hilti/toolchain/include/compiler/printer.h
@@ -21,13 +21,13 @@ class Stream;
  * Prints an AST as HILTI source code. This consults any installed plugin
  * `print_ast` hooks.
  */
-void print(std::ostream& out, const NodePtr& root, bool compact = false);
+void print(std::ostream& out, Node* root, bool compact = false);
 
 /**
  * Prints an AST as HILTI source code. This consults any installed plugin
  * `print_ast` hooks.
  */
-void print(Stream& stream, const NodePtr& root); // NOLINT
+void print(Stream& stream, Node* root); // NOLINT
 
 namespace detail {
 
@@ -100,7 +100,7 @@ public:
     void popScope() { state().scopes.pop_back(); }
 
     template<typename T, IF_DERIVED_FROM(T, Node)>
-    Stream& operator<<(const std::shared_ptr<T>& t) {
+    Stream& operator<<(T* t) {
         _flush_pending();
         ::hilti::printer::print(*this, t);
         return *this;
@@ -134,7 +134,7 @@ public:
     }
 
     template<typename T>
-    Stream& operator<<(std::pair<std::shared_ptr<T>, const char*> p) {
+    Stream& operator<<(std::pair<T*, const char*> p) {
         bool first = true;
         for ( auto& i : p.first ) {
             _flush_pending();

--- a/hilti/toolchain/include/compiler/type-unifier.h
+++ b/hilti/toolchain/include/compiler/type-unifier.h
@@ -13,7 +13,7 @@ namespace hilti::type_unifier {
  *
  * @returns true if at least one type was unified that wasn't before.
  */
-bool unify(Builder* builder, const ASTRootPtr& root);
+bool unify(Builder* builder, ASTRoot* root);
 
 /**
  * Unifies an unqualified type, if possible. If it's already unified, no change
@@ -22,7 +22,7 @@ bool unify(Builder* builder, const ASTRootPtr& root);
  * @returns true if either the type is now unified, either because it was
  * already or because it could be unified now.
  */
-bool unify(ASTContext* ctx, const UnqualifiedTypePtr& type);
+bool unify(ASTContext* ctx, UnqualifiedType* type);
 
 /**
  * API class for implementing type unification for custom types by plugins.
@@ -34,7 +34,7 @@ public:
     void add(UnqualifiedType* t);
 
     /** Add the unification string for a given type. The processes the type recursively. */
-    void add(const QualifiedTypePtr& t);
+    void add(QualifiedType* t);
 
     /** Add a string to the current unification string. */
     void add(const std::string& s);

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -55,7 +55,7 @@ public:
      * Returns the root node of the module's AST. Must only be called if
      * `isCompiledHilti()` returns true.
      */
-    ModulePtr module() const;
+    declaration::Module* module() const;
 
     /** Returns the unique module ID associated with the unit. */
     const auto& uid() const { return _uid; }

--- a/hilti/toolchain/include/compiler/validator.h
+++ b/hilti/toolchain/include/compiler/validator.h
@@ -46,10 +46,10 @@ private:
 namespace detail {
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-void validatePre(Builder* builder, const ASTRootPtr& root);
+void validatePre(Builder* builder, ASTRoot* root);
 
 /** Implements the corresponding functionality for the default HILTI compiler plugin. */
-void validatePost(Builder* builder, const ASTRootPtr& root);
+void validatePost(Builder* builder, ASTRoot* root);
 
 } // namespace detail
 } // namespace hilti::validator

--- a/hilti/toolchain/src/ast/attribute.cc
+++ b/hilti/toolchain/src/ast/attribute.cc
@@ -12,7 +12,7 @@
 
 using namespace hilti;
 
-Result<ExpressionPtr> Attribute::valueAsExpression() const {
+Result<Expression*> Attribute::valueAsExpression() const {
     if ( ! hasValue() )
         return result::Error(hilti::util::fmt("attribute '%s' requires an expression", _tag));
 
@@ -48,7 +48,7 @@ Result<int64_t> Attribute::valueAsInteger() const {
     return result::Error(hilti::util::fmt("value for attribute '%s' must be an integer", _tag));
 }
 
-Result<bool> Attribute::coerceValueTo(Builder* builder, const QualifiedTypePtr& dst) {
+Result<bool> Attribute::coerceValueTo(Builder* builder, QualifiedType* dst) {
     if ( ! dst->isResolved() )
         return result::Error("cannot coerce attribute value to unresolved type");
 
@@ -61,7 +61,7 @@ Result<bool> Attribute::coerceValueTo(Builder* builder, const QualifiedTypePtr& 
         if ( ! ne.nexpr )
             return false;
 
-        setChild(builder->context(), 0, std::move(ne.nexpr));
+        setChild(builder->context(), 0, ne.nexpr);
         return true;
     }
     else
@@ -72,7 +72,7 @@ std::string Attribute::_dump() const { return ""; }
 
 std::string AttributeSet::_dump() const { return ""; }
 
-AttributePtr AttributeSet::find(std::string_view tag) const {
+Attribute* AttributeSet::find(std::string_view tag) const {
     for ( const auto& a : attributes() )
         if ( a->tag() == tag )
             return a;

--- a/hilti/toolchain/src/ast/declarations/module.cc
+++ b/hilti/toolchain/src/ast/declarations/module.cc
@@ -9,17 +9,17 @@ using namespace hilti;
 
 std::string declaration::Module::_dump() const { return ""; }
 
-std::shared_ptr<declaration::Property> declaration::Module::moduleProperty(const ID& id) const {
+declaration::Property* declaration::Module::moduleProperty(const ID& id) const {
     for ( const auto& d : declarations() ) {
         if ( ! d->isA<declaration::Property>() )
             return {};
 
         const auto& x = d->as<declaration::Property>();
         if ( x->id() == id )
-            return {x};
+            return x;
     }
 
-    return {};
+    return nullptr;
 }
 
 node::Set<declaration::Property> declaration::Module::moduleProperties(const ID& id) const {

--- a/hilti/toolchain/src/ast/expressions/name.cc
+++ b/hilti/toolchain/src/ast/expressions/name.cc
@@ -9,12 +9,12 @@
 
 using namespace hilti;
 
-QualifiedTypePtr expression::Name::type() const {
+QualifiedType* expression::Name::type() const {
     struct Visitor : hilti::visitor::PreOrder {
         Visitor(const Name* name) : name(name) {}
 
         const Name* name = nullptr;
-        QualifiedTypePtr result = nullptr;
+        QualifiedType* result = nullptr;
 
         void operator()(declaration::Constant* n) final { result = n->type(); }
         void operator()(declaration::Expression* n) final { result = n->expression()->type(); }

--- a/hilti/toolchain/src/ast/operator.cc
+++ b/hilti/toolchain/src/ast/operator.cc
@@ -78,7 +78,7 @@ std::string _printOperator(operator_::Kind kind, const Expressions& operands, bo
     if ( ! print_signature )
         return _printOperator(kind, util::transform(operands, [](const auto& x) { return x->print(); }), meta);
 
-    auto render_one = [](const QualifiedTypePtr& t) {
+    auto render_one = [](QualifiedType* t) {
         if ( t->type()->template isA<type::Member>() )
             return t->print();
         else
@@ -124,7 +124,7 @@ std::string _printOperator(operator_::Kind kind, const Expressions& operands, bo
 }
 
 std::string _printOperator(operator_::Kind kind, const Operands& operands, const Meta& meta) {
-    auto render_one = [](const OperandPtr& t) {
+    auto render_one = [](Operand* t) {
         if ( t->type()->type()->template isA<type::Member>() )
             return t->print();
         else if ( auto ft = t->type()->type()->tryAs<type::Function>(); ft && ft->functionNameForPrinting() )
@@ -184,7 +184,7 @@ public:
             return;
 
         if ( auto resolved =
-                 scope::lookupID<declaration::Type>(t->id(), builder->context()->root().get(), "built-in type") ) {
+                 scope::lookupID<declaration::Type>(t->id(), builder->context()->root(), "built-in type") ) {
             auto index = builder->context()->register_(resolved->first->type()->type());
             t->setResolvedTypeIndex(index);
         }
@@ -196,8 +196,8 @@ public:
         if ( e->resolvedDeclarationIndex() )
             return;
 
-        if ( auto resolved = scope::lookupID<declaration::Constant>(e->id(), builder->context()->root().get(),
-                                                                    "built-in constant") ) {
+        if ( auto resolved =
+                 scope::lookupID<declaration::Constant>(e->id(), builder->context()->root(), "built-in constant") ) {
             auto index = builder->context()->register_(resolved->first);
             e->setResolvedDeclarationIndex(builder->context(), index);
         }
@@ -206,7 +206,7 @@ public:
     }
 };
 
-bool Operator::init(Builder* builder, const NodePtr& scope_root) {
+bool Operator::init(Builder* builder, Node* scope_root) {
     auto sig = signature(builder);
     assert(sig.skip_doc || ! sig.ns.empty());
 
@@ -307,7 +307,7 @@ bool Operator::init(Builder* builder, const NodePtr& scope_root) {
     return true;
 }
 
-QualifiedTypePtr Operator::result(Builder* builder, const Expressions& operands, const Meta& meta) const {
+QualifiedType* Operator::result(Builder* builder, const Expressions& operands, const Meta& meta) const {
     assert(_signature);
     if ( _signature->result )
         return _signature->result;
@@ -331,8 +331,7 @@ std::string Operator::dump() const {
     return x;
 }
 
-std::shared_ptr<Operand> Operator::operandForType(Builder* builder, parameter::Kind kind, const UnqualifiedTypePtr& t,
-                                                  std::string doc) {
+Operand* Operator::operandForType(Builder* builder, parameter::Kind kind, UnqualifiedType* t, std::string doc) {
     return builder->typeOperandListOperand(kind, t, false, std::move(doc), t->meta());
 }
 

--- a/hilti/toolchain/src/ast/operators/bitfield.cc
+++ b/hilti/toolchain/src/ast/operators/bitfield.cc
@@ -19,7 +19,7 @@ using namespace hilti::operator_;
 namespace {
 namespace bitfield {
 
-QualifiedTypePtr _itemType(Builder* builder, const Expressions& operands) {
+QualifiedType* _itemType(Builder* builder, const Expressions& operands) {
     if ( auto range =
              operands[0]->type()->type()->as<type::Bitfield>()->bits(operands[1]->as<expression::Member>()->id()) )
         return range->itemType();
@@ -48,7 +48,7 @@ right.
 )"};
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return _itemType(builder, operands);
     }
 

--- a/hilti/toolchain/src/ast/operators/bytes.cc
+++ b/hilti/toolchain/src/ast/operators/bytes.cc
@@ -428,8 +428,9 @@ public:
                              },
                          .result = {Constness::Const,
                                     builder->typeTuple(
-                                        {builder->qualifiedType(builder->typeBool(), Constness::Const),
-                                         builder->qualifiedType(builder->typeBytesIterator(), Constness::Const)})},
+                                        QualifiedTypes{builder->qualifiedType(builder->typeBool(), Constness::Const),
+                                                       builder->qualifiedType(builder->typeBytesIterator(),
+                                                                              Constness::Const)})},
                          .ns = "bytes",
                          .doc = R"(
 Searches *needle* in the value's content. Returns a tuple of a boolean and an
@@ -582,8 +583,9 @@ public:
                     .optional = true,
                 },
             .result = {Constness::Const,
-                       builder->typeTuple({builder->qualifiedType(builder->typeBytes(), Constness::Const),
-                                           builder->qualifiedType(builder->typeBytes(), Constness::Const)})},
+                       builder->typeTuple(
+                           QualifiedTypes{builder->qualifiedType(builder->typeBytes(), Constness::Const),
+                                          builder->qualifiedType(builder->typeBytes(), Constness::Const)})},
             .ns = "bytes",
             .doc = R"(
 Splits the bytes value at the first occurrence of *sep* and returns the two parts

--- a/hilti/toolchain/src/ast/operators/enum.cc
+++ b/hilti/toolchain/src/ast/operators/enum.cc
@@ -73,7 +73,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -98,7 +98,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -126,7 +126,7 @@ Instantiates an enum instance initialized from a signed integer value. The value
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -156,7 +156,7 @@ enumerator labels. It must not be larger than the maximum that a
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Type_>()->typeValue();
     }
 

--- a/hilti/toolchain/src/ast/operators/exception.cc
+++ b/hilti/toolchain/src/ast/operators/exception.cc
@@ -30,7 +30,7 @@ Instantiates an instance of the exception type carrying the error message *msg*.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Type_>()->typeValue();
     }
 

--- a/hilti/toolchain/src/ast/operators/generic.cc
+++ b/hilti/toolchain/src/ast/operators/generic.cc
@@ -41,14 +41,14 @@ operator_::Signature CastedCoercion::signature(Builder* builder) const {
     };
 }
 
-QualifiedTypePtr CastedCoercion::result(Builder* builder, const Expressions& operands, const Meta& meta) const {
+QualifiedType* CastedCoercion::result(Builder* builder, const Expressions& operands, const Meta& meta) const {
     return operands[1]->type()->type()->as<type::Type_>()->typeValue();
 }
 
-Result<ResolvedOperatorPtr> CastedCoercion::instantiate(Builder* builder, Expressions operands,
-                                                        const Meta& meta) const {
+Result<expression::ResolvedOperator*> CastedCoercion::instantiate(Builder* builder, Expressions operands,
+                                                                  Meta meta) const {
     auto result_ = result(builder, operands, meta);
-    return {operator_::generic::CastedCoercion::create(builder->context(), this, result_, operands, meta)};
+    return {operator_::generic::CastedCoercion::create(builder->context(), this, result_, operands, std::move(meta))};
 }
 
 } // namespace hilti::generic
@@ -133,12 +133,13 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         const auto args = operands[1]->type()->type()->as<type::Tuple>()->elements();
         if ( args.empty() )
             return builder->qualifiedType(builder->typeError(), Constness::Const);
 
-        auto t = builder->typeTuple({operands[0]->type()->type()->as<type::Type_>()->typeValue(), args[0]->type()},
+        auto t = builder->typeTuple(QualifiedTypes{operands[0]->type()->type()->as<type::Type_>()->typeValue(),
+                                                   args[0]->type()},
                                     operands[0]->meta());
 
         if ( operands[2]->as<expression::Ctor>()->ctor()->as<ctor::Bool>()->value() )
@@ -231,7 +232,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         if ( auto iter = operands[0]->type()->type()->iteratorType() )
             return iter;
         else
@@ -259,7 +260,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         if ( auto iter = operands[0]->type()->type()->iteratorType() )
             return iter;
         else
@@ -291,7 +292,7 @@ If `x` is an expression, an instance of the expression's type will be allocated 
 )",
         };
     }
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         auto t = operands[0]->type();
 
         if ( auto tv = operands[0]->type()->type()->tryAs<type::Type_>() )

--- a/hilti/toolchain/src/ast/operators/list.cc
+++ b/hilti/toolchain/src/ast/operators/list.cc
@@ -26,7 +26,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Optional>()->dereferencedType();
     }
 
@@ -47,7 +47,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -68,7 +68,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 

--- a/hilti/toolchain/src/ast/operators/map.cc
+++ b/hilti/toolchain/src/ast/operators/map.cc
@@ -29,7 +29,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->dereferencedType();
     }
 
@@ -49,7 +49,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -69,7 +69,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -254,7 +254,7 @@ public:
         return {{op0, op1}};
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Map>()->valueType()->recreateAsConst(builder->context());
     }
 
@@ -285,7 +285,7 @@ public:
         return {{op0, op1}};
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Map>()->valueType()->recreateAsLhs(builder->context());
     }
 
@@ -347,7 +347,7 @@ the default value if provided; otherwise throws a runtime error.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Map>()->valueType()->recreateAsLhs(builder->context());
     }
 

--- a/hilti/toolchain/src/ast/operators/optional.cc
+++ b/hilti/toolchain/src/ast/operators/optional.cc
@@ -20,7 +20,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Optional>()->dereferencedType();
     }
 

--- a/hilti/toolchain/src/ast/operators/real.cc
+++ b/hilti/toolchain/src/ast/operators/real.cc
@@ -320,7 +320,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -344,7 +344,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 

--- a/hilti/toolchain/src/ast/operators/reference.cc
+++ b/hilti/toolchain/src/ast/operators/reference.cc
@@ -23,7 +23,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::StrongReference>()->dereferencedType();
     }
 
@@ -91,7 +91,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::WeakReference>()->dereferencedType();
     }
 
@@ -159,7 +159,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::ValueReference>()->dereferencedType();
     }
 

--- a/hilti/toolchain/src/ast/operators/regexp.cc
+++ b/hilti/toolchain/src/ast/operators/regexp.cc
@@ -61,8 +61,9 @@ public:
                     .type = {parameter::Kind::In, builder->typeBytes()},
                 },
             .result = {Constness::Const,
-                       builder->typeTuple({builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
-                                           builder->qualifiedType(builder->typeBytes(), Constness::Mutable)})},
+                       builder->typeTuple(
+                           QualifiedTypes{builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
+                                          builder->qualifiedType(builder->typeBytes(), Constness::Mutable)})},
             .ns = "regexp",
             .doc = R"(
 Searches the regular expression in *data* and returns the matching part.
@@ -154,8 +155,9 @@ public:
                     .default_ = builder->expressionCtor(builder->ctorBool(false)),
                 },
             .result = {Constness::Const,
-                       builder->typeTuple({builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
-                                           builder->qualifiedType(builder->typeStreamView(), Constness::Mutable)})},
+                       builder->typeTuple(
+                           QualifiedTypes{builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
+                                          builder->qualifiedType(builder->typeStreamView(), Constness::Mutable)})},
             .ns = "regexp_match_state",
             .doc = R"(
 Feeds a chunk of data into the token match state, continuing matching where it
@@ -192,8 +194,9 @@ public:
                     .default_ = builder->expressionCtor(builder->ctorBool(false)),
                 },
             .result = {Constness::Const,
-                       builder->typeTuple({builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
-                                           builder->qualifiedType(builder->typeStreamView(), Constness::Mutable)})},
+                       builder->typeTuple(
+                           QualifiedTypes{builder->qualifiedType(builder->typeSignedInteger(32), Constness::Const),
+                                          builder->qualifiedType(builder->typeStreamView(), Constness::Mutable)})},
             .ns = "regexp_match_state",
             .doc = R"(
 Feeds a chunk of data into the token match state, continuing matching where it

--- a/hilti/toolchain/src/ast/operators/result.cc
+++ b/hilti/toolchain/src/ast/operators/result.cc
@@ -23,7 +23,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->dereferencedType();
     }
 

--- a/hilti/toolchain/src/ast/operators/set.cc
+++ b/hilti/toolchain/src/ast/operators/set.cc
@@ -27,7 +27,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->dereferencedType();
     }
 
@@ -47,7 +47,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -67,7 +67,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 

--- a/hilti/toolchain/src/ast/operators/signed-integer.cc
+++ b/hilti/toolchain/src/ast/operators/signed-integer.cc
@@ -8,7 +8,7 @@ using namespace hilti::operator_;
 namespace {
 namespace signed_integer {
 
-inline UnqualifiedTypePtr widestTypeSigned(Builder* builder, const Expressions& operands) {
+inline UnqualifiedType* widestTypeSigned(Builder* builder, const Expressions& operands) {
     unsigned int w1 = 0;
     unsigned int w2 = 0;
 
@@ -49,7 +49,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -70,7 +70,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -91,7 +91,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -112,7 +112,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -133,7 +133,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -155,7 +155,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -183,7 +183,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -211,7 +211,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -239,7 +239,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -387,7 +387,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -415,7 +415,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -443,7 +443,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -471,7 +471,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -499,7 +499,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeSigned(builder, operands), Constness::Const);
     }
 
@@ -527,7 +527,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -581,7 +581,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -605,7 +605,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -649,7 +649,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 

--- a/hilti/toolchain/src/ast/operators/stream.cc
+++ b/hilti/toolchain/src/ast/operators/stream.cc
@@ -522,8 +522,9 @@ public:
                     .type = {parameter::Kind::In, builder->typeBytes()},
                 },
             .result = {Constness::Const,
-                       builder->typeTuple({builder->qualifiedType(builder->typeBool(), Constness::Const),
-                                           builder->qualifiedType(builder->typeStreamIterator(), Constness::Mutable)})},
+                       builder->typeTuple(
+                           QualifiedTypes{builder->qualifiedType(builder->typeBool(), Constness::Const),
+                                          builder->qualifiedType(builder->typeStreamIterator(), Constness::Mutable)})},
             .ns = "stream::view",
             .doc = R"(
 Searches *needle* inside the view's content. Returns a tuple of a boolean and an

--- a/hilti/toolchain/src/ast/operators/tuple.cc
+++ b/hilti/toolchain/src/ast/operators/tuple.cc
@@ -71,7 +71,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         auto ctor = operands[1]->tryAs<expression::Ctor>();
         if ( ! ctor )
             return builder->qualifiedType(builder->typeUnknown(), Constness::Const);
@@ -118,7 +118,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         auto id = operands[1]->as<expression::Member>()->id();
         auto tt = operands[0]->type()->type()->tryAs<type::Tuple>();
         if ( ! tt )
@@ -164,7 +164,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 

--- a/hilti/toolchain/src/ast/operators/union.cc
+++ b/hilti/toolchain/src/ast/operators/union.cc
@@ -16,7 +16,7 @@ using namespace hilti::operator_;
 namespace {
 namespace union_ {
 
-QualifiedTypePtr itemType(Builder* builder, const Expressions& operands) {
+QualifiedType* itemType(Builder* builder, const Expressions& operands) {
     if ( auto field =
              operands[0]->type()->type()->as<type::Union>()->field(operands[1]->as<expression::Member>()->id()) )
         return field->type();
@@ -92,7 +92,7 @@ this triggers an exception.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return itemType(builder, operands);
     }
 
@@ -118,7 +118,7 @@ this triggers an exception unless the value is only being assigned to.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return itemType(builder, operands)->recreateAsLhs(builder->context());
     }
 

--- a/hilti/toolchain/src/ast/operators/unsigned-integer.cc
+++ b/hilti/toolchain/src/ast/operators/unsigned-integer.cc
@@ -8,7 +8,7 @@ using namespace hilti::operator_;
 namespace {
 namespace unsigned_integer {
 
-inline UnqualifiedTypePtr widestTypeUnsigned(Builder* builder, const Expressions& operands) {
+inline UnqualifiedType* widestTypeUnsigned(Builder* builder, const Expressions& operands) {
     unsigned int w1 = 0;
     unsigned int w2 = 0;
 
@@ -49,7 +49,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -70,7 +70,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -91,7 +91,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -112,7 +112,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -133,7 +133,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(builder->typeSignedInteger(
                                           operands[0]->type()->type()->as<type::UnsignedInteger>()->width()),
                                       Constness::Const);
@@ -157,7 +157,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -185,7 +185,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -213,7 +213,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -241,7 +241,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -389,7 +389,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -417,7 +417,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -445,7 +445,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -473,7 +473,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -501,7 +501,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -529,7 +529,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -579,7 +579,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -606,7 +606,7 @@ public:
         return {{op0, op1}};
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -627,7 +627,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -654,7 +654,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return builder->qualifiedType(widestTypeUnsigned(builder, operands), Constness::Const);
     }
 
@@ -682,7 +682,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -704,7 +704,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -727,7 +727,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -751,7 +751,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 
@@ -795,7 +795,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[1]->type()->type()->as<type::Type_>()->typeValue();
     }
 

--- a/hilti/toolchain/src/ast/operators/vector.cc
+++ b/hilti/toolchain/src/ast/operators/vector.cc
@@ -26,7 +26,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->dereferencedType();
     }
 
@@ -46,7 +46,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -66,7 +66,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -195,7 +195,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Vector>()->elementType()->recreateAsConst(builder->context());
     }
 
@@ -216,7 +216,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Vector>()->elementType()->recreateAsLhs(builder->context());
     }
 
@@ -237,7 +237,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -263,7 +263,7 @@ public:
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -367,7 +367,7 @@ empty.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Vector>()->elementType();
     }
 
@@ -391,7 +391,7 @@ empty.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Vector>()->elementType();
     }
 
@@ -471,7 +471,7 @@ Returns an iterator referring to the element at vector index *i*.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type()->type()->as<type::Vector>()->iteratorType();
     }
 
@@ -505,7 +505,7 @@ to (but not including) index *end*.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 
@@ -534,7 +534,7 @@ to (but not including) index *end*.
         };
     }
 
-    QualifiedTypePtr result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return operands[0]->type();
     }
 

--- a/hilti/toolchain/src/ast/scope-lookup.cc
+++ b/hilti/toolchain/src/ast/scope-lookup.cc
@@ -10,7 +10,7 @@
 
 using namespace hilti;
 
-std::pair<bool, Result<std::pair<DeclarationPtr, ID>>> hilti::scope::detail::lookupID(const ID& id, const Node* n) {
+std::pair<bool, Result<std::pair<Declaration*, ID>>> hilti::scope::detail::lookupID(const ID& id, const Node* n) {
     auto resolved = n->scope()->lookupAll(id);
 
     if ( resolved.empty() ) {

--- a/hilti/toolchain/src/ast/scope.cc
+++ b/hilti/toolchain/src/ast/scope.cc
@@ -17,8 +17,8 @@
 
 using namespace hilti;
 
-void Scope::insert(const ID& id, DeclarationPtr d) { _items[id].insert(std::move(d)); }
-void Scope::insert(const DeclarationPtr& d) { _items[d->id()].insert(d); }
+void Scope::insert(const ID& id, Declaration* d) { _items[id].insert(d); }
+void Scope::insert(Declaration* d) { _items[d->id()].insert(d); }
 
 void Scope::insertNotFound(const ID& id) { _items[std::string(id)] = {nullptr}; }
 
@@ -26,8 +26,8 @@ static auto createRefs(const std::vector<Scope::Referee>& refs, const std::strin
     std::vector<Scope::Referee> result;
 
     result.reserve(refs.size());
-    for ( auto r : refs ) {
-        result.push_back(Scope::Referee{.node = std::move(r.node),
+    for ( const auto& r : refs ) {
+        result.push_back(Scope::Referee{.node = r.node,
                                         .qualified = (ns + "::" + r.qualified),
                                         .external = (external || r.external)});
     }

--- a/hilti/toolchain/src/ast/type.cc
+++ b/hilti/toolchain/src/ast/type.cc
@@ -9,7 +9,7 @@
 using namespace hilti;
 using namespace hilti::detail;
 
-std::shared_ptr<declaration::Type> UnqualifiedType::typeDeclaration() const {
+declaration::Type* UnqualifiedType::typeDeclaration() const {
     if ( ! _declaration_index )
         return nullptr;
 
@@ -62,7 +62,7 @@ std::string UnqualifiedType::_dump() const {
     return util::join(x);
 }
 
-bool UnqualifiedType::unify(ASTContext* ctx, const NodePtr& scope_root) {
+bool UnqualifiedType::unify(ASTContext* ctx, Node* scope_root) {
     return type_unifier::unify(ctx, as<UnqualifiedType>());
 }
 
@@ -97,7 +97,7 @@ std::string QualifiedType::_dump() const {
     return util::join(x, " ");
 }
 
-UnqualifiedTypePtr type::follow(const UnqualifiedTypePtr& t) {
+UnqualifiedType* type::follow(UnqualifiedType* t) {
     if ( auto n = t->tryAs<type::Name>() ) {
         if ( auto r = n->resolvedType() )
             return r;
@@ -106,20 +106,19 @@ UnqualifiedTypePtr type::follow(const UnqualifiedTypePtr& t) {
     return t;
 }
 
-QualifiedTypePtr QualifiedType::createExternal(ASTContext* ctx, const UnqualifiedTypePtr& t, Constness const_,
-                                               const Meta& m) {
-    return std::shared_ptr<QualifiedType>(new QualifiedType(ctx, {}, t, const_, Side::RHS, m));
+QualifiedType* QualifiedType::createExternal(ASTContext* ctx, UnqualifiedType* t, Constness const_, const Meta& m) {
+    return ctx->make<QualifiedType>(ctx, {}, t, const_, Side::RHS, m);
 }
 
-QualifiedTypePtr QualifiedType::createAuto(ASTContext* ctx, const Meta& m) {
-    return QualifiedTypePtr(new QualifiedType(ctx, {type::Auto::create(ctx, m)}, Constness::Mutable, Side::RHS, m));
+QualifiedType* QualifiedType::createAuto(ASTContext* ctx, const Meta& m) {
+    return ctx->make<QualifiedType>(ctx, {type::Auto::create(ctx, m)}, Constness::Mutable, Side::RHS, m);
 }
 
-QualifiedTypePtr QualifiedType::createAuto(ASTContext* ctx, Side side, const Meta& m) {
-    return QualifiedTypePtr(new QualifiedType(ctx, {type::Auto::create(ctx, m)}, Constness::Mutable, side, m));
+QualifiedType* QualifiedType::createAuto(ASTContext* ctx, Side side, const Meta& m) {
+    return ctx->make<QualifiedType>(ctx, {type::Auto::create(ctx, m)}, Constness::Mutable, side, m);
 }
 
-UnqualifiedTypePtr QualifiedType::_type() const {
+UnqualifiedType* QualifiedType::_type() const {
     if ( _external )
         return _context->lookup(_external)->as<UnqualifiedType>();
     else

--- a/hilti/toolchain/src/ast/types/bitfield.cc
+++ b/hilti/toolchain/src/ast/types/bitfield.cc
@@ -9,7 +9,7 @@ using namespace hilti;
 
 type::bitfield::BitRange::~BitRange() = default;
 
-type::bitfield::BitRangePtr type::Bitfield::bits(const ID& id) const {
+type::bitfield::BitRange* type::Bitfield::bits(const ID& id) const {
     for ( const auto& b : bits(true) ) {
         if ( id == b->id() )
             return b;
@@ -31,7 +31,7 @@ std::optional<unsigned int> type::Bitfield::bitsIndex(const ID& id) const {
     return {};
 }
 
-CtorPtr type::Bitfield::ctorValue(ASTContext* ctx) {
+Ctor* type::Bitfield::ctorValue(ASTContext* ctx) {
     ctor::bitfield::BitRanges values;
 
     for ( const auto& b : bits() ) {

--- a/hilti/toolchain/src/ast/types/enum.cc
+++ b/hilti/toolchain/src/ast/types/enum.cc
@@ -29,7 +29,7 @@ void type::Enum::_setLabels(ASTContext* ctx, enum_::Labels labels) {
         l->setEnumType(ctx, enum_type);
 
         auto d = declaration::Constant::create(ctx, l->id(), expression::Ctor::create(ctx, ctor::Enum::create(ctx, l)));
-        addChild(ctx, std::move(d));
+        addChild(ctx, d);
     }
 
     auto undef_label = type::enum_::Label::create(ctx, ID("Undef"), -1, meta())->as<type::enum_::Label>();
@@ -39,7 +39,7 @@ void type::Enum::_setLabels(ASTContext* ctx, enum_::Labels labels) {
         declaration::Constant::create(ctx, undef_label->id(),
                                       expression::Ctor::create(ctx, ctor::Enum::create(ctx, undef_label)));
 
-    addChild(ctx, std::move(undef_decl));
+    addChild(ctx, undef_decl);
 }
 
 type::enum_::Labels type::Enum::labels() const {

--- a/hilti/toolchain/src/ast/types/integer.cc
+++ b/hilti/toolchain/src/ast/types/integer.cc
@@ -9,10 +9,10 @@
 using namespace hilti;
 using namespace hilti::type;
 
-std::shared_ptr<SignedInteger> type::SignedInteger::create(ASTContext* ctx, unsigned int width, const Meta& m) {
-    return std::shared_ptr<SignedInteger>(new SignedInteger(ctx, {}, width, m));
+SignedInteger* type::SignedInteger::create(ASTContext* ctx, unsigned int width, const Meta& m) {
+    return ctx->make<SignedInteger>(ctx, {}, width, m);
 }
 
-std::shared_ptr<UnsignedInteger> type::UnsignedInteger::create(ASTContext* ctx, unsigned int width, const Meta& m) {
-    return std::shared_ptr<UnsignedInteger>(new UnsignedInteger(ctx, {}, width, m));
+UnsignedInteger* type::UnsignedInteger::create(ASTContext* ctx, unsigned int width, const Meta& m) {
+    return ctx->make<UnsignedInteger>(ctx, {}, width, m);
 }

--- a/hilti/toolchain/src/ast/types/operand-list.cc
+++ b/hilti/toolchain/src/ast/types/operand-list.cc
@@ -10,9 +10,8 @@ using namespace hilti;
 using namespace hilti::type;
 
 
-QualifiedTypePtr operand_list::Operand::_makeOperandType(ASTContext* ctx, parameter::Kind kind,
-                                                         const UnqualifiedTypePtr& type) {
-    QualifiedTypePtr qtype;
+QualifiedType* operand_list::Operand::_makeOperandType(ASTContext* ctx, parameter::Kind kind, UnqualifiedType* type) {
+    QualifiedType* qtype = nullptr;
 
     switch ( kind ) {
         case parameter::Kind::In:

--- a/hilti/toolchain/src/ast/types/struct.cc
+++ b/hilti/toolchain/src/ast/types/struct.cc
@@ -30,5 +30,5 @@ void Struct::_setSelf(ASTContext* ctx) {
 
     auto decl = declaration::Expression::create(ctx, ID("self"), self, {}, meta());
 
-    setChild(ctx, 0, std::move(decl));
+    setChild(ctx, 0, decl);
 }

--- a/hilti/toolchain/src/ast/types/tuple.cc
+++ b/hilti/toolchain/src/ast/types/tuple.cc
@@ -10,7 +10,7 @@ using namespace hilti;
 
 type::tuple::Element::~Element() = default;
 
-std::optional<std::pair<int, std::shared_ptr<type::tuple::Element>>> type::Tuple::elementByID(const ID& id) const {
+std::optional<std::pair<int, type::tuple::Element*>> type::Tuple::elementByID(const ID& id) const {
     int i = 0;
     for ( const auto& e : elements() ) {
         if ( e->id() == id )

--- a/hilti/toolchain/src/ast/visitor.cc
+++ b/hilti/toolchain/src/ast/visitor.cc
@@ -8,7 +8,7 @@ using namespace hilti;
 visitor::MutatingVisitorBase::MutatingVisitorBase(ASTContext* ctx, logging::DebugStream dbg)
     : _context(ctx), _dbg(std::move(dbg)) {}
 
-void visitor::MutatingVisitorBase::replaceNode(const Node* old, const NodePtr& new_, const std::string& msg) {
+void visitor::MutatingVisitorBase::replaceNode(Node* old, Node* new_, const std::string& msg) {
     auto location = util::fmt("[%s] ", old->location().dump(true));
     std::string msg_;
 
@@ -29,7 +29,7 @@ void visitor::MutatingVisitorBase::replaceNode(const Node* old, const NodePtr& n
     _modified = true;
 }
 
-void visitor::MutatingVisitorBase::recordChange(const Node* old, const NodePtr& changed, const std::string& msg) {
+void visitor::MutatingVisitorBase::recordChange(const Node* old, Node* changed, const std::string& msg) {
     auto location = util::fmt("[%s] ", old->location().dump(true));
     std::string msg_;
 

--- a/hilti/toolchain/src/base/monotonic_buffer_resource.cc
+++ b/hilti/toolchain/src/base/monotonic_buffer_resource.cc
@@ -1,0 +1,53 @@
+// Copyright (c) 2020-2024 by the Zeek Project. See LICENSE for details.
+//
+// This code is copied and adapted from Broker, Zeek's communication framework.
+// The original version can be found at
+// https://github.com/zeek/broker/blob/master/libbroker/broker/detail/monotonic_buffer_resource.cc
+//
+// Functional changes:
+//     - Different from Broker, we *do* follow a geometric progression, just like the std version.
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+
+#include <hilti/base/monotonic_buffer_resource.h>
+
+using namespace hilti::detail;
+
+void* monotonic_buffer_resource::allocate(size_t num_bytes, size_t alignment) {
+    auto res = std::align(alignment, num_bytes, current_->bytes, remaining_);
+    if ( res == nullptr ) {
+        allocate_block(current_, num_bytes);
+        res = std::align(alignment, num_bytes, current_->bytes, remaining_);
+        if ( res == nullptr )
+            throw std::bad_alloc();
+    }
+    current_->bytes = static_cast<std::byte*>(res) + num_bytes;
+    remaining_ -= num_bytes;
+    return res;
+}
+
+void monotonic_buffer_resource::allocate_block(block* prev_block, size_t min_size) {
+    // [Spicy] Grow by 1.5x.
+    auto size = std::max(static_cast<size_t>(previous_size_ * 15 / 10), min_size + sizeof(block) + sizeof(max_align_t));
+    if ( auto vptr = malloc(size) ) {
+        current_ = static_cast<block*>(vptr);
+        current_->next = prev_block;
+        current_->bytes = static_cast<std::byte*>(vptr) + sizeof(block);
+        remaining_ = size - sizeof(block);
+        previous_size_ = size;
+    }
+    else {
+        throw std::bad_alloc();
+    }
+}
+
+void monotonic_buffer_resource::destroy() noexcept {
+    auto blk = current_;
+    while ( blk != nullptr ) {
+        auto prev = blk;
+        blk = blk->next;
+        free(prev);
+    }
+}

--- a/hilti/toolchain/src/compiler/ast-dumper.cc
+++ b/hilti/toolchain/src/compiler/ast-dumper.cc
@@ -10,7 +10,7 @@
 using namespace hilti;
 using util::fmt;
 
-static void dump(const NodePtr& n, std::ostream* out, std::optional<logging::DebugStream> dbg, bool include_scopes) {
+static void dump(Node* n, std::ostream* out, std::optional<logging::DebugStream> dbg, bool include_scopes) {
     util::timing::Collector _("hilti/dumper");
 
     auto nodes = visitor::range(visitor::PreOrder(), n, {});
@@ -56,10 +56,10 @@ static void dump(const NodePtr& n, std::ostream* out, std::optional<logging::Deb
         logger().debugSetIndent(*dbg, 0);
 }
 
-void detail::ast_dumper::dump(std::ostream& out, const NodePtr& node, bool include_scopes) {
+void detail::ast_dumper::dump(std::ostream& out, Node* node, bool include_scopes) {
     ::dump(node, &out, {}, include_scopes);
 }
 
-void detail::ast_dumper::dump(logging::DebugStream stream, const NodePtr& node, bool include_scopes) {
+void detail::ast_dumper::dump(logging::DebugStream stream, Node* node, bool include_scopes) {
     ::dump(node, nullptr, stream, include_scopes);
 }

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -269,7 +269,7 @@ struct Visitor : hilti::visitor::PreOrder {
 
 } // anonymous namespace
 
-cxx::Expression CodeGen::compile(const CtorPtr& c, bool lhs) {
+cxx::Expression CodeGen::compile(Ctor* c, bool lhs) {
     auto v = Visitor(this);
     if ( auto x = hilti::visitor::dispatch(v, c, [](const auto& v) { return v.result; }) )
         return lhs ? _makeLhs(*x, c->type()) : *x;

--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -14,7 +14,7 @@ using util::fmt;
 
 using namespace hilti::detail;
 
-inline auto traceStatement(CodeGen* cg, cxx::Block* b, const StatementPtr& s, bool skip_location = false) {
+inline auto traceStatement(CodeGen* cg, cxx::Block* b, Statement* s, bool skip_location = false) {
     if ( s->isA<statement::Block>() )
         return;
 
@@ -107,7 +107,7 @@ struct Visitor : hilti::visitor::PreOrder {
         }
 
         else
-            block->addBlock(cg->compile(n->as<statement::Block>()));
+            block->addBlock(cg->compile(n));
     }
 
     void operator()(statement::Break* n) final { block->addStatement("break"); }
@@ -226,7 +226,7 @@ struct Visitor : hilti::visitor::PreOrder {
         std::string cxx_type;
         std::string cxx_init;
 
-        const auto& cond = n->condition();
+        auto cond = n->condition();
         cxx_type = cg->compile(cond->type(), codegen::TypeUsage::Storage);
         cxx_id = cxx::ID(cond->id());
         cxx_init = cg->compile(cond->init());
@@ -243,7 +243,7 @@ struct Visitor : hilti::visitor::PreOrder {
             if ( exprs.size() == 1 )
                 cond = cg->compile(*exprs.begin());
             else
-                cond = util::join(node::transform(exprs, [&](auto& e) { return cg->compile(e); }), " || ");
+                cond = util::join(node::transform(exprs, [&](auto e) { return cg->compile(e); }), " || ");
 
             auto body = cg->compile(c->body());
 
@@ -304,7 +304,7 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     void operator()(statement::While* n) final {
-        std::shared_ptr<declaration::LocalVariable> init;
+        declaration::LocalVariable* init = nullptr;
         std::optional<cxx::Expression> cxx_init;
 
         if ( n->init() )
@@ -321,13 +321,13 @@ struct Visitor : hilti::visitor::PreOrder {
             // We generate different code if we have an "else" clause.
             cxx::Block inner_wrapper;
 
-            if ( ! n->condition() )
+            if ( init && ! n->condition() )
                 inner_wrapper.addStatement(fmt("%s = %s", init->id(), *cxx_init));
 
             auto else_ = cg->compile(n->else_());
             else_.addStatement("break");
 
-            if ( n->condition() )
+            if ( n->condition() || ! init )
                 inner_wrapper.addIf(fmt("! (%s)", cg->compile(n->condition())), else_);
             else
                 inner_wrapper.addIf(fmt("! %s", init->id()), else_);
@@ -392,7 +392,7 @@ struct Visitor : hilti::visitor::PreOrder {
 
 } // anonymous namespace
 
-cxx::Block CodeGen::compile(const StatementPtr& s, cxx::Block* b) {
+cxx::Block CodeGen::compile(Statement* s, cxx::Block* b) {
     if ( b ) {
         pushCxxBlock(b);
         traceStatement(this, b, s);

--- a/hilti/toolchain/src/compiler/constant-folder.cc
+++ b/hilti/toolchain/src/compiler/constant-folder.cc
@@ -22,17 +22,17 @@ using namespace hilti;
 namespace {
 
 // Internal version of _foldConstant() that passes exceptions through to caller.
-static Result<CtorPtr> foldConstant(Builder* builder, const ExpressionPtr& expr);
+static Result<Ctor*> foldConstant(Builder* builder, Expression* expr);
 
 template<typename Ctor>
-Result<Ctor> foldConstant(Builder* builder, const ExpressionPtr& expr) {
+Result<Ctor*> foldConstant(Builder* builder, Expression* expr) {
     auto ctor = foldConstant(builder, expr);
     if ( ! ctor )
         return ctor.error();
 
     assert(*ctor);
     if ( auto ctor_ = (*ctor)->tryAs<Ctor>() )
-        return *ctor_;
+        return ctor_;
     else
         return result::Error("unexpected type");
 }
@@ -44,12 +44,12 @@ struct VisitorConstantFolder : public visitor::PreOrder {
     VisitorConstantFolder(Builder* builder) : builder(builder) {}
 
     Builder* builder;
-    CtorPtr result = nullptr;
+    Ctor* result = nullptr;
 
     // Helper to replace an type constructor expression that receives a
     // constant argument with a corresponding ctor expression.
     template<typename Ctor, typename OperatorPtr, typename Fn>
-    CtorPtr tryReplaceCtorExpression(const OperatorPtr& op, Fn cb) {
+    hilti::Ctor* tryReplaceCtorExpression(const OperatorPtr& op, Fn cb) {
         if ( auto ctor = foldConstant<Ctor>(builder, callArgument(op, 0)) ) {
             auto x = cb(*ctor);
             x->setMeta(op->meta());
@@ -60,7 +60,7 @@ struct VisitorConstantFolder : public visitor::PreOrder {
     }
 
     // Helper to extract the 1st argument of a call expression.
-    ExpressionPtr callArgument(const expression::ResolvedOperator* o, int i) {
+    Expression* callArgument(const expression::ResolvedOperator* o, int i) {
         auto ctor = o->op1()->as<expression::Ctor>()->ctor();
 
         if ( auto x = ctor->tryAs<ctor::Coerced>() )
@@ -95,7 +95,7 @@ struct VisitorConstantFolder : public visitor::PreOrder {
 
     void operator()(operator_::signed_integer::SignNeg* n) final {
         if ( auto op = foldConstant<ctor::SignedInteger>(builder, n->op0()) )
-            result = builder->ctorSignedInteger(-op->value(), op->width(), n->meta());
+            result = builder->ctorSignedInteger(-(*op)->value(), (*op)->width(), n->meta());
     }
 
     void operator()(expression::Grouping* n) final {
@@ -107,19 +107,19 @@ struct VisitorConstantFolder : public visitor::PreOrder {
         auto op0 = foldConstant<ctor::Bool>(builder, n->op0());
         auto op1 = foldConstant<ctor::Bool>(builder, n->op1());
         if ( op0 && op1 )
-            result = builder->ctorBool(op0->value() || op1->value(), n->meta());
+            result = builder->ctorBool((*op0)->value() || (*op1)->value(), n->meta());
     }
 
     void operator()(expression::LogicalAnd* n) final {
         auto op0 = foldConstant<ctor::Bool>(builder, n->op0());
         auto op1 = foldConstant<ctor::Bool>(builder, n->op1());
         if ( op0 && op1 )
-            result = builder->ctorBool(op0->value() && op1->value(), n->meta());
+            result = builder->ctorBool((*op0)->value() && (*op1)->value(), n->meta());
     }
 
     void operator()(expression::LogicalNot* n) final {
         if ( auto op = foldConstant<ctor::Bool>(builder, n->expression()) )
-            result = builder->ctorBool(! op->value(), n->meta());
+            result = builder->ctorBool(! (*op)->value(), n->meta());
     }
 
     void operator()(expression::Name* n) final {
@@ -149,191 +149,190 @@ struct VisitorConstantFolder : public visitor::PreOrder {
     void operator()(operator_::unsigned_integer::SignNeg* n) final {
         auto op = foldConstant<ctor::UnsignedInteger>(builder, n->op0());
         if ( op )
-            result = builder->ctorSignedInteger(hilti::rt::integer::safe_negate(op->value()), op->width(), n->meta());
+            result =
+                builder->ctorSignedInteger(hilti::rt::integer::safe_negate((*op)->value()), (*op)->width(), n->meta());
     }
 
     void operator()(operator_::real::SignNeg* n) final {
         if ( auto op = foldConstant<ctor::Real>(builder, n->op0()) )
-            result = builder->ctorReal(-op->value(), n->meta());
+            result = builder->ctorReal(-(*op)->value(), n->meta());
     }
 
     void operator()(operator_::error::Ctor* n) final {
-        result = tryReplaceCtorExpression<ctor::Error>(n, [this](const auto& ctor) {
-            return builder->ctorError(ctor.value());
-        });
+        result =
+            tryReplaceCtorExpression<ctor::Error>(n, [this](auto* ctor) { return builder->ctorError(ctor->value()); });
     }
 
     void operator()(operator_::interval::CtorSignedIntegerSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorInterval(hilti::rt::Interval(ctor.value(), hilti::rt::Interval::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorInterval(hilti::rt::Interval(ctor->value(), hilti::rt::Interval::SecondTag()));
         });
     }
 
     void operator()(operator_::interval::CtorUnsignedIntegerSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorInterval(hilti::rt::Interval(ctor.value(), hilti::rt::Interval::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorInterval(hilti::rt::Interval(ctor->value(), hilti::rt::Interval::SecondTag()));
         });
     }
 
     void operator()(operator_::interval::CtorSignedIntegerNs* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorInterval(hilti::rt::Interval(ctor.value(), hilti::rt::Interval::NanosecondTag()));
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorInterval(hilti::rt::Interval(ctor->value(), hilti::rt::Interval::NanosecondTag()));
         });
     }
 
     void operator()(operator_::interval::CtorUnsignedIntegerNs* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorInterval(hilti::rt::Interval(ctor.value(), hilti::rt::Interval::NanosecondTag()));
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorInterval(hilti::rt::Interval(ctor->value(), hilti::rt::Interval::NanosecondTag()));
         });
     }
 
     void operator()(operator_::interval::CtorRealSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::Real>(n, [this](const auto& ctor) {
-            return builder->ctorInterval(hilti::rt::Interval(ctor.value(), hilti::rt::Interval::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::Real>(n, [this](auto* ctor) {
+            return builder->ctorInterval(hilti::rt::Interval(ctor->value(), hilti::rt::Interval::SecondTag()));
         });
     }
 
     void operator()(operator_::port::Ctor* n) final {
-        result = tryReplaceCtorExpression<ctor::Port>(n, [this](const auto& ctor) {
-            return builder->ctorPort(ctor.value());
-        });
+        result =
+            tryReplaceCtorExpression<ctor::Port>(n, [this](auto* ctor) { return builder->ctorPort(ctor->value()); });
     }
 
     void operator()(operator_::signed_integer::CtorSigned8* n) final {
         result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(ctor.value(), 8);
+            return builder->ctorSignedInteger(ctor->value(), 8);
         });
     }
 
     void operator()(operator_::signed_integer::CtorSigned16* n) final {
         result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(ctor.value(), 16);
+            return builder->ctorSignedInteger(ctor->value(), 16);
         });
     }
 
     void operator()(operator_::signed_integer::CtorSigned32* n) final {
         result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(ctor.value(), 32);
+            return builder->ctorSignedInteger(ctor->value(), 32);
         });
     }
 
     void operator()(operator_::signed_integer::CtorSigned64* n) final {
         result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(ctor.value(), 64);
+            return builder->ctorSignedInteger(ctor->value(), 64);
         });
     }
 
     void operator()(operator_::signed_integer::CtorUnsigned8* n) final {
         result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(to_int64(ctor.value()), 8);
+            return builder->ctorSignedInteger(to_int64(ctor->value()), 8);
         });
     }
 
     void operator()(operator_::signed_integer::CtorUnsigned16* n) final {
         result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(to_int64(ctor.value()), 16);
+            return builder->ctorSignedInteger(to_int64(ctor->value()), 16);
         });
     }
 
     void operator()(operator_::signed_integer::CtorUnsigned32* n) final {
         result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(to_int64(ctor.value()), 32);
+            return builder->ctorSignedInteger(to_int64(ctor->value()), 32);
         });
     }
 
     void operator()(operator_::signed_integer::CtorUnsigned64* n) final {
         result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorSignedInteger(to_int64(ctor.value()), 64);
+            return builder->ctorSignedInteger(to_int64(ctor->value()), 64);
         });
     }
 
     void operator()(operator_::time::CtorSignedIntegerSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorTime(hilti::rt::Time(ctor.value(), hilti::rt::Time::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorTime(hilti::rt::Time(ctor->value(), hilti::rt::Time::SecondTag()));
         });
     }
 
 
     void operator()(operator_::time::CtorUnsignedIntegerSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorTime(hilti::rt::Time(ctor.value(), hilti::rt::Time::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorTime(hilti::rt::Time(ctor->value(), hilti::rt::Time::SecondTag()));
         });
     }
 
     void operator()(operator_::stream::Ctor* n) final {
-        result = tryReplaceCtorExpression<ctor::Stream>(n, [this](const auto& ctor) {
-            return builder->ctorStream(ctor.value());
+        result = tryReplaceCtorExpression<ctor::Stream>(n, [this](auto* ctor) {
+            return builder->ctorStream(ctor->value());
         });
     }
 
     void operator()(operator_::time::CtorSignedIntegerNs* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorTime(hilti::rt::Time(ctor.value(), hilti::rt::Time::NanosecondTag()));
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorTime(hilti::rt::Time(ctor->value(), hilti::rt::Time::NanosecondTag()));
         });
     }
 
     void operator()(operator_::time::CtorUnsignedIntegerNs* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorTime(hilti::rt::Time(ctor.value(), hilti::rt::Time::NanosecondTag()));
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorTime(hilti::rt::Time(ctor->value(), hilti::rt::Time::NanosecondTag()));
         });
     }
 
     void operator()(operator_::time::CtorRealSecs* n) final {
-        result = tryReplaceCtorExpression<ctor::Real>(n, [this](const auto& ctor) {
-            return builder->ctorTime(hilti::rt::Time(ctor.value(), hilti::rt::Time::SecondTag()));
+        result = tryReplaceCtorExpression<ctor::Real>(n, [this](auto* ctor) {
+            return builder->ctorTime(hilti::rt::Time(ctor->value(), hilti::rt::Time::SecondTag()));
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorSigned8* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(to_uint64(ctor.value()), 8);
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(to_uint64(ctor->value()), 8);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorSigned16* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(to_uint64(ctor.value()), 16);
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(to_uint64(ctor->value()), 16);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorSigned32* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(to_uint64(ctor.value()), 32);
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(to_uint64(ctor->value()), 32);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorSigned64* n) final {
-        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(to_uint64(ctor.value()), 64);
+        result = tryReplaceCtorExpression<ctor::SignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(to_uint64(ctor->value()), 64);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorUnsigned8* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(ctor.value(), 8);
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(ctor->value(), 8);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorUnsigned16* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(ctor.value(), 16);
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(ctor->value(), 16);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorUnsigned32* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(ctor.value(), 32);
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(ctor->value(), 32);
         });
     }
 
     void operator()(operator_::unsigned_integer::CtorUnsigned64* n) final {
-        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](const auto& ctor) {
-            return builder->ctorUnsignedInteger(ctor.value(), 64);
+        result = tryReplaceCtorExpression<ctor::UnsignedInteger>(n, [this](auto* ctor) {
+            return builder->ctorUnsignedInteger(ctor->value(), 64);
         });
     }
 };
 
-Result<CtorPtr> foldConstant(Builder* builder, const ExpressionPtr& expr) {
+Result<Ctor*> foldConstant(Builder* builder, Expression* expr) {
     if ( auto result =
              hilti::visitor::dispatch(VisitorConstantFolder(builder), expr, [](const auto& v) { return v.result; }) )
         return result;
@@ -343,7 +342,7 @@ Result<CtorPtr> foldConstant(Builder* builder, const ExpressionPtr& expr) {
 
 } // anonymous namespace
 
-Result<CtorPtr> detail::constant_folder::fold(Builder* builder, const ExpressionPtr& expr) {
+Result<Ctor*> detail::constant_folder::fold(Builder* builder, Expression* expr) {
     // Don't fold away direct, top-level references to constant IDs. It's
     // likely as least as efficient to leave them as is, and potentially more.
     if ( expr->isA<expression::Name>() )

--- a/hilti/toolchain/src/compiler/parser/driver.cc
+++ b/hilti/toolchain/src/compiler/parser/driver.cc
@@ -15,13 +15,15 @@
 using namespace hilti;
 using namespace hilti::detail::parser;
 
-Result<ModulePtr> detail::parser::parseSource(Builder* builder, std::istream& in, const std::string& filename) {
+Result<declaration::Module*> detail::parser::parseSource(Builder* builder, std::istream& in,
+                                                         const std::string& filename) {
     util::timing::Collector _("hilti/compiler/ast/parser");
 
     return Driver().parse(builder, in, filename);
 }
 
-Result<ModulePtr> detail::parser::Driver::parse(Builder* builder, std::istream& in, const std::string& filename) {
+Result<declaration::Module*> detail::parser::Driver::parse(Builder* builder, std::istream& in,
+                                                           const std::string& filename) {
     _builder = builder;
 
     auto old_errors = logger().errors();
@@ -49,7 +51,7 @@ Result<ModulePtr> detail::parser::Driver::parse(Builder* builder, std::istream& 
     if ( logger().errors() > old_errors )
         return result::Error("parse error");
 
-    return {std::move(_module)};
+    return {_module};
 }
 
 void detail::parser::Driver::error(const std::string& msg, const Meta& m) { logger().error(msg, m.location()); }

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -49,7 +49,7 @@ static hilti::Meta toMeta(hilti::detail::parser::location l) {
                                        (l.end.column > 0 ? l.end.column - 1 : 0)));
 }
 
-static hilti::QualifiedTypePtr iteratorForType(hilti::Builder* builder, hilti::QualifiedTypePtr t, hilti::Meta m) {
+static hilti::QualifiedType* iteratorForType(hilti::Builder* builder, hilti::QualifiedType* t, hilti::Meta m) {
     if ( auto iter = t->type()->iteratorType() )
         return iter;
     else {
@@ -58,7 +58,7 @@ static hilti::QualifiedTypePtr iteratorForType(hilti::Builder* builder, hilti::Q
         }
 }
 
-static hilti::QualifiedTypePtr viewForType(hilti::Builder* builder, hilti::QualifiedTypePtr t, hilti::Meta m) {
+static hilti::QualifiedType* viewForType(hilti::Builder* builder, hilti::QualifiedType* t, hilti::Meta m) {
     if ( auto v = t->type()->viewType() )
         return v;
     else {
@@ -242,39 +242,39 @@ static int _field_width = 0;
 %token YIELD "yield"
 
 %type <hilti::ID>                               local_id scoped_id dotted_id function_id scoped_function_id
-%type <hilti::DeclarationPtr>                   local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl struct_field union_field
+%type <hilti::Declaration*>                   local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl struct_field union_field
 %type <hilti::Declarations>                     struct_fields union_fields opt_union_fields
-%type <hilti::UnqualifiedTypePtr>               base_type_no_attrs base_type type function_type tuple_type struct_type enum_type union_type func_param_type bitfield_type
-%type <hilti::QualifiedTypePtr>                 qtype
-%type <hilti::CtorPtr>                          ctor tuple struct_ list regexp map set
-%type <hilti::ExpressionPtr>                    expr tuple_elem tuple_expr member_expr ctor_expr expr_0 expr_1 expr_2 expr_3 expr_4 expr_5 expr_6 expr_7 expr_8 expr_9 expr_a expr_b expr_c expr_d expr_e expr_f expr_g opt_func_default_expr
+%type <hilti::UnqualifiedType*>               base_type_no_attrs base_type type function_type tuple_type struct_type enum_type union_type func_param_type bitfield_type
+%type <hilti::QualifiedType*>                 qtype
+%type <hilti::Ctor*>                          ctor tuple struct_ list regexp map set
+%type <hilti::Expression*>                    expr tuple_elem tuple_expr member_expr ctor_expr expr_0 expr_1 expr_2 expr_3 expr_4 expr_5 expr_6 expr_7 expr_8 expr_9 expr_a expr_b expr_c expr_d expr_e expr_f expr_g opt_func_default_expr
 %type <hilti::Expressions>                      opt_tuple_elems1 opt_tuple_elems2 exprs opt_exprs opt_type_arguments
-%type <hilti::FunctionPtr>                      function_with_body method_with_body hook_with_body function_without_body
-%type <hilti::type::function::ParameterPtr>     func_param
+%type <hilti::Function*>                      function_with_body method_with_body hook_with_body function_without_body
+%type <hilti::type::function::Parameter*>     func_param
 %type <hilti::parameter::Kind>                  opt_func_param_kind
 %type <hilti::type::function::Flavor>           func_flavor opt_func_flavor
 %type <hilti::function::CallingConvention>      opt_func_cc
 %type <hilti::declaration::Linkage>             opt_linkage
 %type <hilti::type::function::Parameters>       func_params opt_func_params opt_struct_params
-%type <hilti::StatementPtr>                     stmt stmt_decl stmt_expr block braced_block opt_else_block
+%type <hilti::Statement*>                     stmt stmt_decl stmt_expr block braced_block opt_else_block
 %type <hilti::Statements>                       stmts opt_stmts
-%type <hilti::AttributePtr>                     attribute
-%type <hilti::AttributeSetPtr>                  opt_attributes
-%type <hilti::type::tuple::ElementPtr>          tuple_type_elem
+%type <hilti::Attribute*>                     attribute
+%type <hilti::AttributeSet*>                  opt_attributes
+%type <hilti::type::tuple::Element*>          tuple_type_elem
 %type <hilti::type::tuple::Elements>            tuple_type_elems
 %type <hilti::ctor::struct_::Fields>            struct_elems
-%type <hilti::ctor::struct_::FieldPtr>          struct_elem
+%type <hilti::ctor::struct_::Field*>          struct_elem
 %type <hilti::ctor::map::Elements>              map_elems opt_map_elems
-%type <hilti::ctor::map::ElementPtr>            map_elem
-%type <hilti::type::enum_::LabelPtr>            enum_label
+%type <hilti::ctor::map::Element*>            map_elem
+%type <hilti::type::enum_::Label*>            enum_label
 %type <hilti::type::enum_::Labels>              enum_labels
 %type <hilti::type::bitfield::BitRanges>        bitfield_bit_ranges opt_bitfield_bit_ranges
-%type <hilti::type::bitfield::BitRangePtr>      bitfield_bit_range
+%type <hilti::type::bitfield::BitRange*>      bitfield_bit_range
 %type <std::vector<std::string>>                re_patterns
 %type <std::string>                             re_pattern_constant
-%type <hilti::statement::switch_::CasePtr>      switch_case
+%type <hilti::statement::switch_::Case*>      switch_case
 %type <hilti::statement::switch_::Cases>        switch_cases opt_switch_cases
-%type <hilti::statement::try_::CatchPtr>        try_catch
+%type <hilti::statement::try_::Catch*>        try_catch
 %type <hilti::statement::try_::Catches>         try_catches
 
 %type <std::pair<Declarations, Statements>>     global_scope_items

--- a/hilti/toolchain/src/compiler/plugin.cc
+++ b/hilti/toolchain/src/compiler/plugin.cc
@@ -64,14 +64,14 @@ Plugin hilti::detail::createHiltiPlugin() {
         .parse = [](Builder* builder, std::istream& in,
                     const hilti::rt::filesystem::path& path) { return parser::parseSource(builder, in, path); },
 
-        .coerce_ctor = [](Builder* builder, const CtorPtr& c, const QualifiedTypePtr& dst,
+        .coerce_ctor = [](Builder* builder, Ctor* c, QualifiedType* dst,
                           bitmask<CoercionStyle> style) { return coercer::detail::coerceCtor(builder, c, dst, style); },
 
-        .coerce_type = [](Builder* builder, const QualifiedTypePtr& t, const QualifiedTypePtr& dst,
+        .coerce_type = [](Builder* builder, QualifiedType* t, QualifiedType* dst,
                           bitmask<CoercionStyle> style) { return coercer::detail::coerceType(builder, t, dst, style); },
 
         .ast_init =
-            [](Builder* builder, const ASTRootPtr& root) {
+            [](Builder* builder, ASTRoot* root) {
                 util::timing::Collector _("hilti/compiler/ast/init");
 
                 if ( builder->options().import_standard_modules )
@@ -79,21 +79,21 @@ Plugin hilti::detail::createHiltiPlugin() {
             },
 
         .ast_build_scopes =
-            [](Builder* builder, const ASTRootPtr& root) {
+            [](Builder* builder, ASTRoot* root) {
                 scope_builder::build(builder, root);
                 return false;
             },
 
-        .ast_resolve = [](Builder* builder, const NodePtr& root) { return resolver::resolve(builder, root); },
+        .ast_resolve = [](Builder* builder, Node* root) { return resolver::resolve(builder, root); },
 
         .ast_validate_pre =
-            [](Builder* builder, const ASTRootPtr& m) {
+            [](Builder* builder, ASTRoot* m) {
                 validator::detail::validatePre(builder, m);
                 return false;
             },
 
         .ast_validate_post =
-            [](Builder* builder, const ASTRootPtr& root) {
+            [](Builder* builder, ASTRoot* root) {
                 validator::detail::validatePost(builder, root);
                 return false;
             },

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -133,7 +133,7 @@ struct Printer : visitor::PreOrder {
 
         _out.pushScope(n->scopeID());
 
-        auto print_decls = [&](const auto& decls) {
+        auto print_decls = [&](const node::Set<Declaration>& decls) {
             for ( const auto& d : decls )
                 _out << d;
 
@@ -448,7 +448,7 @@ struct Printer : visitor::PreOrder {
 
     void operator()(expression::BuiltInFunction* n) final {
         _out << n->name() << "("
-             << util::join(node::transform(n->arguments(), [](auto& p) { return fmt("%s", p); }), ", ") << ")";
+             << util::join(node::transform(n->arguments(), [](auto p) { return fmt("%s", p); }), ", ") << ")";
     }
 
     void operator()(expression::Coerced* n) final { _out << n->expression(); }
@@ -796,7 +796,7 @@ struct Printer : visitor::PreOrder {
 
         _out.setExpandSubsequentType(false);
 
-        auto x = util::transform(util::filter(n->labels(), [](const auto& l) { return l.get()->id() != ID("Undef"); }),
+        auto x = util::transform(util::filter(n->labels(), [](auto l) { return l->id() != ID("Undef"); }),
                                  [](const auto& l) { return l->print(); });
 
         _out << "enum { " << std::make_pair(std::move(x), ", ") << " }";
@@ -1082,7 +1082,7 @@ private:
 
 } // anonymous namespace
 
-void printer::print(std::ostream& out, const NodePtr& root, bool compact) {
+void printer::print(std::ostream& out, Node* root, bool compact) {
     if ( ! detail::State::current )
         detail::State::current = std::make_unique<detail::State>();
 
@@ -1113,7 +1113,7 @@ void printer::print(std::ostream& out, const NodePtr& root, bool compact) {
     }
 }
 
-void printer::print(printer::Stream& stream, const NodePtr& root) {
+void printer::print(printer::Stream& stream, Node* root) {
     util::timing::Collector _("hilti/printer");
 
     for ( auto& p : plugin::registry().plugins() ) {

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -135,7 +135,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     // Checks if a set of operator candidates contains only calls to hooks of the same type.
-    bool checkForHooks(Builder* builder, expression::UnresolvedOperator* u, const std::vector<Expression*>& matches) {
+    bool checkForHooks(Builder* builder, expression::UnresolvedOperator* u, const Expressions& matches) {
         if ( u->kind() != operator_::Kind::Call )
             return false;
 
@@ -405,9 +405,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // Matches an unresolved operator against a set of operator candidates,
     // returning instantiations of all matches.
-    std::vector<Expression*> matchOperators(expression::UnresolvedOperator* u,
-                                            const std::vector<const Operator*>& candidates,
-                                            bool disallow_type_changes = false) {
+    Expressions matchOperators(expression::UnresolvedOperator* u, const std::vector<const Operator*>& candidates,
+                               bool disallow_type_changes = false) {
         const std::array<bitmask<CoercionStyle>, 7> styles = {
             CoercionStyle::TryExactMatch,
             CoercionStyle::TryDeref,
@@ -471,7 +470,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             return resolved;
         };
 
-        auto try_all_candidates = [&](std::vector<Expression*>* resolved, std::set<operator_::Kind>* kinds_resolved,
+        auto try_all_candidates = [&](Expressions* resolved, std::set<operator_::Kind>* kinds_resolved,
                                       operator_::Priority priority) {
             for ( auto style : styles ) {
                 if ( disallow_type_changes )
@@ -526,7 +525,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         logging::DebugPushIndent _(logging::debug::Operator);
 
         std::set<operator_::Kind> kinds_resolved;
-        std::vector<Expression*> resolved;
+        Expressions resolved;
 
         try_all_candidates(&resolved, &kinds_resolved, operator_::Priority::Normal);
         if ( resolved.size() )

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -81,7 +81,7 @@ struct VisitorPass1 : visitor::MutatingPostOrder {
 
                     if ( replace ) {
                         auto rt = builder()->typeValueReference(qtype, Location("<on-heap-replacement>"));
-                        replaceNode(qtype.get(), builder()->qualifiedType(rt, Constness::Mutable, Side::LHS),
+                        replaceNode(qtype, builder()->qualifiedType(rt, Constness::Mutable, Side::LHS),
                                     "&on-heap replacement");
                     }
                 }
@@ -92,11 +92,11 @@ struct VisitorPass1 : visitor::MutatingPostOrder {
 
 // Pass 2 is the main pass implementing most of the resolver's functionality.
 struct VisitorPass2 : visitor::MutatingPostOrder {
-    explicit VisitorPass2(Builder* builder, const NodePtr& root)
+    explicit VisitorPass2(Builder* builder, Node* root)
         : visitor::MutatingPostOrder(builder, logging::debug::Resolver), root(root) {}
 
-    const NodePtr& root;
-    std::map<ID, QualifiedTypePtr> auto_params; // mapping of `auto` parameters inferred, indexed by canonical ID
+    Node* root = nullptr;
+    std::map<ID, QualifiedType*> auto_params; // mapping of `auto` parameters inferred, indexed by canonical ID
 
     // Sets a declaration fully qualified ID
     void setFqID(Declaration* d, ID id) {
@@ -107,7 +107,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // If an expression is a reference, dereference it; otherwise return the
     // expression itself.
-    ExpressionPtr skipReferenceValue(const ExpressionPtr& op) {
+    Expression* skipReferenceValue(Expression* op) {
         static auto value_reference_deref = operator_::get("value_reference::Deref");
         static auto strong_reference_deref = operator_::get("strong_reference::Deref");
         static auto weak_reference_deref = operator_::get("weak_reference::Deref");
@@ -127,7 +127,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // If a type is a reference type, dereference it; otherwise return the type
     // itself.
-    QualifiedTypePtr skipReferenceType(const QualifiedTypePtr& t) {
+    QualifiedType* skipReferenceType(QualifiedType* t) {
         if ( t && t->type()->isReferenceType() )
             return t->type()->dereferencedType();
         else
@@ -135,12 +135,12 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     // Checks if a set of operator candidates contains only calls to hooks of the same type.
-    bool checkForHooks(Builder* builder, expression::UnresolvedOperator* u, const std::vector<ExpressionPtr>& matches) {
+    bool checkForHooks(Builder* builder, expression::UnresolvedOperator* u, const std::vector<Expression*>& matches) {
         if ( u->kind() != operator_::Kind::Call )
             return false;
 
         ID hook_id;
-        type::FunctionPtr hook_type;
+        type::Function* hook_type = nullptr;
 
         for ( const auto& i : matches ) {
             auto ftype = i->as<expression::ResolvedOperator>()->op0()->type()->type()->tryAs<type::Function>();
@@ -181,9 +181,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     // constness of the individual expressions when comparing types, and always
     // returns a non-constant type as the one inferred. If old type is given,
     // returns null if inferred type is the same as the old one.
-    QualifiedTypePtr typeForExpressions(Node* n, node::Range<Expression> exprs,
-                                        const QualifiedTypePtr& old_type = nullptr) {
-        UnqualifiedTypePtr t;
+    QualifiedType* typeForExpressions(Node* n, node::Range<Expression> exprs, QualifiedType* old_type = nullptr) {
+        UnqualifiedType* t = nullptr;
 
         for ( const auto& e : exprs ) {
             if ( ! e->type()->isResolved() )
@@ -240,7 +239,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     // Returns a method call's i-th argument.
-    ExpressionPtr methodArgument(const expression::ResolvedOperator* o, size_t i) {
+    Expression* methodArgument(const expression::ResolvedOperator* o, size_t i) {
         auto ops = o->op2();
 
         // If the argument list was the result of a coercion unpack its result.
@@ -265,8 +264,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     // changed from the old one. Records an error with the node if coercion is
     // not possible, and returns null then. Will indicate no-change if
     // expression or type hasn't been resolved.
-    ExpressionPtr coerceTo(Node* n, const ExpressionPtr& e, const QualifiedTypePtr& t, bool contextual,
-                           bool assignment) {
+    Expression* coerceTo(Node* n, Expression* e, QualifiedType* t, bool contextual, bool assignment) {
         if ( ! (e->isResolved() && t->isResolved()) )
             return nullptr;
 
@@ -320,7 +318,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     // aren't fully resolved yet. Returns an error if a coercion failed with a
     // hard error.
     template<typename Container>
-    Result<std::optional<Expressions>> coerceExpressions(const Container& exprs, const QualifiedTypePtr& dst) {
+    Result<std::optional<Expressions>> coerceExpressions(const Container& exprs, QualifiedType* dst) {
         if ( ! (dst->isResolved() && expression::areResolved(exprs)) )
             return {std::nullopt};
 
@@ -347,8 +345,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // Coerces a specific call argument to a given type returning the coerced
     // expression (only) if its type has changed.
-    Result<ExpressionPtr> coerceMethodArgument(const expression::ResolvedOperator* o, size_t i,
-                                               const QualifiedTypePtr& t) {
+    Result<Expression*> coerceMethodArgument(const expression::ResolvedOperator* o, size_t i, QualifiedType* t) {
         auto ops = o->op2();
 
         // If the argument list was the result of a coercion unpack its result.
@@ -378,7 +375,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // Records the actual type of an `auto` parameter as inferred from a
     // concrete argument value passed to it.
-    void recordAutoParameters(const type::Function& ftype, const ExpressionPtr& args) {
+    void recordAutoParameters(const type::Function& ftype, Expression* args) {
         auto arg = args->as<expression::Ctor>()->ctor()->as<ctor::Tuple>()->value().begin();
         std::vector<type::function::Parameter> params;
         for ( auto& rp : ftype.parameters() ) {
@@ -408,9 +405,9 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     // Matches an unresolved operator against a set of operator candidates,
     // returning instantiations of all matches.
-    std::vector<ExpressionPtr> matchOperators(expression::UnresolvedOperator* u,
-                                              const std::vector<const Operator*>& candidates,
-                                              bool disallow_type_changes = false) {
+    std::vector<Expression*> matchOperators(expression::UnresolvedOperator* u,
+                                            const std::vector<const Operator*>& candidates,
+                                            bool disallow_type_changes = false) {
         const std::array<bitmask<CoercionStyle>, 7> styles = {
             CoercionStyle::TryExactMatch,
             CoercionStyle::TryDeref,
@@ -438,7 +435,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         };
 
         auto try_candidate = [&](const Operator* candidate, const node::Range<Expression>& operands, auto style,
-                                 const Meta& meta, const auto& dbg_msg) -> ExpressionPtr {
+                                 const Meta& meta, const auto& dbg_msg) -> Expression* {
             auto noperands = coerce_operands(candidate, operands, candidate->operands(), style);
             if ( ! noperands ) {
                 HILTI_DEBUG(logging::debug::Operator, util::fmt("-> cannot coerce operands: %s", noperands.error()));
@@ -460,7 +457,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             if ( (*r)->type()->isAuto() )
                 return {};
 
-            ExpressionPtr resolved = *r;
+            Expression* resolved = *r;
 
             // Fold any constants right here in case downstream resolving depends
             // on finding a constant (like for coercion).
@@ -474,7 +471,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             return resolved;
         };
 
-        auto try_all_candidates = [&](std::vector<ExpressionPtr>* resolved, std::set<operator_::Kind>* kinds_resolved,
+        auto try_all_candidates = [&](std::vector<Expression*>* resolved, std::set<operator_::Kind>* kinds_resolved,
                                       operator_::Priority priority) {
             for ( auto style : styles ) {
                 if ( disallow_type_changes )
@@ -499,7 +496,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                         if ( c->signature().priority == operator_::Priority::Normal )
                             kinds_resolved->insert(c->kind());
 
-                        resolved->push_back(std::move(r));
+                        resolved->push_back(r);
                     }
                     else {
                         auto operands = u->operands();
@@ -513,7 +510,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                                 if ( c->signature().priority == operator_::Priority::Normal )
                                     kinds_resolved->insert(c->kind());
 
-                                resolved->emplace_back(std::move(r));
+                                resolved->emplace_back(r);
                             }
                         }
                     }
@@ -529,7 +526,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         logging::DebugPushIndent _(logging::debug::Operator);
 
         std::set<operator_::Kind> kinds_resolved;
-        std::vector<ExpressionPtr> resolved;
+        std::vector<Expression*> resolved;
 
         try_all_candidates(&resolved, &kinds_resolved, operator_::Priority::Normal);
         if ( resolved.size() )
@@ -580,7 +577,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             // even though the list's type on its own isn't known, then
             // transfer the container's element type over.
             if ( auto parent = n->parent()->tryAs<ctor::Coerced>(); parent && parent->type()->isResolved() ) {
-                QualifiedTypePtr etype;
+                QualifiedType* etype = nullptr;
 
                 if ( auto l = parent->type()->type()->tryAs<type::List>() )
                     etype = l->elementType();
@@ -609,8 +606,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         }
 
         if ( ! n->type()->isResolved() ) {
-            QualifiedTypePtr key;
-            QualifiedTypePtr value;
+            QualifiedType* key = nullptr;
+            QualifiedType* value = nullptr;
 
             for ( const auto& e : n->value() ) {
                 if ( ! key )
@@ -816,7 +813,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         if ( auto a = n->attributes()->find("&default") ) {
             auto val = a->valueAsExpression();
             if ( auto x = coerceTo(n, *val, n->type(), false, true) ) {
-                recordChange(val->get(), x, "attribute");
+                recordChange(*val, x, "attribute");
                 n->attributes()->remove("&default");
                 n->attributes()->add(context(), builder()->attribute("&default", x));
             }
@@ -828,7 +825,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 // We register operators here so that we have the type ID for
                 // the struct available.
                 recordChange(n, "creating member call operator");
-                std::unique_ptr<struct_::MemberCall> op(new struct_::MemberCall(n->as<declaration::Field>()));
+                std::unique_ptr<struct_::MemberCall> op(new struct_::MemberCall(n));
                 n->setOperator(op.get());
                 operator_::registry().register_(std::move(op));
             }
@@ -847,8 +844,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
         if ( auto ns = n->id().namespace_() ) {
             // Link namespaced function to its base type and/or prototype.
-            std::shared_ptr<declaration::Type> linked_type;
-            std::shared_ptr<Declaration> linked_prototype;
+            declaration::Type* linked_type = nullptr;
+            Declaration* linked_prototype = nullptr;
 
             if ( auto resolved = scope::lookupID<declaration::Type>(ns, n, "struct type") ) {
                 linked_type = resolved->first;
@@ -913,7 +910,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
         if ( n->linkage() != declaration::Linkage::Struct && ! n->operator_() && n->function()->type()->isResolved() ) {
             recordChange(n, "creating function call operator");
-            std::unique_ptr<function::Call> op(new function::Call(n->as<declaration::Function>()));
+            std::unique_ptr<function::Call> op(new function::Call(n));
             n->setOperator(op.get());
             operator_::registry().register_(std::move(op));
         }
@@ -925,7 +922,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 setFqID(n, m->scopeID() + n->id()); // global scope
         }
 
-        ExpressionPtr init;
+        Expression* init = nullptr;
         std::optional<Expressions> args;
 
         if ( auto e = n->init(); e && ! type::sameExceptForConstness(n->type(), e->type()) ) {
@@ -990,12 +987,12 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         if ( ! n->fullyQualifiedID() )
             setFqID(n, n->id()); // local scope
 
-        ExpressionPtr init;
+        Expression* init = nullptr;
         std::optional<Expressions> args;
 
         if ( auto e = n->init() ) {
             if ( auto x = coerceTo(n, e, n->type(), false, true) )
-                init = std::move(x);
+                init = x;
         }
 
         if ( (! n->type()->type()->parameters().empty()) && n->typeArguments().size() ) {
@@ -1033,11 +1030,11 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             recordChange(n, util::fmt("set module's canonical ID to %s", n->canonicalID()));
         }
 
-        if ( auto p = n->moduleProperty("%skip-implementation") )
+        if ( n->moduleProperty("%skip-implementation") )
             n->setSkipImplementation(true);
 
         if ( ! n->declarationIndex() ) {
-            auto index = context()->register_(n->as<declaration::Module>());
+            auto index = context()->register_(n);
             recordChange(n, util::fmt("set module's declaration index to %s", index));
         }
     }
@@ -1072,8 +1069,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         }
 
         if ( ! n->declarationIndex() ) {
-            auto index = context()->register_(n->as<declaration::Type>());
-            recordChange(n->type()->type().get(), util::fmt("set type's declaration to %s", index));
+            auto index = context()->register_(n);
+            recordChange(n->type()->type(), util::fmt("set type's declaration to %s", index));
         }
 
         if ( auto x = n->type()->type()->tryAs<type::Library>(); x && ! n->attributes()->has("&cxxname") )
@@ -1083,7 +1080,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     void operator()(Expression* n) final {
         if ( n->isResolved() && ! n->isA<expression::Ctor>() ) {
-            auto ctor = detail::constant_folder::fold(builder(), n->as<Expression>());
+            auto ctor = detail::constant_folder::fold(builder(), n);
             if ( ! ctor ) {
                 n->addError(ctor.error());
                 return;
@@ -1107,18 +1104,17 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             auto key = index_non_const->op1();
             if ( key->type() != key_type ) {
                 if ( auto nexpr = hilti::coerceExpression(builder(), key, key_type).nexpr )
-                    key = std::move(nexpr);
+                    key = nexpr;
             }
 
             auto value = n->source();
             if ( value->type() != value_type ) {
                 if ( auto nexpr = hilti::coerceExpression(builder(), value, value_type).nexpr )
-                    value = std::move(nexpr);
+                    value = nexpr;
             }
 
-            auto index_assign =
-                builder()->expressionUnresolvedOperator(hilti::operator_::Kind::IndexAssign,
-                                                        {map, std::move(key), std::move(value)}, n->meta());
+            auto index_assign = builder()->expressionUnresolvedOperator(hilti::operator_::Kind::IndexAssign,
+                                                                        {map, key, value}, n->meta());
 
             replaceNode(n, index_assign);
         }
@@ -1179,7 +1175,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             }
 
             const auto& et = container->type()->elementType();
-            recordChange(n->local().get(), et);
+            recordChange(n->local(), et);
             n->local()->setType(context(), et);
         }
     }
@@ -1187,31 +1183,31 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     void operator()(expression::LogicalAnd* n) final {
         if ( auto x = coerceTo(n, n->op0(), n->type(), true, false) ) {
             recordChange(n, x, "op0");
-            n->setOp0(context(), std::move(x));
+            n->setOp0(context(), x);
         }
 
         if ( auto x = coerceTo(n, n->op1(), n->type(), true, false) ) {
             recordChange(n, x, "op1");
-            n->setOp1(context(), std::move(x));
+            n->setOp1(context(), x);
         }
     }
 
     void operator()(expression::LogicalNot* n) final {
         if ( auto x = coerceTo(n, n->expression(), n->type(), true, false) ) {
             recordChange(n, x, "expression");
-            n->setExpression(context(), std::move(x));
+            n->setExpression(context(), x);
         }
     }
 
     void operator()(expression::LogicalOr* n) final {
         if ( auto x = coerceTo(n, n->op0(), n->type(), true, false) ) {
             recordChange(n, x, "op0");
-            n->setOp0(context(), std::move(x));
+            n->setOp0(context(), x);
         }
 
         if ( auto x = coerceTo(n, n->op1(), n->type(), true, false) ) {
             recordChange(n, x, "op1");
-            n->setOp1(context(), std::move(x));
+            n->setOp1(context(), x);
         }
     }
 
@@ -1352,7 +1348,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         if ( n->ftype()->result()->isAuto() ) {
             // Look for a `return` to infer the return type.
             auto v = visitor::PreOrder();
-            for ( const auto i : visitor::range(v, n->as<Function>(), {}) ) {
+            for ( const auto i : visitor::range(v, n, {}) ) {
                 if ( auto x = i->tryAs<statement::Return>(); x && x->expression() && x->expression()->isResolved() ) {
                     const auto& rt = x->expression()->type();
                     recordChange(n, rt, "auto return");
@@ -1448,10 +1444,10 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
                         if ( auto x = coerceTo(n, rhs_elem, lhs_elem_type, false, true) ) {
                             changed = true;
-                            new_elems.push_back(std::move(x));
+                            new_elems.push_back(x);
                         }
                         else
-                            new_elems.emplace_back(std::move(rhs_elem));
+                            new_elems.emplace_back(rhs_elem);
                     }
 
                     if ( changed ) {
@@ -1469,11 +1465,9 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             // Need to coerce the element here as the normal overload resolution
             // couldn't know the element type yet.
             auto etype = n->op0()->type()->type()->as<type::Vector>()->elementType();
-            auto elem = methodArgument(n, 0);
-
-            if ( auto x = coerceTo(n, n->op2(),
-                                   builder()->qualifiedType(builder()->typeTuple({std::move(etype)}), Constness::Const),
-                                   false, true) ) {
+            if ( auto x =
+                     coerceTo(n, n->op2(), builder()->qualifiedType(builder()->typeTuple({etype}), Constness::Const),
+                              false, true) ) {
                 recordChange(n, x, "element type");
                 n->setOp2(context(), x);
             }
@@ -1501,7 +1495,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
         if ( n->init() && ! n->condition() ) {
             auto cond = builder()->expressionName(n->init()->id());
-            n->setCondition(context(), std::move(cond));
+            n->setCondition(context(), cond);
             recordChange(n, cond);
         }
     }
@@ -1594,7 +1588,7 @@ struct VisitorPass3 : visitor::MutatingPostOrder {
             if ( auto d = n->parent<declaration::Function>(); d && d->linkedPrototypeIndex() ) {
                 auto prototype = builder()->context()->lookup(d->linkedPrototypeIndex());
 
-                std::shared_ptr<type::Function> ftype;
+                type::Function* ftype = nullptr;
                 if ( auto f = prototype->tryAs<declaration::Function>() )
                     ftype = f->function()->ftype();
 
@@ -1619,7 +1613,7 @@ struct VisitorPass3 : visitor::MutatingPostOrder {
 
 } // anonymous namespace
 
-bool detail::resolver::resolve(Builder* builder, const NodePtr& root) {
+bool detail::resolver::resolve(Builder* builder, Node* root) {
     util::timing::Collector _("hilti/compiler/ast/resolver");
 
     auto v1 = VisitorPass1(builder);

--- a/hilti/toolchain/src/compiler/type-unifier.cc
+++ b/hilti/toolchain/src/compiler/type-unifier.cc
@@ -82,7 +82,7 @@ public:
             unifier->add(to_string(op->kind()));
             unifier->add(op->id());
             unifier->add(":");
-            unifier->add(op->type()->type().get());
+            unifier->add(op->type()->type());
             unifier->add(",");
         }
         unifier->add(")");
@@ -207,7 +207,7 @@ void type_unifier::Unifier::add(UnqualifiedType* t) {
         return;
 
     if ( auto name = t->tryAs<type::Name>() ) {
-        t = name->resolvedType().get();
+        t = name->resolvedType();
         if ( ! t ) {
             abort();
             return;
@@ -239,20 +239,20 @@ void type_unifier::Unifier::add(UnqualifiedType* t) {
     }
 }
 
-void type_unifier::Unifier::add(const QualifiedTypePtr& t) {
+void type_unifier::Unifier::add(QualifiedType* t) {
     if ( _abort )
         return;
 
     if ( t->type()->unification() )
         add(t->type()->unification());
     else
-        add(t->type().get());
+        add(t->type());
 }
 
 void type_unifier::Unifier::add(const std::string& s) { _serial += s; }
 
 // Public entry function going through all plugins.
-bool type_unifier::unify(Builder* builder, const ASTRootPtr& root) {
+bool type_unifier::unify(Builder* builder, ASTRoot* root) {
     util::timing::Collector _("hilti/compiler/ast/type-unifier");
 
     return hilti::visitor::visit(VisitorTypeUnifier(builder->context()), root, {},
@@ -260,7 +260,7 @@ bool type_unifier::unify(Builder* builder, const ASTRootPtr& root) {
 }
 
 // Public entry function going through all plugins.
-bool type_unifier::unify(ASTContext* ctx, const UnqualifiedTypePtr& type) {
+bool type_unifier::unify(ASTContext* ctx, UnqualifiedType* type) {
     util::timing::Collector _("hilti/compiler/ast/type-unifier");
 
     if ( ! type->unification() )

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -44,7 +44,7 @@ std::shared_ptr<Unit> Unit::fromExistingUID(const std::shared_ptr<Context>& cont
 
 Unit::~Unit() {}
 
-ModulePtr Unit::module() const { return context()->astContext()->module(_uid); }
+declaration::Module* Unit::module() const { return context()->astContext()->module(_uid); }
 
 bool Unit::isCompiledHILTI() const {
     if ( ! _uid.id )
@@ -55,7 +55,7 @@ bool Unit::isCompiledHILTI() const {
 }
 
 Result<Nothing> Unit::print(std::ostream& out) const {
-    if ( auto m = module() )
+    if ( module() )
         printer::print(out, module());
 
     return Nothing();

--- a/hilti/toolchain/tests/visitor.cc
+++ b/hilti/toolchain/tests/visitor.cc
@@ -82,7 +82,7 @@ TEST_CASE("Visitor, pre-order") {
         void operator()(hilti::ctor::Bool* b) final { x += "(c:b)"; }
         void operator()(hilti::statement::Block* n) final { x += "(s:b)"; }
 
-        void testDispatch(const hilti::NodePtr& i) {
+        void testDispatch(hilti::Node* i) {
             auto old = x.size();
             dispatch(i);
             if ( x.size() == old )
@@ -116,7 +116,7 @@ TEST_CASE("Visitor, pre-order") {
         void operator()(hilti::ctor::Bool* b) final { x += "(c:b)"; }
         void operator()(hilti::statement::Block* n) final { x += "(s:b)"; }
 
-        void testDispatch(const hilti::NodePtr& i) {
+        void testDispatch(hilti::Node* i) {
             auto old = x.size();
             dispatch(i);
             if ( x.size() == old )
@@ -173,7 +173,7 @@ TEST_CASE("Copy node by value on insert") {
     auto ctx = std::make_unique<hilti::ASTContext>(nullptr);
     auto builder = hilti::Builder(ctx.get());
 
-    std::shared_ptr<hilti::Declaration> d =
+    hilti::Declaration* d =
         builder.declarationType(hilti::ID("x"), builder.qualifiedType(builder.typeString(), hilti::Constness::Mutable));
     auto uid = hilti::declaration::module::UID("m", "/tmp/m.hlt");
     auto m = builder.declarationModule(uid, {}, {d});

--- a/spicy/toolchain/bin/spicy-doc.cc
+++ b/spicy/toolchain/bin/spicy-doc.cc
@@ -12,7 +12,7 @@
 
 using nlohmann::json;
 
-static std::string formatType(const hilti::UnqualifiedTypePtr& t) {
+static std::string formatType(const hilti::UnqualifiedType* t) {
     if ( auto d = t->tryAs<hilti::type::DocOnly>() )
         return d->description();
 

--- a/spicy/toolchain/include/ast/builder/builder.h
+++ b/spicy/toolchain/include/ast/builder/builder.h
@@ -22,8 +22,8 @@ public:
     BuilderBase(ASTContext* ctx) : hilti::Builder(ctx), spicy::builder::NodeFactory(ctx) {}
     BuilderBase(hilti::Builder* builder) : hilti::Builder(builder), builder::NodeFactory(builder->context()) {}
 
-    BuilderBase(ASTContext* context, std::shared_ptr<hilti::statement::Block> block)
-        : hilti::Builder(context, std::move(block)), spicy::builder::NodeFactory(context) {}
+    BuilderBase(ASTContext* context, hilti::statement::Block* block)
+        : hilti::Builder(context, block), spicy::builder::NodeFactory(context) {}
 
     using hilti::Builder::context;
 };
@@ -40,7 +40,7 @@ namespace builder {
  * @param expr the expression to parse
  * @param meta meta information to attach to the resulting expression
  */
-hilti::Result<hilti::ExpressionPtr> parseExpression(Builder* builder, const std::string& expr, const hilti::Meta& meta);
+hilti::Result<hilti::Expression*> parseExpression(Builder* builder, const std::string& expr, const hilti::Meta& meta);
 
 } // namespace builder
 } // namespace spicy

--- a/spicy/toolchain/include/ast/builder/node-factory.h
+++ b/spicy/toolchain/include/ast/builder/node-factory.h
@@ -25,17 +25,17 @@ public:
     /** Returns the AST context in use for creating nodes. */
     ASTContext* context() const { return _context; }
 
-    auto ctorUnit(ctor::unit::Fields fields, QualifiedTypePtr t, const Meta& meta = {}) {
-        return spicy::ctor::Unit::create(context(), std::move(fields), std::move(t), meta);
+    auto ctorUnit(ctor::unit::Fields fields, QualifiedType* t, Meta meta = {}) {
+        return spicy::ctor::Unit::create(context(), std::move(fields), t, std::move(meta));
     }
-    auto ctorUnit(ctor::unit::Fields fields, const Meta& meta = {}) {
-        return spicy::ctor::Unit::create(context(), std::move(fields), meta);
+    auto ctorUnit(ctor::unit::Fields fields, Meta meta = {}) {
+        return spicy::ctor::Unit::create(context(), std::move(fields), std::move(meta));
     }
-    auto declarationHook(const hilti::declaration::Parameters& parameters, const StatementPtr& body, Engine engine,
-                         AttributeSetPtr attrs, const Meta& m = Meta()) {
-        return spicy::declaration::Hook::create(context(), parameters, body, engine, std::move(attrs), m);
+    auto declarationHook(const hilti::declaration::Parameters& parameters, Statement* body, Engine engine,
+                         AttributeSet* attrs, const Meta& m = Meta()) {
+        return spicy::declaration::Hook::create(context(), parameters, body, engine, attrs, m);
     }
-    auto declarationUnitHook(const ID& id, const declaration::HookPtr& hook, Meta meta = {}) {
+    auto declarationUnitHook(const ID& id, declaration::Hook* hook, Meta meta = {}) {
         return spicy::declaration::UnitHook::create(context(), id, hook, std::move(meta));
     }
     auto statementConfirm(Meta meta = {}) { return spicy::statement::Confirm::create(context(), std::move(meta)); }
@@ -44,100 +44,90 @@ public:
     }
     auto statementReject(Meta meta = {}) { return spicy::statement::Reject::create(context(), std::move(meta)); }
     auto statementStop(Meta meta = {}) { return spicy::statement::Stop::create(context(), std::move(meta)); }
-    auto typeSink(const Meta& meta = {}) { return spicy::type::Sink::create(context(), meta); }
-    auto typeUnit(const hilti::declaration::Parameters& params, type::unit::Items items, AttributeSetPtr attrs,
-                  const Meta& meta = {}) {
-        return spicy::type::Unit::create(context(), params, std::move(items), std::move(attrs), meta);
+    auto typeSink(Meta meta = {}) { return spicy::type::Sink::create(context(), std::move(meta)); }
+    auto typeUnit(const hilti::declaration::Parameters& params, type::unit::Items items, AttributeSet* attrs,
+                  Meta meta = {}) {
+        return spicy::type::Unit::create(context(), params, std::move(items), attrs, std::move(meta));
     }
-    auto typeUnit(hilti::type::Wildcard _, const Meta& meta = {}) {
-        return spicy::type::Unit::create(context(), _, meta);
+    auto typeUnit(hilti::type::Wildcard _, Meta meta = {}) {
+        return spicy::type::Unit::create(context(), _, std::move(meta));
     }
-    auto typeUnitItemField(const ID& id, CtorPtr ctor, Engine engine, bool skip, Expressions args, ExpressionPtr repeat,
-                           Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                           spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::Field::create(context(), id, std::move(ctor), engine, skip, std::move(args),
-                                                      std::move(repeat), std::move(sinks), std::move(attrs),
-                                                      std::move(cond), std::move(hooks), meta);
+    auto typeUnitItemField(const ID& id, Ctor* ctor, Engine engine, bool skip, Expressions args, Expression* repeat,
+                           Expressions sinks, AttributeSet* attrs, Expression* cond, spicy::declaration::Hooks hooks,
+                           Meta meta = {}) {
+        return spicy::type::unit::item::Field::create(context(), id, ctor, engine, skip, std::move(args), repeat,
+                                                      std::move(sinks), attrs, cond, std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemField(const ID& id, const QualifiedTypePtr& type, Engine engine, bool skip, Expressions args,
-                           ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                           spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::Field::create(context(), id, type, engine, skip, std::move(args),
-                                                      std::move(repeat), std::move(sinks), std::move(attrs),
-                                                      std::move(cond), std::move(hooks), meta);
+    auto typeUnitItemField(const ID& id, QualifiedType* type, Engine engine, bool skip, Expressions args,
+                           Expression* repeat, Expressions sinks, AttributeSet* attrs, Expression* cond,
+                           spicy::declaration::Hooks hooks, Meta meta = {}) {
+        return spicy::type::unit::item::Field::create(context(), id, type, engine, skip, std::move(args), repeat,
+                                                      std::move(sinks), attrs, cond, std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemField(const ID& id, type::unit::ItemPtr item, Engine engine, bool skip, Expressions args,
-                           ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                           spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::Field::create(context(), id, std::move(item), engine, skip, std::move(args),
-                                                      std::move(repeat), std::move(sinks), std::move(attrs),
-                                                      std::move(cond), std::move(hooks), meta);
+    auto typeUnitItemField(const ID& id, type::unit::Item* item, Engine engine, bool skip, Expressions args,
+                           Expression* repeat, Expressions sinks, AttributeSet* attrs, Expression* cond,
+                           spicy::declaration::Hooks hooks, Meta meta = {}) {
+        return spicy::type::unit::item::Field::create(context(), id, item, engine, skip, std::move(args), repeat,
+                                                      std::move(sinks), attrs, cond, std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemProperty(ID id, AttributeSetPtr attrs, bool inherited = false, const Meta& meta = {}) {
-        return spicy::type::unit::item::Property::create(context(), std::move(id), std::move(attrs), inherited, meta);
+    auto typeUnitItemProperty(ID id, AttributeSet* attrs, bool inherited = false, Meta meta = {}) {
+        return spicy::type::unit::item::Property::create(context(), std::move(id), attrs, inherited, std::move(meta));
     }
-    auto typeUnitItemProperty(ID id, ExpressionPtr expr, AttributeSetPtr attrs, bool inherited = false,
-                              const Meta& meta = {}) {
-        return spicy::type::unit::item::Property::create(context(), std::move(id), std::move(expr), std::move(attrs),
-                                                         inherited, meta);
+    auto typeUnitItemProperty(ID id, Expression* expr, AttributeSet* attrs, bool inherited = false, Meta meta = {}) {
+        return spicy::type::unit::item::Property::create(context(), std::move(id), expr, attrs, inherited,
+                                                         std::move(meta));
     }
-    auto typeUnitItemSink(ID id, AttributeSetPtr attrs, const Meta& meta = {}) {
-        return spicy::type::unit::item::Sink::create(context(), std::move(id), std::move(attrs), meta);
+    auto typeUnitItemSink(ID id, AttributeSet* attrs, Meta meta = {}) {
+        return spicy::type::unit::item::Sink::create(context(), std::move(id), attrs, std::move(meta));
     }
-    auto typeUnitItemSwitch(ExpressionPtr expr, type::unit::item::switch_::Cases cases, Engine engine,
-                            ExpressionPtr cond, spicy::declaration::Hooks hooks, AttributeSetPtr attrs,
-                            const Meta& meta = {}) {
-        return spicy::type::unit::item::Switch::create(context(), std::move(expr), std::move(cases), engine,
-                                                       std::move(cond), std::move(hooks), std::move(attrs), meta);
+    auto typeUnitItemSwitch(Expression* expr, type::unit::item::switch_::Cases cases, Engine engine, Expression* cond,
+                            spicy::declaration::Hooks hooks, AttributeSet* attrs, Meta meta = {}) {
+        return spicy::type::unit::item::Switch::create(context(), expr, std::move(cases), engine, cond,
+                                                       std::move(hooks), attrs, std::move(meta));
     }
     auto typeUnitItemSwitchCase(const Expressions& exprs, const type::unit::Items& items, const Meta& m = Meta()) {
         return spicy::type::unit::item::switch_::Case::create(context(), exprs, items, m);
     }
-    auto typeUnitItemSwitchCase(const type::unit::ItemPtr& field, const Meta& m = Meta()) {
+    auto typeUnitItemSwitchCase(type::unit::Item* field, const Meta& m = Meta()) {
         return spicy::type::unit::item::switch_::Case::create(context(), field, m);
     }
     auto typeUnitItemSwitchCase(const type::unit::Items& items, const Meta& m = Meta()) {
         return spicy::type::unit::item::switch_::Case::create(context(), items, m);
     }
-    auto typeUnitItemUnitHook(const ID& id, spicy::declaration::HookPtr hook, const Meta& meta = {}) {
-        return spicy::type::unit::item::UnitHook::create(context(), id, std::move(hook), meta);
+    auto typeUnitItemUnitHook(const ID& id, spicy::declaration::Hook* hook, Meta meta = {}) {
+        return spicy::type::unit::item::UnitHook::create(context(), id, hook, std::move(meta));
     }
-    auto typeUnitItemUnresolvedField(ID id, CtorPtr ctor, Engine engine, bool skip, Expressions args,
-                                     ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                                     spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), std::move(ctor), engine, skip,
-                                                                std::move(args), std::move(repeat), std::move(sinks),
-                                                                std::move(attrs), std::move(cond), std::move(hooks),
-                                                                meta);
+    auto typeUnitItemUnresolvedField(ID id, Ctor* ctor, Engine engine, bool skip, Expressions args, Expression* repeat,
+                                     Expressions sinks, AttributeSet* attrs, Expression* cond,
+                                     spicy::declaration::Hooks hooks, Meta meta = {}) {
+        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), ctor, engine, skip,
+                                                                std::move(args), repeat, std::move(sinks), attrs, cond,
+                                                                std::move(hooks), std::move(meta));
     }
     auto typeUnitItemUnresolvedField(ID id, ID unresolved_id, Engine engine, bool skip, Expressions args,
-                                     ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                                     spicy::declaration::Hooks hooks, const Meta& meta = {}) {
+                                     Expression* repeat, Expressions sinks, AttributeSet* attrs, Expression* cond,
+                                     spicy::declaration::Hooks hooks, Meta meta = {}) {
         return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), std::move(unresolved_id),
-                                                                engine, skip, std::move(args), std::move(repeat),
-                                                                std::move(sinks), std::move(attrs), std::move(cond),
-                                                                std::move(hooks), meta);
+                                                                engine, skip, std::move(args), repeat, std::move(sinks),
+                                                                attrs, cond, std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemUnresolvedField(ID id, QualifiedTypePtr type, Engine engine, bool skip, Expressions args,
-                                     ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                                     spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), std::move(type), engine, skip,
-                                                                std::move(args), std::move(repeat), std::move(sinks),
-                                                                std::move(attrs), std::move(cond), std::move(hooks),
-                                                                meta);
+    auto typeUnitItemUnresolvedField(ID id, QualifiedType* type, Engine engine, bool skip, Expressions args,
+                                     Expression* repeat, Expressions sinks, AttributeSet* attrs, Expression* cond,
+                                     spicy::declaration::Hooks hooks, Meta meta = {}) {
+        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), type, engine, skip,
+                                                                std::move(args), repeat, std::move(sinks), attrs, cond,
+                                                                std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemUnresolvedField(ID id, type::unit::ItemPtr item, Engine engine, bool skip, Expressions args,
-                                     ExpressionPtr repeat, Expressions sinks, AttributeSetPtr attrs, ExpressionPtr cond,
-                                     spicy::declaration::Hooks hooks, const Meta& meta = {}) {
-        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), std::move(item), engine, skip,
-                                                                std::move(args), std::move(repeat), std::move(sinks),
-                                                                std::move(attrs), std::move(cond), std::move(hooks),
-                                                                meta);
+    auto typeUnitItemUnresolvedField(ID id, type::unit::Item* item, Engine engine, bool skip, Expressions args,
+                                     Expression* repeat, Expressions sinks, AttributeSet* attrs, Expression* cond,
+                                     spicy::declaration::Hooks hooks, Meta meta = {}) {
+        return spicy::type::unit::item::UnresolvedField::create(context(), std::move(id), item, engine, skip,
+                                                                std::move(args), repeat, std::move(sinks), attrs, cond,
+                                                                std::move(hooks), std::move(meta));
     }
-    auto typeUnitItemVariable(ID id, QualifiedTypePtr type, ExpressionPtr default_, AttributeSetPtr attrs,
-                              const Meta& meta = {}) {
-        return spicy::type::unit::item::Variable::create(context(), std::move(id), std::move(type), std::move(default_),
-                                                         std::move(attrs), meta);
+    auto typeUnitItemVariable(ID id, QualifiedType* type, Expression* default_, AttributeSet* attrs, Meta meta = {}) {
+        return spicy::type::unit::item::Variable::create(context(), std::move(id), type, default_, attrs,
+                                                         std::move(meta));
     }
 
 

--- a/spicy/toolchain/include/ast/ctors/unit.h
+++ b/spicy/toolchain/include/ast/ctors/unit.h
@@ -20,7 +20,6 @@ namespace unit {
  * field constructor).
  */
 using Field = hilti::ctor::struct_::Field;
-using FieldPtr = hilti::ctor::struct_::FieldPtr;
 using Fields = hilti::ctor::struct_::Fields;
 } // namespace unit
 
@@ -34,7 +33,7 @@ public:
     auto utype() const { return child<type::Unit>(0); }
 
     /** Returns a field initialized by the constructor through its ID. */
-    unit::FieldPtr field(const ID& id) const {
+    unit::Field* field(const ID& id) const {
         for ( const auto& f : fields() ) {
             if ( f->id() == id )
                 return f;
@@ -43,17 +42,17 @@ public:
         return {};
     }
 
-    QualifiedTypePtr type() const final { return child<QualifiedType>(0); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
 
-    void setType(ASTContext* ctx, QualifiedTypePtr t) { setChild(ctx, 0, std::move(t)); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 
-    static auto create(ASTContext* ctx, ctor::unit::Fields fields, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ctor::unit::Fields fields, Meta meta = {}) {
         auto auto_ = QualifiedType::create(ctx, hilti::type::Auto::create(ctx), hilti::Constness::Const, meta);
-        return std::shared_ptr<Unit>(new Unit(ctx, node::flatten(std::move(auto_), std::move(fields)), meta));
+        return ctx->make<Unit>(ctx, node::flatten(auto_, std::move(fields)), std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ctor::unit::Fields fields, QualifiedTypePtr t, const Meta& meta = {}) {
-        return std::shared_ptr<Unit>(new Unit(ctx, node::flatten(std::move(t), std::move(fields)), meta));
+    static auto create(ASTContext* ctx, ctor::unit::Fields fields, QualifiedType* t, Meta meta = {}) {
+        return ctx->make<Unit>(ctx, node::flatten(t, std::move(fields)), std::move(meta));
     }
 
 protected:

--- a/spicy/toolchain/include/ast/declarations/hook.h
+++ b/spicy/toolchain/include/ast/declarations/hook.h
@@ -48,7 +48,7 @@ public:
     auto unitTypeIndex() { return _unit_type_index; }
     auto unitFieldIndex() { return _unit_field_index; }
 
-    ExpressionPtr priority() const {
+    hilti::Expression* priority() const {
         if ( auto attr = attributes()->find("priority") )
             return *attr->valueAsExpression();
         else
@@ -68,20 +68,20 @@ public:
         _unit_field_index = index;
     }
 
-    void setDDType(ASTContext* ctx, const QualifiedTypePtr& t) {
+    void setDDType(ASTContext* ctx, QualifiedType* t) {
         setChild(ctx, 1, hilti::expression::Keyword::createDollarDollarDeclaration(ctx, t));
     }
 
     void setParameters(ASTContext* ctx, const hilti::declaration::Parameters& params) {
         ftype()->setParameters(ctx, params);
     }
-    void setResult(ASTContext* ctx, const QualifiedTypePtr& t) { function()->setResultType(ctx, t); }
+    void setResult(ASTContext* ctx, QualifiedType* t) { function()->setResultType(ctx, t); }
 
     std::string_view displayName() const override { return "Spicy hook"; }
     node::Properties properties() const final;
 
-    static auto create(ASTContext* ctx, const hilti::declaration::Parameters& parameters, const StatementPtr& body,
-                       Engine engine, AttributeSetPtr attrs, const Meta& m = Meta()) {
+    static auto create(ASTContext* ctx, const hilti::declaration::Parameters& parameters, Statement* body,
+                       Engine engine, AttributeSet* attrs, const Meta& m = Meta()) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
@@ -91,7 +91,7 @@ public:
                                                    parameters, hilti::type::function::Flavor::Hook, m);
         auto func = hilti::Function::create(ctx, hilti::ID(), ftype, body, hilti::function::CallingConvention::Standard,
                                             attrs, m);
-        return std::shared_ptr<Hook>(new Hook(ctx, {func, nullptr}, engine, m));
+        return ctx->make<Hook>(ctx, {func, nullptr}, engine, m);
     }
 
 protected:
@@ -108,8 +108,7 @@ private:
     hilti::ast::DeclarationIndex _unit_field_index;
 };
 
-using HookPtr = std::shared_ptr<Hook>;
-using Hooks = std::vector<HookPtr>;
+using Hooks = std::vector<Hook*>;
 
 } // namespace declaration
 } // namespace spicy

--- a/spicy/toolchain/include/ast/declarations/hook.h
+++ b/spicy/toolchain/include/ast/declarations/hook.h
@@ -108,7 +108,7 @@ private:
     hilti::ast::DeclarationIndex _unit_field_index;
 };
 
-using Hooks = std::vector<Hook*>;
+using Hooks = NodeVector<Hook>;
 
 } // namespace declaration
 } // namespace spicy

--- a/spicy/toolchain/include/ast/declarations/unit-hook.h
+++ b/spicy/toolchain/include/ast/declarations/unit-hook.h
@@ -19,8 +19,8 @@ public:
 
     std::string_view displayName() const final { return "unit hook"; }
 
-    static auto create(ASTContext* ctx, const ID& id, const declaration::HookPtr& hook, Meta meta = {}) {
-        auto h = std::shared_ptr<UnitHook>(new UnitHook(ctx, {hook}, id, std::move(meta)));
+    static auto create(ASTContext* ctx, const ID& id, declaration::Hook* hook, Meta meta = {}) {
+        auto h = ctx->make<UnitHook>(ctx, {hook}, id, std::move(meta));
         h->hook()->setID(id);
         return h;
     }

--- a/spicy/toolchain/include/ast/forward.h
+++ b/spicy/toolchain/include/ast/forward.h
@@ -41,8 +41,7 @@ namespace declaration {
 class Hook;
 class UnitHook;
 
-using HookPtr = std::shared_ptr<Hook>;
-using Hooks = std::vector<HookPtr>;
+using Hooks = std::vector<Hook*>;
 } // namespace declaration
 
 namespace operator_ {
@@ -103,8 +102,7 @@ class Unit;
 
 namespace unit {
 class Item;
-using ItemPtr = std::shared_ptr<Item>;
-using Items = std::vector<ItemPtr>;
+using Items = std::vector<Item*>;
 
 namespace item {
 class Field;
@@ -117,26 +115,13 @@ class Variable;
 
 namespace switch_ {
 class Case;
-using CasePtr = std::shared_ptr<Case>;
-using Cases = std::vector<CasePtr>;
+using Cases = std::vector<Case*>;
 }; // namespace switch_
 
-using HookPtr = std::shared_ptr<declaration::Hook>;
-using FieldPtr = std::shared_ptr<Field>;
-using ItemPtr = std::shared_ptr<Item>;
-using PropertyPtr = std::shared_ptr<Property>;
-using SinkPtr = std::shared_ptr<Sink>;
-using VariablePtr = std::shared_ptr<Variable>;
-using SwitchPtr = std::shared_ptr<Switch>;
-using UnitHookPtr = std::shared_ptr<UnitHook>;
-using UnresolvedFieldPtr = std::shared_ptr<UnresolvedField>;
-
-using Properties = std::vector<PropertyPtr>;
+using Properties = std::vector<Property*>;
 } // namespace item
 
 } // namespace unit
-
-using UnitPtr = std::shared_ptr<Unit>;
 
 } // namespace type
 
@@ -153,19 +138,6 @@ using QualifiedType = hilti::QualifiedType;
 using Statement = hilti::Statement;
 using UnqualifiedType = hilti::UnqualifiedType;
 using AttributeSet = hilti::AttributeSet;
-
-using AttributePtr = hilti::AttributePtr;
-using AttributeSetPtr = hilti::AttributeSetPtr;
-using CtorPtr = hilti::CtorPtr;
-using DeclarationPtr = hilti::DeclarationPtr;
-using ExpressionPtr = hilti::ExpressionPtr;
-using FunctionPtr = hilti::FunctionPtr;
-using NodePtr = hilti::NodePtr;
-using StatementPtr = hilti::StatementPtr;
-using QualifiedTypePtr = hilti::QualifiedTypePtr;
-using UnqualifiedTypePtr = hilti::UnqualifiedTypePtr;
-using ModulePtr = hilti::ModulePtr;
-using ASTRootPtr = hilti::ASTRootPtr;
 
 using Nodes = hilti::Nodes;
 using Expressions = hilti::Expressions;

--- a/spicy/toolchain/include/ast/forward.h
+++ b/spicy/toolchain/include/ast/forward.h
@@ -9,8 +9,6 @@
 
 #include <spicy/ast/node-tag.h>
 
-namespace hilti::node {}
-
 namespace hilti {
 class ID;
 class Meta;
@@ -24,6 +22,12 @@ class ExtendedBuilderTemplate;
 namespace spicy {
 
 namespace node = hilti::node; // NOLINT
+
+template<typename T>
+using NodeVector = hilti::NodeVector<T>;
+
+using Node = hilti::Node;
+using Nodes = hilti::Nodes;
 
 class BuilderBase;
 using Builder = hilti::ExtendedBuilderTemplate<BuilderBase>;
@@ -41,7 +45,7 @@ namespace declaration {
 class Hook;
 class UnitHook;
 
-using Hooks = std::vector<Hook*>;
+using Hooks = NodeVector<Hook>;
 } // namespace declaration
 
 namespace operator_ {
@@ -102,7 +106,7 @@ class Unit;
 
 namespace unit {
 class Item;
-using Items = std::vector<Item*>;
+using Items = NodeVector<Item>;
 
 namespace item {
 class Field;
@@ -115,10 +119,10 @@ class Variable;
 
 namespace switch_ {
 class Case;
-using Cases = std::vector<Case*>;
+using Cases = NodeVector<Case>;
 }; // namespace switch_
 
-using Properties = std::vector<Property*>;
+using Properties = NodeVector<Property>;
 } // namespace item
 
 } // namespace unit
@@ -139,10 +143,10 @@ using Statement = hilti::Statement;
 using UnqualifiedType = hilti::UnqualifiedType;
 using AttributeSet = hilti::AttributeSet;
 
-using Nodes = hilti::Nodes;
-using Expressions = hilti::Expressions;
-using Statements = hilti::Statements;
 using Declarations = hilti::Declarations;
+using Expressions = hilti::Expressions;
+using QualifiedTypes = hilti::QualifiedTypes;
+using Statements = hilti::Statements;
 
 using ASTContext = hilti::ASTContext;
 using Meta = hilti::Meta;

--- a/spicy/toolchain/include/ast/node-tag.h
+++ b/spicy/toolchain/include/ast/node-tag.h
@@ -7,97 +7,97 @@
 namespace hilti::node::tag {
 
 namespace type::unit::item::switch_ {
-const Tag Case = 10000;
+constexpr Tag Case = 10000;
 }
 
 namespace ctor {
-const Tag Unit = 10100;
+constexpr Tag Unit = 10100;
 }
 
 namespace declaration {
-const Tag Hook = 10200;
-const Tag UnitHook = 10201;
+constexpr Tag Hook = 10200;
+constexpr Tag UnitHook = 10201;
 } // namespace declaration
 
 namespace operator_::sink {
-const unsigned int Close = 10301;
-const unsigned int Connect = 10302;
-const unsigned int ConnectFilter = 10303;
-const unsigned int ConnectMIMETypeBytes = 10304;
-const unsigned int ConnectMIMETypeString = 10305;
-const unsigned int Gap = 10306;
-const unsigned int SequenceNumber = 10307;
-const unsigned int SetAutoTrim = 10308;
-const unsigned int SetInitialSequenceNumber = 10309;
-const unsigned int SetPolicy = 10310;
-const unsigned int SizeReference = 10311;
-const unsigned int SizeValue = 10312;
-const unsigned int Skip = 10313;
-const unsigned int Trim = 10314;
-const unsigned int Write = 10315;
+constexpr unsigned int Close = 10301;
+constexpr unsigned int Connect = 10302;
+constexpr unsigned int ConnectFilter = 10303;
+constexpr unsigned int ConnectMIMETypeBytes = 10304;
+constexpr unsigned int ConnectMIMETypeString = 10305;
+constexpr unsigned int Gap = 10306;
+constexpr unsigned int SequenceNumber = 10307;
+constexpr unsigned int SetAutoTrim = 10308;
+constexpr unsigned int SetInitialSequenceNumber = 10309;
+constexpr unsigned int SetPolicy = 10310;
+constexpr unsigned int SizeReference = 10311;
+constexpr unsigned int SizeValue = 10312;
+constexpr unsigned int Skip = 10313;
+constexpr unsigned int Trim = 10314;
+constexpr unsigned int Write = 10315;
 } // namespace operator_::sink
 
 namespace operator_::unit {
-const unsigned int Backtrack = 10316;
-const unsigned int ConnectFilter = 10317;
-const unsigned int ContextConst = 10318;
-const unsigned int ContextNonConst = 10319;
-const unsigned int Find = 10320;
-const unsigned int Forward = 10321;
-const unsigned int ForwardEod = 10322;
-const unsigned int HasMember = 10323;
-const unsigned int Input = 10324;
-const unsigned int MemberCall = 10325;
-const unsigned int MemberConst = 10326;
-const unsigned int MemberNonConst = 10327;
-const unsigned int Offset = 10328;
-const unsigned int Position = 10329;
-const unsigned int SetInput = 1033;
-const unsigned int TryMember = 10331;
-const unsigned int Unset = 10332;
+constexpr unsigned int Backtrack = 10316;
+constexpr unsigned int ConnectFilter = 10317;
+constexpr unsigned int ContextConst = 10318;
+constexpr unsigned int ContextNonConst = 10319;
+constexpr unsigned int Find = 10320;
+constexpr unsigned int Forward = 10321;
+constexpr unsigned int ForwardEod = 10322;
+constexpr unsigned int HasMember = 10323;
+constexpr unsigned int Input = 10324;
+constexpr unsigned int MemberCall = 10325;
+constexpr unsigned int MemberConst = 10326;
+constexpr unsigned int MemberNonConst = 10327;
+constexpr unsigned int Offset = 10328;
+constexpr unsigned int Position = 10329;
+constexpr unsigned int SetInput = 1033;
+constexpr unsigned int TryMember = 10331;
+constexpr unsigned int Unset = 10332;
 } // namespace operator_::unit
 
 namespace statement {
-const Tag Confirm = 10500;
-const Tag Print = 10501;
-const Tag Reject = 10502;
-const Tag Stop = 10503;
+constexpr Tag Confirm = 10500;
+constexpr Tag Print = 10501;
+constexpr Tag Reject = 10502;
+constexpr Tag Stop = 10503;
 } // namespace statement
 
 namespace type {
-const Tag Sink = 10600;
-const Tag Unit = 10601;
+constexpr Tag Sink = 10600;
+constexpr Tag Unit = 10601;
 
 namespace unit {
-const Tag Item = 10700;
+constexpr Tag Item = 10700;
 }
 
 namespace unit::item {
-const Tag Field = 10800;
+constexpr Tag Field = 10800;
 }
 
 namespace unit::item {
-const Tag Property = 10900;
+constexpr Tag Property = 10900;
 }
 
 namespace unit::item {
-const Tag Sink = 11000;
+constexpr Tag Sink = 11000;
 }
 
 namespace unit::item {
-const Tag Switch = 11100;
+constexpr Tag Switch = 11100;
 }
 
 namespace unit::item {
-const Tag UnitHook = 11200;
+constexpr Tag UnitHook = 11200;
 }
 
 namespace unit::item {
-const Tag UnresolvedField = 11300;
+constexpr Tag UnresolvedField = 11300;
 }
 
 namespace unit::item {
-const Tag Variable = 11400;
+constexpr Tag Variable = 11400;
 }
 
 } // namespace type

--- a/spicy/toolchain/include/ast/node.h
+++ b/spicy/toolchain/include/ast/node.h
@@ -65,17 +65,15 @@
     namespace ns {                                                                                                     \
     class cls : public hilti::expression::ResolvedOperator {                                                           \
     public:                                                                                                            \
-        static std::shared_ptr<cls> create(hilti::ASTContext* ctx, const hilti::Operator* op,                          \
-                                           const hilti::QualifiedTypePtr& result, const hilti::Expressions& operands,  \
-                                           const hilti::Meta& meta) {                                                  \
-            return std::shared_ptr<cls>(new cls(ctx, op, result, operands, meta));                                     \
+        static cls* create(hilti::ASTContext* ctx, const hilti::Operator* op, hilti::QualifiedType* result,            \
+                           const hilti::Expressions& operands, hilti::Meta meta) {                                     \
+            return ctx->make<cls>(ctx, op, result, operands, std::move(meta));                                         \
         }                                                                                                              \
                                                                                                                        \
         SPICY_NODE_2(operator_::ns::cls, expression::ResolvedOperator, Expression, final);                             \
                                                                                                                        \
     private:                                                                                                           \
-        cls(ASTContext* ctx, const hilti::Operator* op, const QualifiedTypePtr& result, const Expressions& operands,   \
-            Meta meta)                                                                                                 \
+        cls(ASTContext* ctx, const hilti::Operator* op, QualifiedType* result, const Expressions& operands, Meta meta) \
             : ResolvedOperator(ctx, NodeTags, op, result, operands, std::move(meta)) {}                                \
     };                                                                                                                 \
     } // namespace ns

--- a/spicy/toolchain/include/ast/operators/sink.h
+++ b/spicy/toolchain/include/ast/operators/sink.h
@@ -8,6 +8,7 @@
 #include <hilti/ast/operators/common.h>
 
 #include <spicy/ast/forward.h>
+#include <spicy/ast/node.h>
 
 namespace spicy::operator_ {
 

--- a/spicy/toolchain/include/ast/operators/unit.h
+++ b/spicy/toolchain/include/ast/operators/unit.h
@@ -8,6 +8,7 @@
 #include <hilti/ast/operators/common.h>
 
 #include <spicy/ast/forward.h>
+#include <spicy/ast/node.h>
 
 namespace spicy {
 
@@ -35,19 +36,19 @@ namespace unit {
 
 class MemberCall final : public hilti::Operator {
 public:
-    MemberCall(const type::unit::item::FieldPtr& field);
+    MemberCall(type::unit::item::Field* field);
     ~MemberCall() final;
 
-    auto field() const { return _field.lock(); }
+    auto field() const { return _field; }
 
     hilti::operator_::Signature signature(hilti::Builder* builder) const final;
-    hilti::Result<hilti::ResolvedOperatorPtr> instantiate(hilti::Builder* builder, Expressions operands,
-                                                          const Meta& meta) const final;
+    hilti::Result<hilti::expression::ResolvedOperator*> instantiate(hilti::Builder* builder, Expressions operands,
+                                                                    Meta meta) const final;
 
     std::string name() const final { return "unit::MemberCall"; }
 
 private:
-    std::weak_ptr<type::unit::item::Field> _field;
+    type::unit::item::Field* _field = nullptr;
 };
 
 } // namespace unit

--- a/spicy/toolchain/include/ast/statements/confirm.h
+++ b/spicy/toolchain/include/ast/statements/confirm.h
@@ -14,9 +14,7 @@ namespace spicy::statement {
 /** AST node for a `break` statement. */
 class Confirm : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Confirm>(new Confirm(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Confirm>(ctx, {}, std::move(meta)); }
 
 protected:
     Confirm(ASTContext* ctx, Nodes children, Meta meta)

--- a/spicy/toolchain/include/ast/statements/print.h
+++ b/spicy/toolchain/include/ast/statements/print.h
@@ -18,7 +18,7 @@ public:
     auto expressions() const { return children<hilti::Expression>(0, {}); }
 
     static auto create(ASTContext* ctx, Expressions expressions, Meta meta = {}) {
-        return std::shared_ptr<Print>(new Print(ctx, std::move(expressions), std::move(meta)));
+        return ctx->make<Print>(ctx, std::move(expressions), std::move(meta));
     }
 
 protected:

--- a/spicy/toolchain/include/ast/statements/reject.h
+++ b/spicy/toolchain/include/ast/statements/reject.h
@@ -14,9 +14,7 @@ namespace spicy::statement {
 /** AST node for a `break` statement. */
 class Reject : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Reject>(new Reject(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Reject>(ctx, {}, std::move(meta)); }
 
 protected:
     Reject(ASTContext* ctx, Nodes children, Meta meta)

--- a/spicy/toolchain/include/ast/statements/stop.h
+++ b/spicy/toolchain/include/ast/statements/stop.h
@@ -14,9 +14,7 @@ namespace spicy::statement {
 /** AST node for a `break` statement. */
 class Stop : public Statement {
 public:
-    static auto create(ASTContext* ctx, Meta meta = {}) {
-        return std::shared_ptr<Stop>(new Stop(ctx, {}, std::move(meta)));
-    }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Stop>(ctx, {}, std::move(meta)); }
 
 protected:
     Stop(ASTContext* ctx, Nodes children, Meta meta) : Statement(ctx, NodeTags, std::move(children), std::move(meta)) {}

--- a/spicy/toolchain/include/ast/types/sink.h
+++ b/spicy/toolchain/include/ast/types/sink.h
@@ -15,14 +15,14 @@ namespace spicy::type {
 /** AST node for a Sink type. */
 class Sink : public UnqualifiedType {
 public:
-    static auto create(ASTContext* ctx, const Meta& meta = {}) { return std::shared_ptr<Sink>(new Sink(ctx, meta)); }
+    static auto create(ASTContext* ctx, Meta meta = {}) { return ctx->make<Sink>(ctx, std::move(meta)); }
 
     std::string_view typeClass() const final { return "sink"; }
 
     bool isAllocable() const final { return true; }
 
 protected:
-    Sink(ASTContext* ctx, const Meta& meta) : UnqualifiedType(ctx, NodeTags, {"sink"}, meta) {}
+    Sink(ASTContext* ctx, Meta meta) : UnqualifiedType(ctx, NodeTags, {"sink"}, std::move(meta)) {}
 
     SPICY_NODE_1(type::Sink, UnqualifiedType, final);
 };

--- a/spicy/toolchain/include/ast/types/unit-item.h
+++ b/spicy/toolchain/include/ast/types/unit-item.h
@@ -17,14 +17,14 @@ namespace spicy::type::unit {
 class Item : public hilti::Declaration {
 public:
     /** Returns the type of the parsed unit item. */
-    virtual QualifiedTypePtr itemType() const = 0;
+    virtual QualifiedType* itemType() const = 0;
 
     /** Returns true if the item's type has been resolved. */
     virtual bool isResolved(hilti::node::CycleDetector* cd = nullptr) const = 0;
 
 protected:
-    Item(ASTContext* ctx, node::Tags node_tags, Nodes children, ID id, const Meta& meta)
-        : hilti::Declaration(ctx, node_tags, std::move(children), std::move(id), {}, meta) {}
+    Item(ASTContext* ctx, node::Tags node_tags, Nodes children, ID id, Meta meta)
+        : hilti::Declaration(ctx, node_tags, std::move(children), std::move(id), {}, std::move(meta)) {}
 
     SPICY_NODE_1(type::unit::Item, Declaration, override);
 };

--- a/spicy/toolchain/include/ast/types/unit-items/property.h
+++ b/spicy/toolchain/include/ast/types/unit-items/property.h
@@ -23,34 +23,32 @@ public:
     auto attributes() const { return child<AttributeSet>(1); }
     auto inherited() const { return _inherited; }
 
-    QualifiedTypePtr itemType() const final { return child<QualifiedType>(2); }
+    QualifiedType* itemType() const final { return child<QualifiedType>(2); }
 
     bool isResolved(hilti::node::CycleDetector* cd) const final { return true; }
 
     std::string_view displayName() const final { return "unit property"; }
 
-    static auto create(ASTContext* ctx, ID id, AttributeSetPtr attrs, bool inherited = false, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ID id, AttributeSet* attrs, bool inherited = false, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Property>(new Property(ctx,
-                                                      node::flatten(nullptr, attrs, hilti::type::Void::create(ctx)),
-                                                      std::move(id), false, meta));
+        return ctx->make<Property>(ctx, node::flatten(nullptr, attrs, hilti::type::Void::create(ctx)), std::move(id),
+                                   false, std::move(meta));
     }
 
-    static auto create(ASTContext* ctx, ID id, ExpressionPtr expr, AttributeSetPtr attrs, bool inherited = false,
-                       const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ID id, Expression* expr, AttributeSet* attrs, bool inherited = false,
+                       Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Property>(
-            new Property(ctx, node::flatten(std::move(expr), attrs, hilti::type::Void::create(ctx)), std::move(id),
-                         inherited, meta));
+        return ctx->make<Property>(ctx, node::flatten(expr, attrs, hilti::type::Void::create(ctx)), std::move(id),
+                                   inherited, std::move(meta));
     }
 
 protected:
-    Property(ASTContext* ctx, Nodes children, ID id, bool inherited, const Meta& meta)
-        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), meta), _inherited(inherited) {}
+    Property(ASTContext* ctx, Nodes children, ID id, bool inherited, Meta meta)
+        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), std::move(meta)), _inherited(inherited) {}
 
     SPICY_NODE_2(type::unit::item::Property, type::unit::Item, Declaration, final);
 

--- a/spicy/toolchain/include/ast/types/unit-items/sink.h
+++ b/spicy/toolchain/include/ast/types/unit-items/sink.h
@@ -21,24 +21,24 @@ class Sink : public unit::Item {
 public:
     auto attributes() const { return child<AttributeSet>(0); }
 
-    QualifiedTypePtr itemType() const final { return child<QualifiedType>(1); }
+    QualifiedType* itemType() const final { return child<QualifiedType>(1); }
 
     bool isResolved(hilti::node::CycleDetector* cd) const final { return itemType()->isResolved(cd); }
 
     std::string_view displayName() const final { return "unit sink"; }
 
-    static auto create(ASTContext* ctx, ID id, AttributeSetPtr attrs, const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ID id, AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Sink>(
-            new Sink(ctx, {attrs, QualifiedType::create(ctx, type::Sink::create(ctx), hilti::Constness::Mutable)},
-                     std::move(id), meta));
+        return ctx->make<Sink>(ctx,
+                               {attrs, QualifiedType::create(ctx, type::Sink::create(ctx), hilti::Constness::Mutable)},
+                               std::move(id), std::move(meta));
     }
 
 protected:
-    Sink(ASTContext* ctx, Nodes children, ID id, const Meta& meta)
-        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), meta) {}
+    Sink(ASTContext* ctx, Nodes children, ID id, Meta meta)
+        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), std::move(meta)) {}
 
     SPICY_NODE_2(type::unit::item::Sink, type::unit::Item, Declaration, final);
 };

--- a/spicy/toolchain/include/ast/types/unit-items/switch.h
+++ b/spicy/toolchain/include/ast/types/unit-items/switch.h
@@ -73,7 +73,7 @@ private:
     bool _look_ahead = false;
 };
 
-using Cases = std::vector<Case*>;
+using Cases = NodeVector<Case>;
 
 } // namespace switch_
 

--- a/spicy/toolchain/include/ast/types/unit-items/switch.h
+++ b/spicy/toolchain/include/ast/types/unit-items/switch.h
@@ -50,17 +50,17 @@ public:
 
     static auto create(ASTContext* ctx, const Expressions& exprs, const type::unit::Items& items,
                        const Meta& m = Meta()) {
-        return std::shared_ptr<Case>(new Case(ctx, node::flatten(exprs, items), false, m));
+        return ctx->make<Case>(ctx, node::flatten(exprs, items), false, m);
     }
 
     /** Factory function for a default case. */
     static auto create(ASTContext* ctx, const type::unit::Items& items, const Meta& m = Meta()) {
-        return std::shared_ptr<Case>(new Case(ctx, items, false, m));
+        return ctx->make<Case>(ctx, items, false, m);
     }
 
     /** Factory function for a look-ahead case. */
-    static auto create(ASTContext* ctx, const type::unit::ItemPtr& field, const Meta& m = Meta()) {
-        return std::shared_ptr<Case>(new Case(ctx, {field}, true, m));
+    static auto create(ASTContext* ctx, type::unit::Item* field, const Meta& m = Meta()) {
+        return ctx->make<Case>(ctx, {field}, true, m);
     }
 
 protected:
@@ -73,8 +73,7 @@ private:
     bool _look_ahead = false;
 };
 
-using CasePtr = std::shared_ptr<Case>;
-using Cases = std::vector<CasePtr>;
+using Cases = std::vector<Case*>;
 
 } // namespace switch_
 
@@ -95,9 +94,9 @@ public:
      *
      * field: The field.
      */
-    switch_::CasePtr case_(const type::unit::item::FieldPtr& field) const;
+    switch_::Case* case_(const type::unit::item::Field* field) const;
 
-    QualifiedTypePtr itemType() const final { return child<QualifiedType>(3); }
+    QualifiedType* itemType() const final { return child<QualifiedType>(3); }
 
     bool isResolved(hilti::node::CycleDetector* cd) const final {
         for ( const auto& c : cases() ) {
@@ -115,24 +114,22 @@ public:
         return unit::Item::properties() + p;
     }
 
-    static auto create(ASTContext* ctx, ExpressionPtr expr, type::unit::item::switch_::Cases cases, Engine engine,
-                       ExpressionPtr cond, spicy::declaration::Hooks hooks, AttributeSetPtr attrs,
-                       const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, Expression* expr, type::unit::item::switch_::Cases cases, Engine engine,
+                       Expression* cond, spicy::declaration::Hooks hooks, AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Switch>(
-            new Switch(ctx,
-                       node::flatten(std::move(expr), std::move(cond), attrs,
-                                     QualifiedType::create(ctx, hilti::type::Void::create(ctx),
-                                                           hilti::Constness::Const),
-                                     std::move(cases), std::move(hooks)),
-                       engine, meta));
+        return ctx->make<Switch>(ctx,
+                                 node::flatten(expr, cond, attrs,
+                                               QualifiedType::create(ctx, hilti::type::Void::create(ctx),
+                                                                     hilti::Constness::Const),
+                                               std::move(cases), std::move(hooks)),
+                                 engine, std::move(meta));
     }
 
 protected:
-    Switch(ASTContext* ctx, Nodes children, Engine engine, const Meta& meta)
-        : unit::Item(ctx, NodeTags, std::move(children), ID(), meta), _engine(engine) {}
+    Switch(ASTContext* ctx, Nodes children, Engine engine, Meta meta)
+        : unit::Item(ctx, NodeTags, std::move(children), ID(), std::move(meta)), _engine(engine) {}
 
     SPICY_NODE_2(type::unit::item::Switch, type::unit::Item, Declaration, final);
 

--- a/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
+++ b/spicy/toolchain/include/ast/types/unit-items/unit-hook.h
@@ -22,21 +22,21 @@ public:
     auto hook() const { return child<spicy::declaration::Hook>(0); }
     auto location() const { return hook()->location(); }
 
-    QualifiedTypePtr itemType() const final { return hook()->function()->type(); }
+    QualifiedType* itemType() const final { return hook()->function()->type(); }
 
     bool isResolved(hilti::node::CycleDetector* cd) const final { return itemType()->isResolved(cd); }
 
     std::string_view displayName() const final { return "unit hook"; }
 
-    static auto create(ASTContext* ctx, const ID& id, spicy::declaration::HookPtr hook, const Meta& meta = {}) {
-        auto h = std::shared_ptr<UnitHook>(new UnitHook(ctx, {std::move(hook)}, id, meta));
+    static auto create(ASTContext* ctx, const ID& id, spicy::declaration::Hook* hook, Meta meta = {}) {
+        auto h = ctx->make<UnitHook>(ctx, {hook}, id, std::move(meta));
         h->hook()->setID(id);
         return h;
     }
 
 protected:
-    UnitHook(ASTContext* ctx, Nodes children, ID id, const Meta& meta)
-        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), meta) {}
+    UnitHook(ASTContext* ctx, Nodes children, ID id, Meta meta)
+        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), std::move(meta)) {}
 
     SPICY_NODE_2(type::unit::item::UnitHook, type::unit::Item, Declaration, final);
 };

--- a/spicy/toolchain/include/ast/types/unit-items/variable.h
+++ b/spicy/toolchain/include/ast/types/unit-items/variable.h
@@ -28,24 +28,23 @@ public:
 
     bool isOptional() const { return attributes()->has("&optional"); }
 
-    QualifiedTypePtr itemType() const final { return child<QualifiedType>(0); }
+    QualifiedType* itemType() const final { return child<QualifiedType>(0); }
 
     bool isResolved(hilti::node::CycleDetector* cd) const final { return itemType()->isResolved(cd); }
 
     std::string_view displayName() const final { return "unit variable"; }
 
-    static auto create(ASTContext* ctx, ID id, QualifiedTypePtr type, ExpressionPtr default_, AttributeSetPtr attrs,
-                       const Meta& meta = {}) {
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, Expression* default_, AttributeSet* attrs,
+                       Meta meta = {}) {
         if ( ! attrs )
             attrs = AttributeSet::create(ctx);
 
-        return std::shared_ptr<Variable>(
-            new Variable(ctx, {std::move(type), std::move(default_), attrs}, std::move(id), meta));
+        return ctx->make<Variable>(ctx, {type, default_, attrs}, std::move(id), std::move(meta));
     }
 
 protected:
-    Variable(ASTContext* ctx, Nodes children, ID id, const Meta& meta)
-        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), meta) {}
+    Variable(ASTContext* ctx, Nodes children, ID id, Meta meta)
+        : unit::Item(ctx, NodeTags, std::move(children), std::move(id), std::move(meta)) {}
 
     SPICY_NODE_2(type::unit::item::Variable, type::unit::Item, Declaration, final);
 };

--- a/spicy/toolchain/include/ast/types/unit.h
+++ b/spicy/toolchain/include/ast/types/unit.h
@@ -34,13 +34,13 @@ public:
     }
 
     /** Returns the type set through ``%context`, if available and resolved already. */
-    UnqualifiedTypePtr contextType() const { return child<UnqualifiedType>(2); }
+    UnqualifiedType* contextType() const { return child<UnqualifiedType>(2); }
 
     /**
      * Returns the item of a given name if it exists. This descends
      * recursively into children as well.
      */
-    unit::ItemPtr itemByName(const ID& id) const;
+    unit::Item* itemByName(const ID& id) const;
 
     /**
      * Returns all of the unit's items of a particular subtype T.
@@ -54,7 +54,7 @@ public:
      * Returns the property of a given name if it exists. If it exists more
      * than once, it's undefined which one is returned.
      */
-    type::unit::item::PropertyPtr propertyItem(const std::string& name) const;
+    type::unit::item::Property* propertyItem(const std::string& name) const;
 
     /** Returns all properties of a given name. */
     unit::item::Properties propertyItems(const std::string& name) const;
@@ -72,8 +72,7 @@ public:
      * bitfield, and the bitrange within it named *id*; if not successful, a
      * pair of null pointers
      */
-    std::pair<unit::item::FieldPtr, std::shared_ptr<hilti::type::bitfield::BitRange>> findRangeInAnonymousBitField(
-        const ID& id) const;
+    std::pair<unit::item::Field*, hilti::type::bitfield::BitRange*> findRangeInAnonymousBitField(const ID& id) const;
 
     /**
      * Returns true if the unit has been declared as publically/externally
@@ -99,8 +98,8 @@ public:
         _assignItemIndices();
     }
 
-    void setAttributes(ASTContext* ctx, const AttributeSetPtr& attrs) { setChild(ctx, 1, attrs); }
-    void setContextType(ASTContext* ctx, const UnqualifiedTypePtr& type) { setChild(ctx, 2, type); }
+    void setAttributes(ASTContext* ctx, AttributeSet* attrs) { setChild(ctx, 1, attrs); }
+    void setContextType(ASTContext* ctx, UnqualifiedType* type) { setChild(ctx, 2, type); }
     void setGrammar(std::shared_ptr<spicy::detail::codegen::Grammar> g) { _grammar = std::move(g); }
     void setPublic(bool p) { _public = p; }
 
@@ -119,28 +118,28 @@ public:
     }
 
     static auto create(ASTContext* ctx, const hilti::declaration::Parameters& params, type::unit::Items items,
-                       AttributeSetPtr attrs, const Meta& meta = {}) {
+                       AttributeSet* attrs, Meta meta = {}) {
         if ( ! attrs )
             attrs = hilti::AttributeSet::create(ctx);
 
         for ( auto&& p : params )
             p->setIsTypeParameter();
 
-        auto t = std::shared_ptr<Unit>(
-            new Unit(ctx, node::flatten(nullptr, attrs, nullptr, params, std::move(items)), meta));
+        auto t =
+            ctx->make<Unit>(ctx, node::flatten(nullptr, attrs, nullptr, params, std::move(items)), std::move(meta));
 
         t->_setSelf(ctx);
         return t;
     }
 
-    static auto create(ASTContext* ctx, hilti::type::Wildcard _, const Meta& meta = {}) {
-        return std::shared_ptr<Unit>(
-            new Unit(ctx, hilti::type::Wildcard(), {nullptr, AttributeSet::create(ctx), nullptr}, meta));
+    static auto create(ASTContext* ctx, hilti::type::Wildcard _, Meta meta = {}) {
+        return ctx->make<Unit>(ctx, hilti::type::Wildcard(), {nullptr, AttributeSet::create(ctx), nullptr},
+                               std::move(meta));
     }
 
 protected:
-    Unit(ASTContext* ctx, const Nodes& children, const Meta& meta)
-        : UnqualifiedType(ctx, NodeTags, {}, children, meta) {
+    Unit(ASTContext* ctx, const Nodes& children, Meta meta)
+        : UnqualifiedType(ctx, NodeTags, {}, children, std::move(meta)) {
         _assignItemIndices();
     }
 

--- a/spicy/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/codegen.h
@@ -45,19 +45,16 @@ public:
     const auto& options() const { return compilerContext()->options(); }
 
     /** Entry point for transformation from a Spicy AST to a HILTI AST. */
-    bool compileAST(const ASTRootPtr& root);
+    bool compileAST(hilti::ASTRoot* root);
 
     /** Turns a Spicy unit into a HILTI struct, along with all the necessary implementation code. */
-    UnqualifiedTypePtr compileUnit(
-        const type::UnitPtr& unit,
+    UnqualifiedType* compileUnit(
+        type::Unit* unit,
         bool declare_only = true); // Compiles a Unit type into its HILTI struct representation.
 
-    std::shared_ptr<hilti::declaration::Function> compileHook(const type::Unit& unit, const ID& id,
-                                                              std::shared_ptr<type::unit::item::Field> field,
-                                                              bool foreach, bool debug,
-                                                              hilti::type::function::Parameters params,
-                                                              const hilti::StatementPtr& body,
-                                                              const ExpressionPtr& priority, const hilti::Meta& meta);
+    hilti::declaration::Function* compileHook(const type::Unit& unit, const ID& id, type::unit::item::Field* field,
+                                              bool foreach, bool debug, hilti::type::function::Parameters params,
+                                              hilti::Statement* body, Expression* priority, const hilti::Meta& meta);
 
     // These must be called only while a module is being compiled.
     codegen::ParserBuilder* parserBuilder() { return &_pb; }
@@ -75,16 +72,16 @@ public:
      * We leave the latter to a later stage, which will replace all recorded
      * mappings at the end when its safe to modify the AST.
      */
-    auto recordTypeMapping(UnqualifiedType* from, UnqualifiedTypePtr to) { _type_mappings[from] = std::move(to); }
+    auto recordTypeMapping(UnqualifiedType* from, UnqualifiedType* to) { _type_mappings[from] = to; }
 
     /**
      * Records a new declaration to be added to the current module. The
      * additional will be performed at the end of codegen when its safe to
      * modify the AST.
      */
-    void addDeclaration(DeclarationPtr d) {
+    void addDeclaration(Declaration* d) {
         _decls_added.insert(d->id());
-        _new_decls.push_back(std::move(d));
+        _new_decls.push_back(d);
     }
 
     /**
@@ -94,7 +91,7 @@ public:
     bool haveAddedDeclaration(const ID& id) { return _decls_added.find(id) != _decls_added.end(); }
 
 private:
-    bool _compileModule(const ModulePtr& module, int pass);
+    bool _compileModule(hilti::declaration::Module* module, int pass);
     void _updateDeclarations(visitor::MutatingPostOrder* v, hilti::declaration::Module* module);
 
     Builder* _builder;
@@ -102,7 +99,7 @@ private:
     codegen::ParserBuilder _pb;
 
     std::vector<hilti::declaration::Property> _properties;
-    std::map<UnqualifiedType*, UnqualifiedTypePtr> _type_mappings;
+    std::map<UnqualifiedType*, UnqualifiedType*> _type_mappings;
 
     hilti::declaration::Module* _hilti_module = nullptr;
     Declarations _new_decls;

--- a/spicy/toolchain/include/compiler/detail/codegen/grammar-builder.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/grammar-builder.h
@@ -40,7 +40,7 @@ public:
      * Generates the grammar for a unit type. The grammar will afterwards be
      * available through `grammar()`.
      */
-    hilti::Result<hilti::Nothing> run(const std::shared_ptr<type::Unit>& unit);
+    hilti::Result<hilti::Nothing> run(type::Unit* unit);
 
     /**
      * Returns the grammar for a unit type. The type must have been computed

--- a/spicy/toolchain/include/compiler/detail/codegen/production.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/production.h
@@ -55,21 +55,21 @@ public:
      */
     auto container() const { return _container; }
 
-    void setField(const type::unit::item::FieldPtr& n, bool is_field_production) {
+    void setField(type::unit::item::Field* n, bool is_field_production) {
         assert(n);
         _is_field_production = is_field_production;
         _field = n;
     }
 
-    void setContainer(const type::unit::item::FieldPtr& n) {
+    void setContainer(type::unit::item::Field* n) {
         assert(n);
         _container = n;
     }
 
 private:
     bool _is_field_production = false;
-    type::unit::item::FieldPtr _field;
-    type::unit::item::FieldPtr _container;
+    type::unit::item::Field* _field = nullptr;
+    type::unit::item::Field* _container = nullptr;
 };
 
 } // namespace production
@@ -118,19 +118,19 @@ public:
      * will be called when a value has been parsed for the terminal. It must
      * return a value to use instead of the parsed value.
      */
-    void setFilter(ExpressionPtr filter) { _filter = std::move(filter); }
+    void setFilter(Expression* filter) { _filter = filter; }
 
     /**
      * Sets the production meta data. The meta data is filled as
      * grammar and parser are being built.
      */
-    void setMeta(production::Meta m) { *_meta = std::move(m); }
+    void setMeta(production::Meta m) { *_meta = m; }
 
     /**
      * For terminals, associates a sink with it. Any parsed data will be
      * forwarded to the sink.
      */
-    void setSink(ExpressionPtr sink) { _sink = std::move(sink); }
+    void setSink(Expression* sink) { _sink = sink; }
 
     /** Renames the production. */
     void setSymbol(std::string s) { _symbol = std::move(s); }
@@ -174,10 +174,10 @@ public:
     /**
      * For literals, returns the expression associated with it.
      */
-    virtual ExpressionPtr expression() const { return nullptr; }
+    virtual Expression* expression() const { return nullptr; }
 
     /** Returns any type associated with this production. */
-    virtual QualifiedTypePtr type() const { return nullptr; };
+    virtual QualifiedType* type() const { return nullptr; };
 
     /**
      * Returns a ID for this literal that's guaranteed to be globally unique
@@ -290,8 +290,8 @@ protected:
 private:
     std::string _symbol;
     Location _location;
-    ExpressionPtr _filter;
-    ExpressionPtr _sink;
+    Expression* _filter = nullptr;
+    Expression* _sink = nullptr;
     std::shared_ptr<production::Meta> _meta;
 };
 

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/boolean.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/boolean.h
@@ -20,11 +20,9 @@ namespace spicy::detail::codegen::production {
  */
 class Boolean : public Production {
 public:
-    Boolean(ASTContext* /* ctx */, const std::string& symbol, ExpressionPtr e, std::unique_ptr<Production> alt1,
+    Boolean(ASTContext* /* ctx */, const std::string& symbol, Expression* e, std::unique_ptr<Production> alt1,
             std::unique_ptr<Production> alt2, const hilti::Location& l = hilti::location::None)
-        : Production(symbol, l),
-          _expression(std::move(e)),
-          _alternatives(std::make_pair(std::move(alt1), std::move(alt2))) {}
+        : Production(symbol, l), _expression(e), _alternatives(std::make_pair(std::move(alt1), std::move(alt2))) {}
 
     std::pair<Production*, Production*> alternatives() const {
         return std::make_pair(_alternatives.first.get(), _alternatives.second.get());
@@ -44,7 +42,7 @@ public:
         return {{_alternatives.first.get()}, {_alternatives.second.get()}};
     }
 
-    ExpressionPtr expression() const final { return _expression; }
+    Expression* expression() const final { return _expression; }
 
     std::string dump() const final {
         return hilti::util::fmt("true: %s / false: %s", _alternatives.first->symbol(), _alternatives.second->symbol());
@@ -53,7 +51,7 @@ public:
     SPICY_PRODUCTION
 
 private:
-    ExpressionPtr _expression;
+    Expression* _expression = nullptr;
     std::pair<std::unique_ptr<Production>, std::unique_ptr<Production>> _alternatives;
 };
 

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/counter.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/counter.h
@@ -19,9 +19,9 @@ namespace spicy::detail::codegen::production {
  */
 class Counter : public Production {
 public:
-    Counter(ASTContext* /* ctx */, const std::string& symbol, ExpressionPtr e, std::unique_ptr<Production> body,
+    Counter(ASTContext* /* ctx */, const std::string& symbol, Expression* e, std::unique_ptr<Production> body,
             const Location& l = location::None)
-        : Production(symbol, l), _expression(std::move(e)), _body(std::move(body)) {}
+        : Production(symbol, l), _expression(e), _body(std::move(body)) {}
 
     auto body() const { return _body.get(); }
 
@@ -30,7 +30,7 @@ public:
     bool isLiteral() const final { return false; };
     bool isNullable() const final { return production::isNullable(rhss()); };
     bool isTerminal() const final { return false; };
-    ExpressionPtr expression() const final { return _expression; }
+    Expression* expression() const final { return _expression; }
 
     std::vector<std::vector<Production*>> rhss() const final { return {{_body.get()}}; };
     std::string dump() const override { return hilti::util::fmt("counter(%s): %s", _expression, _body->symbol()); }
@@ -38,7 +38,7 @@ public:
     SPICY_PRODUCTION
 
 private:
-    ExpressionPtr _expression;
+    Expression* _expression = nullptr;
     std::unique_ptr<Production> _body;
 };
 

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/ctor.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/ctor.h
@@ -16,7 +16,7 @@ namespace spicy::detail::codegen::production {
 /** A literal represented by a ctor. */
 class Ctor : public Production {
 public:
-    Ctor(ASTContext* ctx, const std::string& symbol, const CtorPtr& ctor, const Location& l = location::None)
+    Ctor(ASTContext* ctx, const std::string& symbol, hilti::Ctor* ctor, const Location& l = location::None)
         : Production(symbol, l), _ctor(hilti::expression::Ctor::create(ctx, ctor)) {
         assert(_ctor->isA<hilti::expression::Ctor>());
     }
@@ -30,8 +30,8 @@ public:
     bool isTerminal() const final { return true; };
 
     // std::vector<std::vector<Production*>> rhss() const final { return {}; };
-    ExpressionPtr expression() const final { return _ctor; }
-    QualifiedTypePtr type() const final { return _ctor->type(); };
+    Expression* expression() const final { return _ctor; }
+    QualifiedType* type() const final { return _ctor->type(); };
 
     int64_t tokenID() const final {
         return static_cast<int64_t>(Production::tokenID(hilti::util::fmt("%s|%s", *_ctor, *_ctor->type())));
@@ -42,7 +42,7 @@ public:
     SPICY_PRODUCTION
 
 private:
-    ExpressionPtr _ctor;
+    Expression* _ctor = nullptr;
 };
 
 } // namespace spicy::detail::codegen::production

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/enclosure.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/enclosure.h
@@ -32,7 +32,7 @@ public:
     bool isTerminal() const final { return false; };
 
     std::vector<std::vector<Production*>> rhss() const final { return {{_child.get()}}; };
-    QualifiedTypePtr type() const final { return _child->type(); };
+    QualifiedType* type() const final { return _child->type(); };
 
     std::string dump() const override { return _child->symbol(); }
 

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/reference.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/reference.h
@@ -36,8 +36,8 @@ public:
     bool isTerminal() const final { return _production->isTerminal(); };
 
     std::vector<std::vector<Production*>> rhss() const final { return _production->rhss(); }
-    ExpressionPtr expression() const final { return _production->expression(); }
-    QualifiedTypePtr type() const final { return _production->type(); }
+    Expression* expression() const final { return _production->expression(); }
+    QualifiedType* type() const final { return _production->type(); }
     int64_t tokenID() const final { return _production->tokenID(); };
 
     std::string dump() const final { return hilti::util::fmt("ref(%s)", _production->dump()); }

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/skip.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/skip.h
@@ -16,10 +16,10 @@ namespace spicy::detail::codegen::production {
 /** A production simply skipping input data. */
 class Skip : public Production {
 public:
-    Skip(ASTContext* ctx, const std::string& symbol, type::unit::item::FieldPtr field, std::unique_ptr<Production> ctor,
+    Skip(ASTContext* ctx, const std::string& symbol, type::unit::item::Field* field, std::unique_ptr<Production> ctor,
          const Location& l = location::None)
         : Production(symbol, l),
-          _field(std::move(field)),
+          _field(field),
           _ctor(std::move(ctor)),
           _void(QualifiedType::create(ctx, hilti::type::Void::create(ctx), hilti::Constness::Const)) {}
 
@@ -32,7 +32,7 @@ public:
     bool isNullable() const final { return false; };
     bool isTerminal() const final { return true; };
 
-    QualifiedTypePtr type() const final { return _void; };
+    QualifiedType* type() const final { return _void; };
 
     std::string dump() const override {
         return hilti::util::fmt("skip: %s", _ctor ? to_string(*_ctor) : _field->print());
@@ -41,9 +41,9 @@ public:
     SPICY_PRODUCTION
 
 private:
-    type::unit::item::FieldPtr _field; // stores a shallow copy of the reference passed into ctor
+    type::unit::item::Field* _field = nullptr; // stores a shallow copy of the reference passed into ctor
     std::unique_ptr<Production> _ctor;
-    QualifiedTypePtr _void;
+    QualifiedType* _void = nullptr;
 };
 
 } // namespace spicy::detail::codegen::production

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/switch.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/switch.h
@@ -19,15 +19,15 @@ namespace spicy::detail::codegen::production {
  */
 class Switch : public Production {
 public:
-    using Cases = std::vector<std::pair<std::vector<ExpressionPtr>, std::unique_ptr<Production>>>;
+    using Cases = std::vector<std::pair<std::vector<Expression*>, std::unique_ptr<Production>>>;
 
-    Switch(ASTContext* /* ctx */, const std::string& symbol, ExpressionPtr expr, Cases cases,
-           std::unique_ptr<Production> default_, AttributeSetPtr attributes, const Location& l = location::None)
+    Switch(ASTContext* /* ctx */, const std::string& symbol, Expression* expr, Cases cases,
+           std::unique_ptr<Production> default_, AttributeSet* attributes, const Location& l = location::None)
         : Production(symbol, l),
-          _expression(std::move(expr)),
+          _expression(expr),
           _cases(std::move(cases)),
           _default(std::move(default_)),
-          _attributes(std::move(attributes)) {}
+          _attributes(attributes) {}
 
     const auto& cases() const { return _cases; }
     const auto* default_() const { return _default.get(); }
@@ -42,7 +42,7 @@ public:
     bool isNullable() const final { return production::isNullable(rhss()); };
     bool isTerminal() const final { return false; };
 
-    ExpressionPtr expression() const final { return _expression; }
+    Expression* expression() const final { return _expression; }
     std::vector<std::vector<Production*>> rhss() const final;
 
     std::string dump() const final;
@@ -50,10 +50,10 @@ public:
     SPICY_PRODUCTION
 
 private:
-    ExpressionPtr _expression;
+    Expression* _expression = nullptr;
     Cases _cases;
     std::unique_ptr<Production> _default;
-    AttributeSetPtr _attributes;
+    AttributeSet* _attributes = nullptr;
 };
 
 } // namespace spicy::detail::codegen::production

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/type-literal.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/type-literal.h
@@ -20,8 +20,8 @@ namespace spicy::detail::codegen::production {
  */
 class TypeLiteral : public Production {
 public:
-    TypeLiteral(ASTContext* ctx, const std::string& symbol, QualifiedTypePtr type, const Location& l = location::None)
-        : Production(symbol, l), _type(std::move(type)), _expr(hilti::expression::Type_::create(ctx, _type)) {}
+    TypeLiteral(ASTContext* ctx, const std::string& symbol, QualifiedType* type, const Location& l = location::None)
+        : Production(symbol, l), _type(type), _expr(hilti::expression::Type_::create(ctx, _type)) {}
 
     bool isAtomic() const final { return true; };
     bool isEodOk() const final { return false; };
@@ -29,8 +29,8 @@ public:
     bool isNullable() const final { return false; };
     bool isTerminal() const final { return true; };
 
-    ExpressionPtr expression() const final { return _expr; }
-    QualifiedTypePtr type() const final { return _type; };
+    Expression* expression() const final { return _expr; }
+    QualifiedType* type() const final { return _type; };
     int64_t tokenID() const final { return static_cast<int64_t>(Production::tokenID(_type->print())); }
 
     std::string dump() const final { return _type->print(); }
@@ -38,8 +38,8 @@ public:
     SPICY_PRODUCTION
 
 private:
-    QualifiedTypePtr _type;
-    ExpressionPtr _expr;
+    QualifiedType* _type = nullptr;
+    Expression* _expr = nullptr;
 };
 
 } // namespace spicy::detail::codegen::production

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/unit.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/unit.h
@@ -23,10 +23,10 @@ namespace spicy::detail::codegen::production {
  */
 class Unit : public Production {
 public:
-    Unit(ASTContext* ctx, const std::string& symbol, type::UnitPtr type, Expressions args,
+    Unit(ASTContext* ctx, const std::string& symbol, type::Unit* type, Expressions args,
          std::vector<std::unique_ptr<Production>> fields, const Location& l = location::None)
         : Production(symbol, l),
-          _type(QualifiedType::create(ctx, std::move(type), hilti::Constness::Const)),
+          _type(QualifiedType::create(ctx, type, hilti::Constness::Const)),
           _args(std::move(args)),
           _fields(std::move(fields)) {}
 
@@ -44,7 +44,7 @@ public:
         return {hilti::util::transform(_fields, [](const auto& p) { return p.get(); })};
     }
 
-    QualifiedTypePtr type() const final { return _type; };
+    QualifiedType* type() const final { return _type; };
 
     std::string dump() const final {
         return hilti::util::join(hilti::util::transform(_fields, [](const auto& p) { return p->symbol(); }), " ");
@@ -53,7 +53,7 @@ public:
     SPICY_PRODUCTION
 
 private:
-    QualifiedTypePtr _type;
+    QualifiedType* _type = nullptr;
     Expressions _args;
     std::vector<std::unique_ptr<Production>> _fields;
 };

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/variable.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/variable.h
@@ -19,9 +19,8 @@ namespace spicy::detail::codegen::production {
  */
 class Variable : public Production {
 public:
-    Variable(ASTContext* /* ctx */, const std::string& symbol, QualifiedTypePtr type,
-             const Location& l = location::None)
-        : Production(symbol, l), _type(std::move(type)) {}
+    Variable(ASTContext* /* ctx */, const std::string& symbol, QualifiedType* type, const Location& l = location::None)
+        : Production(symbol, l), _type(type) {}
 
     bool isAtomic() const final { return true; };
     bool isEodOk() const final { return false; };
@@ -29,14 +28,14 @@ public:
     bool isNullable() const final { return false; };
     bool isTerminal() const final { return true; };
 
-    QualifiedTypePtr type() const final { return _type; };
+    QualifiedType* type() const final { return _type; };
 
     std::string dump() const final { return hilti::util::fmt("%s", *_type); }
 
     SPICY_PRODUCTION
 
 private:
-    QualifiedTypePtr _type;
+    QualifiedType* _type = nullptr;
 };
 
 } // namespace spicy::detail::codegen::production

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/while.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/while.h
@@ -23,9 +23,9 @@ public:
     /**
      * Constructor for a while-loop using an expression as the condition for termination.
      */
-    While(ASTContext* /* ctx */, const std::string& symbol, ExpressionPtr e, std::unique_ptr<Production> body,
+    While(ASTContext* /* ctx */, const std::string& symbol, Expression* e, std::unique_ptr<Production> body,
           const Location& l = location::None)
-        : Production(symbol, l), _body(std::move(body)), _expression(std::move(e)) {}
+        : Production(symbol, l), _body(std::move(body)), _expression(e) {}
 
     /**
      * Constructor for a while-loop using look-ahead as the condition for
@@ -70,7 +70,7 @@ public:
     }
 
     /** Returns the loop expression if passed into the corresponding constructor. */
-    ExpressionPtr expression() const final { return _expression; }
+    Expression* expression() const final { return _expression; }
 
     std::string dump() const final;
 
@@ -78,7 +78,7 @@ public:
 
 private:
     std::unique_ptr<Production> _body;
-    ExpressionPtr _expression;
+    Expression* _expression = nullptr;
     std::unique_ptr<Production> _body_for_grammar;
 };
 

--- a/spicy/toolchain/include/compiler/detail/coercer.h
+++ b/spicy/toolchain/include/compiler/detail/coercer.h
@@ -9,11 +9,9 @@
 namespace spicy::detail::coercer {
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-CtorPtr coerceCtor(Builder* builder, const CtorPtr& c, const QualifiedTypePtr& dst,
-                   bitmask<hilti::CoercionStyle> style);
+Ctor* coerceCtor(Builder* builder, Ctor* c, QualifiedType* dst, bitmask<hilti::CoercionStyle> style);
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-QualifiedTypePtr coerceType(Builder* builder, const QualifiedTypePtr& t, const QualifiedTypePtr& dst,
-                            bitmask<hilti::CoercionStyle> style);
+QualifiedType* coerceType(Builder* builder, QualifiedType* t, QualifiedType* dst, bitmask<hilti::CoercionStyle> style);
 
 } // namespace spicy::detail::coercer

--- a/spicy/toolchain/include/compiler/detail/parser/driver.h
+++ b/spicy/toolchain/include/compiler/detail/parser/driver.h
@@ -56,7 +56,8 @@ namespace detail::parser {
  *
  * Returns: The parsed AST, or a corresponding error if parsing failed.
  */
-extern hilti::Result<ModulePtr> parseSource(Builder* builder, std::istream& in, const std::string& filename);
+extern hilti::Result<hilti::declaration::Module*> parseSource(Builder* builder, std::istream& in,
+                                                              const std::string& filename);
 
 /**
  * Parses a single Spicy expression into a corresponding AST.
@@ -66,8 +67,7 @@ extern hilti::Result<ModulePtr> parseSource(Builder* builder, std::istream& in, 
  *
  * Returns: The parsed expression, or a corresponding error if parsing failed.
  */
-extern hilti::Result<ExpressionPtr> parseExpression(Builder* builder, const std::string& expr,
-                                                    const Meta& meta = Meta());
+extern hilti::Result<Expression*> parseExpression(Builder* builder, const std::string& expr, const Meta& meta = Meta());
 
 class Parser;
 class Scanner;
@@ -77,9 +77,8 @@ class Driver {
 public:
     Driver() : _preprocessor(spicy::configuration().preprocessor_constants) {}
 
-    hilti::Result<ModulePtr> parse(Builder* builder, std::istream& in, const std::string& filename);
-    hilti::Result<ExpressionPtr> parseExpression(Builder* builder, const std::string& expression,
-                                                 const Meta& m = Meta());
+    hilti::Result<hilti::declaration::Module*> parse(Builder* builder, std::istream& in, const std::string& filename);
+    hilti::Result<Expression*> parseExpression(Builder* builder, const std::string& expression, const Meta& m = Meta());
 
     Scanner* scanner() const { return _scanner; }
     Parser* parser() const { return _parser; }
@@ -100,8 +99,8 @@ public:
     void disableHookIDMode();
     void enableNewKeywordMode();
     void disableNewKeywordMode();
-    void setDestinationModule(const ModulePtr& m) { _module = m; }
-    void setDestinationExpression(const ExpressionPtr& e) { _expression = e; }
+    void setDestinationModule(hilti::declaration::Module* m) { _module = m; }
+    void setDestinationExpression(Expression* e) { _expression = e; }
     int nextToken();
     void processPreprocessorLine(const std::string_view& directive, const std::string_view& expression, const Meta& m);
 
@@ -115,8 +114,8 @@ public:
 private:
     Builder* _builder = nullptr;
     hilti::DocString _doc;
-    ModulePtr _module;
-    ExpressionPtr _expression;
+    hilti::declaration::Module* _module = nullptr;
+    Expression* _expression = nullptr;
     std::string _filename;
     int _line{};
     Parser* _parser = nullptr;

--- a/spicy/toolchain/include/compiler/detail/printer.h
+++ b/spicy/toolchain/include/compiler/detail/printer.h
@@ -16,6 +16,6 @@ namespace spicy::detail::printer {
  * where we don't, in which case the caller should fall back on HILTI-side node
  * printing.
  */
-bool print(hilti::printer::Stream& stream, const NodePtr& root);
+bool print(hilti::printer::Stream& stream, Node* root);
 
 } // namespace spicy::detail::printer

--- a/spicy/toolchain/include/compiler/detail/resolver.h
+++ b/spicy/toolchain/include/compiler/detail/resolver.h
@@ -7,6 +7,6 @@
 namespace spicy::detail::resolver {
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-bool resolve(Builder* builder, const NodePtr& root);
+bool resolve(Builder* builder, Node* root);
 
 } // namespace spicy::detail::resolver

--- a/spicy/toolchain/include/compiler/detail/scope-builder.h
+++ b/spicy/toolchain/include/compiler/detail/scope-builder.h
@@ -9,6 +9,6 @@
 namespace spicy::detail::scope_builder {
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-void build(Builder* builder, const ASTRootPtr& root);
+void build(Builder* builder, hilti::ASTRoot* root);
 
 } // namespace spicy::detail::scope_builder

--- a/spicy/toolchain/include/compiler/detail/validator.h
+++ b/spicy/toolchain/include/compiler/detail/validator.h
@@ -7,9 +7,9 @@
 namespace spicy::detail::validator {
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-void validatePre(Builder* builder, const ASTRootPtr& root);
+void validatePre(Builder* builder, hilti::ASTRoot* root);
 
 /** Implements the corresponding functionality for the Spicy compiler plugin. */
-void validatePost(Builder* builder, const ASTRootPtr& root);
+void validatePost(Builder* builder, hilti::ASTRoot* root);
 
 } // namespace spicy::detail::validator

--- a/spicy/toolchain/src/ast/builder/builder.cc
+++ b/spicy/toolchain/src/ast/builder/builder.cc
@@ -5,7 +5,7 @@
 
 using namespace spicy;
 
-hilti::Result<hilti::ExpressionPtr> builder::parseExpression(Builder* builder, const std::string& expr,
-                                                             const hilti::Meta& meta) {
+hilti::Result<hilti::Expression*> builder::parseExpression(Builder* builder, const std::string& expr,
+                                                           const hilti::Meta& meta) {
     return detail::parser::parseExpression(builder, expr, meta);
 }

--- a/spicy/toolchain/src/ast/operators/unit.cc
+++ b/spicy/toolchain/src/ast/operators/unit.cc
@@ -9,7 +9,7 @@
 using namespace spicy;
 using namespace hilti::operator_;
 
-spicy::unit::MemberCall::MemberCall(const type::unit::item::FieldPtr& field)
+spicy::unit::MemberCall::MemberCall(type::unit::item::Field* field)
     : hilti::Operator(field->meta(), false), _field(field) {}
 
 spicy::unit::MemberCall::~MemberCall() {}
@@ -32,9 +32,9 @@ hilti::operator_::Signature spicy::unit::MemberCall::signature(hilti::Builder* b
     };
 }
 
-hilti::Result<hilti::ResolvedOperatorPtr> spicy::unit::MemberCall::instantiate(hilti::Builder* builder,
-                                                                               Expressions operands,
-                                                                               const Meta& meta) const {
+hilti::Result<hilti::expression::ResolvedOperator*> spicy::unit::MemberCall::instantiate(hilti::Builder* builder,
+                                                                                         Expressions operands,
+                                                                                         Meta meta) const {
     auto field = MemberCall::field();
     assert(field);
 
@@ -43,8 +43,8 @@ hilti::Result<hilti::ResolvedOperatorPtr> spicy::unit::MemberCall::instantiate(h
     auto args = operands[2];
     auto result = field->itemType()->type()->as<hilti::type::Function>()->result();
 
-    return {operator_::unit::MemberCall::create(builder->context(), this, result,
-                                                {std::move(callee), std::move(member), std::move(args)}, meta)};
+    return {
+        operator_::unit::MemberCall::create(builder->context(), this, result, {callee, member, args}, std::move(meta))};
 }
 
 namespace {
@@ -60,7 +60,7 @@ void checkName(hilti::expression::ResolvedOperator* op) {
 }
 
 
-QualifiedTypePtr itemType(hilti::Builder* builder, const Expressions& operands) {
+QualifiedType* itemType(hilti::Builder* builder, const Expressions& operands) {
     auto unit = operands[0]->type()->type()->as<type::Unit>();
     auto id = operands[1]->as<hilti::expression::Member>()->id();
 
@@ -72,7 +72,7 @@ QualifiedTypePtr itemType(hilti::Builder* builder, const Expressions& operands) 
         return builder->qualifiedType(builder->typeAuto(), hilti::Constness::Const);
 }
 
-QualifiedTypePtr contextResult(hilti::Builder* builder, const Expressions& operands, hilti::Constness constness) {
+QualifiedType* contextResult(hilti::Builder* builder, const Expressions& operands, hilti::Constness constness) {
     if ( operands.empty() )
         return builder->qualifiedType(builder->typeDocOnly("<context>&"), constness);
 
@@ -123,7 +123,7 @@ triggers an exception.
         };
     }
 
-    QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return itemType(builder, operands)->recreateAsLhs(builder->context());
     }
 
@@ -152,7 +152,7 @@ triggers an exception.
         };
     }
 
-    QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return itemType(builder, operands)->recreateAsConst(builder->context());
     }
 
@@ -183,7 +183,7 @@ exception differently).
         };
     }
 
-    QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return itemType(builder, operands)->recreateAsLhs(builder->context());
     }
 
@@ -466,7 +466,7 @@ Returns a reference to the ``%context`` instance associated with the unit.
         };
     }
 
-    QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return contextResult(builder, operands, hilti::Constness::Const);
     }
 
@@ -490,7 +490,7 @@ Returns a reference to the ``%context`` instance associated with the unit.
         };
     }
 
-    QualifiedTypePtr result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
+    QualifiedType* result(hilti::Builder* builder, const Expressions& operands, const Meta& meta) const final {
         return contextResult(builder, operands, hilti::Constness::Mutable);
     }
 

--- a/spicy/toolchain/src/ast/types/unit-items/field.cc
+++ b/spicy/toolchain/src/ast/types/unit-items/field.cc
@@ -11,7 +11,7 @@
 using namespace spicy;
 using namespace spicy::detail;
 
-std::optional<std::pair<ExpressionPtr, QualifiedTypePtr>> type::unit::item::Field::convertExpression() const {
+std::optional<std::pair<Expression*, QualifiedType*>> type::unit::item::Field::convertExpression() const {
     if ( auto convert = attributes()->find("&convert") )
         return std::make_pair(*convert->valueAsExpression(), nullptr);
 
@@ -22,13 +22,13 @@ std::optional<std::pair<ExpressionPtr, QualifiedTypePtr>> type::unit::item::Fiel
 
     if ( auto x = t->type()->tryAs<type::Unit>() ) {
         if ( auto convert = x->attributes()->find("&convert") )
-            return std::make_pair(*convert->valueAsExpression(), std::move(t));
+            return std::make_pair(*convert->valueAsExpression(), t);
     }
 
     return {};
 }
 
-void type::unit::item::Field::setDDType(ASTContext* ctx, const QualifiedTypePtr& t) {
+void type::unit::item::Field::setDDType(ASTContext* ctx, QualifiedType* t) {
     setChild(ctx, 0, hilti::expression::Keyword::createDollarDollarDeclaration(ctx, t));
 }
 
@@ -37,7 +37,7 @@ struct SizeVisitor : hilti::visitor::PreOrder {
 
     Builder* builder;
     const spicy::type::unit::item::Field& field;
-    ExpressionPtr result;
+    Expression* result = nullptr;
 
     void operator()(hilti::type::Address* n) final {
         if ( field.attributes()->has("&ipv4") )
@@ -59,7 +59,7 @@ struct SizeVisitor : hilti::visitor::PreOrder {
     }
 };
 
-ExpressionPtr spicy::type::unit::item::Field::size(ASTContext* ctx) const {
+Expression* spicy::type::unit::item::Field::size(ASTContext* ctx) const {
     Builder builder(ctx);
 
     if ( const auto& size = attributes()->find("&size") )

--- a/spicy/toolchain/src/ast/types/unit-items/switch.cc
+++ b/spicy/toolchain/src/ast/types/unit-items/switch.cc
@@ -20,8 +20,8 @@ bool spicy::type::unit::item::Switch::hasNoFields() const {
     return true;
 }
 
-spicy::type::unit::item::switch_::CasePtr spicy::type::unit::item::Switch::case_(
-    const type::unit::item::FieldPtr& field) const {
+spicy::type::unit::item::switch_::Case* spicy::type::unit::item::Switch::case_(
+    const type::unit::item::Field* field) const {
     for ( const auto& c : cases() ) {
         for ( const auto& i : c->items() ) {
             if ( i == field )

--- a/spicy/toolchain/src/ast/types/unit.cc
+++ b/spicy/toolchain/src/ast/types/unit.cc
@@ -16,7 +16,7 @@
 using namespace spicy;
 using namespace spicy::type;
 
-static NodePtr itemByNameBackend(const std::shared_ptr<spicy::type::unit::Item>& i, const ID& id) {
+static Node* itemByNameBackend(spicy::type::unit::Item* i, const ID& id) {
     if ( i->id() == id &&
          (i->isA<unit::item::Field>() || i->isA<unit::item::Variable>() || i->isA<unit::item::Sink>()) )
         return i;
@@ -33,7 +33,7 @@ static NodePtr itemByNameBackend(const std::shared_ptr<spicy::type::unit::Item>&
     return {};
 }
 
-unit::item::PropertyPtr Unit::propertyItem(const std::string& name) const {
+unit::item::Property* Unit::propertyItem(const std::string& name) const {
     for ( const auto& i : items<unit::item::Property>() ) {
         if ( i->id() == name )
             return i;
@@ -75,7 +75,7 @@ bool Unit::isResolved(node::CycleDetector* cd) const {
     return true;
 }
 
-unit::ItemPtr Unit::itemByName(const ID& id) const {
+unit::Item* Unit::itemByName(const ID& id) const {
     for ( const auto& i : items() ) {
         if ( auto x = itemByNameBackend(i, id) )
             return x->as<unit::Item>();
@@ -84,7 +84,7 @@ unit::ItemPtr Unit::itemByName(const ID& id) const {
     return {};
 }
 
-static std::pair<unit::item::FieldPtr, std::shared_ptr<hilti::type::bitfield::BitRange>> findRangeInAnonymousBitField(
+static std::pair<unit::item::Field*, hilti::type::bitfield::BitRange*> findRangeInAnonymousBitField(
     const hilti::node::Set<type::unit::Item>& items, const ID& id) {
     for ( const auto& item : items ) {
         if ( auto field = item->tryAs<type::unit::item::Field>() ) {
@@ -109,8 +109,7 @@ static std::pair<unit::item::FieldPtr, std::shared_ptr<hilti::type::bitfield::Bi
     return {};
 }
 
-std::pair<unit::item::FieldPtr, std::shared_ptr<hilti::type::bitfield::BitRange>> Unit::findRangeInAnonymousBitField(
-    const ID& id) const {
+std::pair<unit::item::Field*, hilti::type::bitfield::BitRange*> Unit::findRangeInAnonymousBitField(const ID& id) const {
     return ::findRangeInAnonymousBitField(items(), id);
 }
 
@@ -154,5 +153,5 @@ void Unit::_setSelf(ASTContext* ctx) {
 
     auto decl = hilti::declaration::Expression::create(ctx, ID("self"), self, {}, meta());
 
-    setChild(ctx, 0, std::move(decl));
+    setChild(ctx, 0, decl);
 }

--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -47,7 +47,7 @@ struct VisitorPass1 : public visitor::MutatingPostOrder {
         : visitor::MutatingPostOrder(cg->builder(), logging::debug::CodeGen), cg(cg), module(module) {}
 
     CodeGen* cg;
-    hilti::declaration::Module* module;
+    hilti::declaration::Module* module = nullptr;
     ID module_id = ID("<no module>");
 
     void operator()(hilti::declaration::Type* n) final {
@@ -72,7 +72,7 @@ struct VisitorPass1 : public visitor::MutatingPostOrder {
 
         n->setType(context(), qstruct);
         n->addAttribute(context(), builder()->attribute("&on-heap"));
-        cg->recordTypeMapping(u.get(), struct_);
+        cg->recordTypeMapping(u, struct_);
 
         recordChange(n, "replaced unit type with struct");
     }
@@ -91,10 +91,10 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
         : visitor::MutatingPostOrder(cg->builder(), logging::debug::CodeGen), cg(cg), module(module) {}
 
     CodeGen* cg;
-    hilti::declaration::Module* module;
+    hilti::declaration::Module* module = nullptr;
     ID module_id = ID("<no module>");
 
-    ExpressionPtr argument(const ExpressionPtr& args, unsigned int i, std::optional<ExpressionPtr> def = {}) {
+    Expression* argument(Expression* args, unsigned int i, std::optional<Expression*> def = {}) {
         auto ctor = args->as<hilti::expression::Ctor>()->ctor();
 
         if ( auto x = ctor->tryAs<hilti::ctor::Coerced>() )
@@ -122,7 +122,7 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
             cg->compileHook(*unit_type->as<type::Unit>(), n->hook()->id(), {}, hook->isForEach(), hook->isDebug(),
                             hook->ftype()->parameters(), hook->body(), hook->priority(), n->meta());
 
-        replaceNode(n, std::move(func));
+        replaceNode(n, func);
     }
 
     void operator()(operator_::unit::Unset* n) final {
@@ -182,7 +182,7 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
         auto direction = argument(n->op2(), 1, builder()->id("spicy::Direction::Forward"));
         auto i = argument(n->op2(), 2, builder()->null());
         auto x = builder()->call("spicy_rt::unit_find", {begin, end, i, needle, direction});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::unit::ContextConst* n) final {
@@ -197,7 +197,7 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
 
     void operator()(operator_::unit::Backtrack* n) final {
         auto x = builder()->call("spicy_rt::backtrack", {});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(spicy::ctor::Unit* n) final {
@@ -208,94 +208,94 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
 
     void operator()(operator_::unit::ConnectFilter* n) final {
         auto x = builder()->call("spicy_rt::filter_connect", {n->op0(), argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::unit::Forward* n) final {
         auto x = builder()->call("spicy_rt::filter_forward", {n->op0(), argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::unit::ForwardEod* n) final {
         auto x = builder()->call("spicy_rt::filter_forward_eod", {n->op0()});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Close* n) final {
         auto x = builder()->memberCall(n->op0(), "close");
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Connect* n) final {
         auto x = builder()->memberCall(n->op0(), "connect", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::ConnectMIMETypeBytes* n) final {
         auto x = builder()->memberCall(n->op0(), "connect_mime_type", {argument(n->op2(), 0), builder()->scope()});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::ConnectMIMETypeString* n) final {
         auto x = builder()->memberCall(n->op0(), "connect_mime_type", {argument(n->op2(), 0), builder()->scope()});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::ConnectFilter* n) final {
         auto x = builder()->memberCall(n->op0(), "connect_filter", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Gap* n) final {
         auto x = builder()->memberCall(n->op0(), "gap", {argument(n->op2(), 0), argument(n->op2(), 1)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SequenceNumber* n) final {
         auto x = builder()->memberCall(n->op0(), "sequence_number");
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SetAutoTrim* n) final {
         auto x = builder()->memberCall(n->op0(), "set_auto_trim", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SetInitialSequenceNumber* n) final {
         auto x = builder()->memberCall(n->op0(), "set_initial_sequence_number", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SetPolicy* n) final {
         auto x = builder()->memberCall(n->op0(), "set_policy", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SizeValue* n) final {
         auto x = builder()->memberCall(n->op0(), "size");
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::SizeReference* n) final {
         auto x = builder()->memberCall(n->op0(), "size");
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Skip* n) final {
         auto x = builder()->memberCall(n->op0(), "skip", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Trim* n) final {
         auto x = builder()->memberCall(n->op0(), "trim", {argument(n->op2(), 0)});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Write* n) final {
         auto x = builder()->memberCall(n->op0(), "write",
                                        {argument(n->op2(), 0), argument(n->op2(), 1, builder()->null()),
                                         argument(n->op2(), 2, builder()->null())});
-        replaceNode(n, std::move(x));
+        replaceNode(n, x);
     }
 
     void operator()(statement::Print* n) final {
@@ -370,7 +370,7 @@ struct VisitorPass3 : public visitor::MutatingPostOrder {
         : visitor::MutatingPostOrder(cg->builder(), logging::debug::CodeGen), cg(cg), module(module) {}
 
     CodeGen* cg;
-    hilti::declaration::Module* module;
+    hilti::declaration::Module* module = nullptr;
 
     void operator()(hilti::ctor::Coerced* n) final {
         // Replace coercions with their final result, so that HILTI will not
@@ -397,24 +397,24 @@ struct VisitorPass3 : public visitor::MutatingPostOrder {
 
 } // anonymous namespace
 
-bool CodeGen::_compileModule(const ModulePtr& module, int pass) {
+bool CodeGen::_compileModule(hilti::declaration::Module* module, int pass) {
     switch ( pass ) {
         case 1: {
-            auto v1 = VisitorPass1(this, module.get());
+            auto v1 = VisitorPass1(this, module);
             visitor::visit(v1, module, ".spicy");
-            _updateDeclarations(&v1, module.get());
+            _updateDeclarations(&v1, module);
             return v1.isModified();
         }
 
         case 2: {
             bool is_modified = false;
 
-            auto v2 = VisitorPass2(this, module.get());
+            auto v2 = VisitorPass2(this, module);
             while ( true ) {
                 v2.clearModified();
 
                 visitor::visit(v2, module, ".spicy");
-                _updateDeclarations(&v2, module.get());
+                _updateDeclarations(&v2, module);
 
                 if ( v2.isModified() )
                     is_modified = true;
@@ -427,9 +427,9 @@ bool CodeGen::_compileModule(const ModulePtr& module, int pass) {
             module->add(context(), builder()->import("hilti"));
             module->add(context(), builder()->import("spicy_rt"));
 
-            auto v3 = VisitorPass3(this, module.get());
+            auto v3 = VisitorPass3(this, module);
             visitor::visit(v3, module, ".spicy");
-            _updateDeclarations(&v3, module.get());
+            _updateDeclarations(&v3, module);
 
             if ( driver()->lookupUnit(module->uid()) ) {
                 driver()->updateProcessExtension(module->uid(), ".hlt");
@@ -461,7 +461,7 @@ void CodeGen::_updateDeclarations(visitor::MutatingPostOrder* v, hilti::declarat
     v->recordChange("new declarations added");
 }
 
-bool CodeGen::compileAST(const ASTRootPtr& root) {
+bool CodeGen::compileAST(hilti::ASTRoot* root) {
     hilti::util::timing::Collector _("spicy/compiler/codegen");
 
     // Find all the Spicy modules and transform them one by one. We do this in
@@ -476,12 +476,12 @@ bool CodeGen::compileAST(const ASTRootPtr& root) {
 
         void operator()(hilti::declaration::Module* n) final {
             if ( n->uid().process_extension == ".spicy" ) {
-                auto module = n->as<hilti::declaration::Module>();
+                auto module = n;
                 HILTI_DEBUG(logging::debug::CodeGen,
                             fmt("[pass %d] processing module '%s'", pass, module->canonicalID()));
                 hilti::logging::DebugPushIndent _(logging::debug::CodeGen);
 
-                cg->_hilti_module = module.get();
+                cg->_hilti_module = module;
                 modified = modified | cg->_compileModule(module, pass);
                 cg->_hilti_module = nullptr;
             }
@@ -499,15 +499,14 @@ bool CodeGen::compileAST(const ASTRootPtr& root) {
     return modified;
 }
 
-std::shared_ptr<hilti::declaration::Function> CodeGen::compileHook(
-    const type::Unit& unit, const ID& id, std::shared_ptr<type::unit::item::Field> field, bool foreach, bool debug,
-    hilti::type::function::Parameters params, const StatementPtr& body, const ExpressionPtr& priority,
-    const hilti::Meta& meta) {
+hilti::declaration::Function* CodeGen::compileHook(const type::Unit& unit, const ID& id, type::unit::item::Field* field,
+                                                   bool foreach, bool debug, hilti::type::function::Parameters params,
+                                                   Statement* body, Expression* priority, const hilti::Meta& meta) {
     if ( debug && ! options().debug )
         return {};
 
     bool is_container = false;
-    QualifiedTypePtr original_field_type;
+    QualifiedType* original_field_type = nullptr;
 
     if ( field ) {
         if ( ! field->parseType()->type()->isA<hilti::type::Void>() && ! field->isSkip() )
@@ -545,7 +544,7 @@ std::shared_ptr<hilti::declaration::Function> CodeGen::compileHook(
     }
 
     std::string hid;
-    QualifiedTypePtr result;
+    QualifiedType* result = nullptr;
 
     if ( id.local().str() == "0x25_print" ) {
         // Special-case: We simply translate this into HITLI's __str__ hook.
@@ -563,7 +562,7 @@ std::shared_ptr<hilti::declaration::Function> CodeGen::compileHook(
 
     auto ft = builder()->typeFunction(result, params, hilti::type::function::Flavor::Hook, meta);
 
-    AttributeSetPtr attrs = builder()->attributeSet();
+    AttributeSet* attrs = builder()->attributeSet();
 
     if ( priority )
         attrs->add(context(), builder()->attribute("&priority", priority));

--- a/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
@@ -22,13 +22,13 @@ struct ProductionFactory {
     ProductionFactory(CodeGen* cg, codegen::GrammarBuilder* gb, Grammar* g) : cg(cg), grammar(g) {}
 
     const auto& currentField() { return fields.back(); }
-    void pushField(spicy::type::unit::item::FieldPtr f) { fields.emplace_back(std::move(f)); }
+    void pushField(spicy::type::unit::item::Field* f) { fields.emplace_back(f); }
     void popField() { fields.pop_back(); }
     bool haveField() { return ! fields.empty(); }
 
-    std::unique_ptr<Production> createProduction(const NodePtr& node);
+    std::unique_ptr<Production> createProduction(Node* node);
 
-    std::vector<spicy::type::unit::item::FieldPtr> fields;
+    std::vector<spicy::type::unit::item::Field*> fields;
     hilti::util::Cache<ID, Production*> cache;
     CodeGen* cg;
     Grammar* grammar;
@@ -43,7 +43,7 @@ struct Visitor : public visitor::PreOrder {
 
     auto context() const { return pf->cg->context(); }
 
-    std::unique_ptr<Production> productionForItem(const NodePtr& item) {
+    std::unique_ptr<Production> productionForItem(Node* item) {
         auto field = item->tryAs<spicy::type::unit::item::Field>();
         if ( field )
             pf->pushField(field);
@@ -56,11 +56,11 @@ struct Visitor : public visitor::PreOrder {
         return p;
     }
 
-    std::unique_ptr<Production> productionForCtor(const CtorPtr& c, const ID& id) {
+    std::unique_ptr<Production> productionForCtor(Ctor* c, const ID& id) {
         return std::make_unique<production::Ctor>(context(), pf->cg->uniquer()->get(id), c, c->meta().location());
     }
 
-    std::unique_ptr<Production> productionForType(const QualifiedTypePtr& t, const ID& id) {
+    std::unique_ptr<Production> productionForType(QualifiedType* t, const ID& id) {
         if ( auto prod = pf->createProduction(t->type()) )
             return prod;
         else
@@ -69,7 +69,7 @@ struct Visitor : public visitor::PreOrder {
                                                           t->meta().location());
     }
 
-    std::unique_ptr<Production> productionForLoop(std::unique_ptr<Production> sub, const NodePtr& n) {
+    std::unique_ptr<Production> productionForLoop(std::unique_ptr<Production> sub, Node* n) {
         const auto& loc = n->location();
         const auto& field = pf->currentField();
         auto id = pf->cg->uniquer()->get(field->id());
@@ -89,7 +89,7 @@ struct Visitor : public visitor::PreOrder {
             m.setField(field, false);
 
         m.setContainer(field);
-        sub->setMeta(std::move(m));
+        sub->setMeta(m);
 
         if ( repeat && ! repeat->type()->type()->isA<hilti::type::Null>() )
             return std::make_unique<production::Counter>(context(), id, repeat, std::move(sub), loc);
@@ -118,7 +118,7 @@ struct Visitor : public visitor::PreOrder {
         c->preprocessLookAhead(pf->cg->context(), pf->grammar);
         auto me = c->meta();
         me.setField(field, false);
-        c->setMeta(std::move(me));
+        c->setMeta(me);
         return std::move(c);
     }
 
@@ -131,10 +131,9 @@ struct Visitor : public visitor::PreOrder {
                 auto prod = productionForCtor(ctor, n->id());
                 auto m = prod->meta();
                 m.setField(pf->currentField(), true);
-                prod->setMeta(std::move(m));
-                skip = std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()),
-                                                          n->as<type::unit::item::Field>(), std::move(prod),
-                                                          n->meta().location());
+                prod->setMeta(m);
+                skip = std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()), n,
+                                                          std::move(prod), n->meta().location());
             }
 
             else if ( n->item() ) {
@@ -142,9 +141,8 @@ struct Visitor : public visitor::PreOrder {
             }
 
             else if ( n->size(context()) )
-                skip =
-                    std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()),
-                                                       n->as<type::unit::item::Field>(), nullptr, n->meta().location());
+                skip = std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()), n, nullptr,
+                                                          n->meta().location());
 
             else if ( n->parseType()->type()->isA<hilti::type::Bytes>() ) {
                 // Bytes with fixed size already handled above.
@@ -153,8 +151,7 @@ struct Visitor : public visitor::PreOrder {
                 auto until_including_attr = n->attributes()->find("&until-including");
 
                 if ( eod_attr || until_attr || until_including_attr )
-                    skip = std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()),
-                                                              n->as<type::unit::item::Field>(), nullptr,
+                    skip = std::make_unique<production::Skip>(context(), pf->cg->uniquer()->get(n->id()), n, nullptr,
                                                               n->meta().location());
             }
 
@@ -178,14 +175,13 @@ struct Visitor : public visitor::PreOrder {
             prod = productionForCtor(c, n->id());
 
             if ( n->isContainer() )
-                prod = productionForLoop(std::move(prod), n->as<Node>());
+                prod = productionForLoop(std::move(prod), n);
         }
         else if ( n->item() ) {
-            auto sub = productionForItem(n->as<spicy::type::unit::item::Field>()->item());
-            auto m = sub->meta();
+            auto sub = productionForItem(n->item());
 
             if ( n->isContainer() )
-                prod = productionForLoop(std::move(sub), n->as<Node>());
+                prod = productionForLoop(std::move(sub), n);
             else {
                 if ( sub->meta().field() )
                     sub->meta().field()->setForwarding(true);
@@ -199,18 +195,17 @@ struct Visitor : public visitor::PreOrder {
 
         auto m = prod->meta();
         m.setField(pf->currentField(), true);
-        prod->setMeta(std::move(m));
+        prod->setMeta(m);
 
         result = std::move(prod);
     }
 
     void operator()(spicy::type::unit::item::Switch* n) final {
-        auto productionForCase = [this](const std::shared_ptr<spicy::type::unit::item::switch_::Case>& c,
-                                        const std::string& label) {
+        auto productionForCase = [this](spicy::type::unit::item::switch_::Case* c, const std::string& label) {
             std::vector<std::unique_ptr<Production>> prods;
 
             for ( const auto& n : c->items() ) {
-                if ( auto prod = productionForItem(NodePtr(n)) )
+                if ( auto prod = productionForItem(n) )
                     prods.push_back(std::move(prod));
             }
 
@@ -225,7 +220,7 @@ struct Visitor : public visitor::PreOrder {
             std::unique_ptr<Production> default_;
             int i = 0;
 
-            for ( const auto& c : n->as<spicy::type::unit::item::Switch>()->cases() ) {
+            for ( const auto& c : n->cases() ) {
                 if ( c->isDefault() )
                     default_ = productionForCase(c, fmt("%s_default", switch_sym));
                 else {
@@ -246,7 +241,7 @@ struct Visitor : public visitor::PreOrder {
             int i = 0;
             auto d = production::look_ahead::Default::None;
 
-            for ( const auto& c : n->as<spicy::type::unit::item::Switch>()->cases() ) {
+            for ( const auto& c : n->cases() ) {
                 std::unique_ptr<Production> prod;
 
                 if ( c->isDefault() )
@@ -301,8 +296,8 @@ struct Visitor : public visitor::PreOrder {
 
         std::vector<std::unique_ptr<Production>> items;
 
-        for ( const auto& n : n->as<type::Unit>()->childrenOfType<spicy::type::unit::Item>() ) {
-            if ( auto p = productionForItem(NodePtr(n)) )
+        for ( const auto& n : n->childrenOfType<spicy::type::unit::Item>() ) {
+            if ( auto p = productionForItem(n) )
                 items.push_back(std::move(p));
         }
 
@@ -311,8 +306,7 @@ struct Visitor : public visitor::PreOrder {
         if ( pf->haveField() )
             args = pf->currentField()->arguments();
 
-        auto unit = std::make_unique<production::Unit>(context(), pid, n->as<type::Unit>(), args, std::move(items),
-                                                       n->meta().location());
+        auto unit = std::make_unique<production::Unit>(context(), pid, n, args, std::move(items), n->meta().location());
 
         // This takes ownership of the unit production, storing it inside the grammar.
         pf->grammar->resolve(dynamic_cast<production::Deferred*>(unresolved.get()), std::move(unit));
@@ -322,18 +316,18 @@ struct Visitor : public visitor::PreOrder {
 
     void operator()(hilti::type::Vector* n) final {
         auto sub = productionForType(n->elementType(), ID(fmt("%s", n->elementType())));
-        result = productionForLoop(std::move(sub), n->as<Node>());
+        result = productionForLoop(std::move(sub), n);
     }
 };
 
-std::unique_ptr<Production> ProductionFactory::createProduction(const NodePtr& node) {
+std::unique_ptr<Production> ProductionFactory::createProduction(Node* node) {
     return visitor::dispatch(Visitor(this), node,
                              [](auto& v) -> std::unique_ptr<Production> { return std::move(v.result); });
 }
 
 } // anonymous namespace
 
-hilti::Result<hilti::Nothing> GrammarBuilder::run(const std::shared_ptr<type::Unit>& unit) {
+hilti::Result<hilti::Nothing> GrammarBuilder::run(type::Unit* unit) {
     assert(unit->canonicalID());
     auto id = unit->canonicalID();
     if ( _grammars.find(id) != _grammars.end() )

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -288,7 +288,7 @@ struct ProductionVisitor : public production::Visitor {
                             builder()->startProfiler(fmt("spicy/unit/%s", hilti::util::join(_path, "::")), offset);
                     }
 
-                    std::vector<QualifiedType*> x =
+                    QualifiedTypes x =
                         {builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Mutable),
                          pb->lookAheadType(),
                          builder()->qualifiedType(builder()->typeStreamIterator(), hilti::Constness::Const),
@@ -444,7 +444,7 @@ struct ProductionVisitor : public production::Visitor {
 
                     builder()->setLocation(p.location());
 
-                    std::vector<QualifiedType*> x =
+                    QualifiedTypes x =
                         {builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Mutable),
                          pb->lookAheadType(),
                          builder()->qualifiedType(builder()->typeStreamIterator(), hilti::Constness::Const),

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -48,15 +48,14 @@ namespace spicy::logging::debug {
 inline const hilti::logging::DebugStream ParserBuilder("parser-builder");
 } // namespace spicy::logging::debug
 
-ParserState::ParserState(Builder* builder, const type::UnitPtr& unit, const Grammar& grammar, ExpressionPtr data,
-                         ExpressionPtr cur)
+ParserState::ParserState(Builder* builder, type::Unit* unit, const Grammar& grammar, Expression* data, Expression* cur)
     : unit(unit),
       unit_id(unit->typeID()),
       needs_look_ahead(grammar.needsLookAhead()),
       self(builder->expressionName(ID("self"))),
-      data(std::move(data)),
+      data(data),
       begin(builder->begin(cur)),
-      cur(std::move(cur)),
+      cur(cur),
       lahead(builder->integer(look_ahead::None)) {}
 
 void ParserState::printDebug(Builder* builder) const {
@@ -73,7 +72,7 @@ struct ProductionVisitor : public production::Visitor {
     ParserBuilder* pb;
     const Grammar& grammar;
     hilti::util::Cache<std::string, ID> parse_functions;
-    std::vector<hilti::declaration::FieldPtr> new_fields;
+    std::vector<hilti::declaration::Field*> new_fields;
     Expressions _destinations;
     std::vector<ID> _path; // paths of IDs followed to get to current unit/field
 
@@ -94,9 +93,9 @@ struct ProductionVisitor : public production::Visitor {
 
     auto destination() { return _destinations.back(); }
 
-    auto pushDestination(ExpressionPtr e) {
+    auto pushDestination(Expression* e) {
         HILTI_DEBUG(spicy::logging::debug::ParserBuilder, fmt("- push destination: %s", *e));
-        _destinations.emplace_back(std::move(e));
+        _destinations.emplace_back(e);
     }
 
     auto popDestination() {
@@ -164,7 +163,7 @@ struct ProductionVisitor : public production::Visitor {
                               hilti::statement::comment::Separator::After);
     }
 
-    void parseNonAtomicProduction(const Production& p, const type::UnitPtr& unit) {
+    void parseNonAtomicProduction(const Production& p, type::Unit* unit) {
         // We wrap the parsing of a non-atomic production into a new
         // function that's cached and reused. This ensures correct
         // operation for productions that recurse.
@@ -174,7 +173,7 @@ struct ProductionVisitor : public production::Visitor {
                 auto id_stage1 = id;
                 auto id_stage2 = ID(fmt("__parse_%s_stage2", p.symbol()));
 
-                hilti::type::function::ParameterPtr addl_param;
+                hilti::type::function::Parameter* addl_param = nullptr;
 
                 if ( ! unit && p.meta().field() ) // for units, "self" is the destination
                     addl_param = builder()->parameter("__dst", p.meta().field()->parseType()->type(),
@@ -222,8 +221,8 @@ struct ProductionVisitor : public production::Visitor {
                     // is that we want a reliable point of error handling
                     // no matter what kind of trouble a Spicy script runs
                     // into.
-                    auto catch_ = try_->addCatch(
-                        {builder()->parameter("__except", builder()->typeName("hilti::SystemException"))});
+                    auto catch_ =
+                        try_->addCatch(builder()->parameter("__except", builder()->typeName("hilti::SystemException")));
 
                     pushBuilder(catch_, [&]() {
                         pb->finalizeUnit(false, p.location());
@@ -280,7 +279,7 @@ struct ProductionVisitor : public production::Visitor {
                     pstate.error = builder()->id("__error");
 
                     std::optional<PathTracker> path_tracker;
-                    ExpressionPtr profiler;
+                    Expression* profiler = nullptr;
 
                     if ( unit->typeID() ) {
                         path_tracker = PathTracker(&_path, unit->typeID());
@@ -289,7 +288,7 @@ struct ProductionVisitor : public production::Visitor {
                             builder()->startProfiler(fmt("spicy/unit/%s", hilti::util::join(_path, "::")), offset);
                     }
 
-                    std::vector<QualifiedTypePtr> x =
+                    std::vector<QualifiedType*> x =
                         {builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Mutable),
                          pb->lookAheadType(),
                          builder()->qualifiedType(builder()->typeStreamIterator(), hilti::Constness::Const),
@@ -445,7 +444,7 @@ struct ProductionVisitor : public production::Visitor {
 
                     builder()->setLocation(p.location());
 
-                    std::vector<QualifiedTypePtr> x =
+                    std::vector<QualifiedType*> x =
                         {builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Mutable),
                          pb->lookAheadType(),
                          builder()->qualifiedType(builder()->typeStreamIterator(), hilti::Constness::Const),
@@ -505,7 +504,7 @@ struct ProductionVisitor : public production::Visitor {
     }
 
     // Returns a boolean expression that's 'true' if a 'stop' was encountered.
-    ExpressionPtr _parseProduction(const Production& p_, bool top_level, const production::Meta& meta) {
+    Expression* _parseProduction(const Production& p_, bool top_level, const production::Meta& meta) {
         const auto* p = &p_;
         const auto is_field_owner = (meta.field() && meta.isFieldProduction() && ! p->isA<production::Deferred>());
 
@@ -563,9 +562,9 @@ struct ProductionVisitor : public production::Visitor {
 
         builder()->setLocation(p->location());
 
-        std::optional<ExpressionPtr> pre_container_offset;
+        std::optional<Expression*> pre_container_offset;
         std::optional<PathTracker> path_tracker;
-        ExpressionPtr profiler;
+        Expression* profiler = nullptr;
 
         if ( is_field_owner ) {
             path_tracker = PathTracker(&_path, field->id());
@@ -599,7 +598,7 @@ struct ProductionVisitor : public production::Visitor {
             }
 
             if ( meta.field() && ! meta.field()->isSkip() ) {
-                ExpressionPtr default_ =
+                Expression* default_ =
                     builder()->default_(builder()->typeName(unit->unitType()->typeID()), type_args, location);
                 builder()->addAssign(destination(), default_);
             }
@@ -629,7 +628,7 @@ struct ProductionVisitor : public production::Visitor {
         }
 
         // Top of stack will now have the final value for the field.
-        ExpressionPtr stop = builder()->bool_(false);
+        Expression* stop = builder()->bool_(false);
 
         if ( meta.container() ) {
             auto elem = destination();
@@ -665,7 +664,7 @@ struct ProductionVisitor : public production::Visitor {
         return stop;
     }
 
-    std::optional<ExpressionPtr> preParseField(const Production& /* i */, const production::Meta& meta) {
+    std::optional<Expression*> preParseField(const Production& /* i */, const production::Meta& meta) {
         const auto& field = meta.field();
         assert(field); // Must only be called if we have a field.
 
@@ -674,7 +673,7 @@ struct ProductionVisitor : public production::Visitor {
         // If the field holds a container we expect to see the offset of the field, not the individual container
         // elements inside e.g., this unit's fields hooks. Store the value before parsing of a container starts so we
         // can restore it later.
-        std::optional<ExpressionPtr> pre_container_offset;
+        std::optional<Expression*> pre_container_offset;
         if ( field && field->isContainer() )
             pre_container_offset =
                 builder()->addTmp("pre_container_offset",
@@ -717,7 +716,7 @@ struct ProductionVisitor : public production::Visitor {
 
         // `&size` and `&max-size` share the same underlying infrastructure
         // so try to extract both of them and compute the ultimate value.
-        std::optional<ExpressionPtr> length;
+        std::optional<Expression*> length;
         // Only at most one of `&max-size` and `&size` will be set.
         assert(! (field->attributes()->find("&size") && field->attributes()->find("&max-size")));
         if ( auto a = field->attributes()->find("&size") )
@@ -760,20 +759,20 @@ struct ProductionVisitor : public production::Visitor {
                                                                                    hilti::Constness::Const))}));
         }
 
-        if ( auto a = field->attributes()->find("&try") )
+        if ( field->attributes()->find("&try") )
             pb->initBacktracking();
 
         return pre_container_offset;
     }
 
     void postParseField(const Production& p, const production::Meta& meta,
-                        const std::optional<ExpressionPtr>& pre_container_offset) {
+                        const std::optional<Expression*>& pre_container_offset) {
         const auto& field = meta.field();
         assert(field); // Must only be called if we have a field.
 
         // If the field holds a container we expect to see the offset of the field, not the individual container
         // elements inside e.g., this unit's fields hooks. Temporarily restore the previously stored offset.
-        std::optional<ExpressionPtr> prev;
+        std::optional<Expression*> prev;
         if ( pre_container_offset ) {
             prev = builder()->addTmp("prev", builder()->ternary(pb->featureConstant(state().unit, "uses_offset"),
                                                                 builder()->member(state().self, "__offset"),
@@ -786,7 +785,7 @@ struct ProductionVisitor : public production::Visitor {
 
         HILTI_DEBUG(spicy::logging::debug::ParserBuilder, fmt("- post-parse field: %s", field->id()));
 
-        if ( auto a = field->attributes()->find("&try") )
+        if ( field->attributes()->find("&try") )
             pb->finishBacktracking();
 
         if ( pb->options().getAuxOption<bool>("spicy.track_offsets", false) ) {
@@ -803,7 +802,7 @@ struct ProductionVisitor : public production::Visitor {
 
         // Expression tracking `ncur` in case we operate on a limited view from `&max-size` parsing.
         // This differs from `&size` parsing in that we do not need to consume the full limited view.
-        ExpressionPtr ncur_max_size;
+        Expression* ncur_max_size = nullptr;
 
         if ( auto a = field->attributes()->find("&max-size") ) {
             // Check that we did not read into the sentinel byte.
@@ -890,15 +889,15 @@ struct ProductionVisitor : public production::Visitor {
     // don't need to create a function wrapper first.
     //
     // Returns a boolean expression that's 'true' if a 'stop' was encountered.
-    ExpressionPtr parseProduction(const Production& p, bool top_level = false) {
+    Expression* parseProduction(const Production& p, bool top_level = false) {
         return _parseProduction(p, top_level, p.meta());
     }
 
     // Inject parser code to skip a certain regexp pattern in the input. We
     // expect the passed expression to contain a ctor for a RegExp; else this
     // function does nothing.
-    void skipRegExp(const ExpressionPtr& e) {
-        std::shared_ptr<hilti::ctor::RegExp> c;
+    void skipRegExp(Expression* e) {
+        hilti::ctor::RegExp* c = nullptr;
 
         if ( auto ctor = e->tryAs<hilti::expression::Ctor>() )
             c = ctor->ctor()->tryAs<hilti::ctor::RegExp>();
@@ -1186,7 +1185,7 @@ struct ProductionVisitor : public production::Visitor {
         if ( while_ && while_->expression() )
             hilti::logger().error("&synchronize cannot be used on while loops with conditions");
 
-        ExpressionPtr profiler;
+        Expression* profiler = nullptr;
 
         // Helper to validate the parser state after search for a lookahead.
         auto validateSearchResult = [&]() {
@@ -1201,14 +1200,14 @@ struct ProductionVisitor : public production::Visitor {
                 // recover from this and directly trigger a parse error.
                 builder()->addAssert(state().error, "original error not set");
                 auto original_error = builder()->deref(state().error);
-                pb->parseError("failed to synchronize: %s", {original_error});
+                pb->parseError("failed to synchronize: %s", original_error);
             });
         };
 
         // Handle synchronization via `synchronize-at` or `synchronize-after` unit properties.
         // We can either see a unit for synchronization in a list (generating a
         // `while` production), or directly.
-        std::shared_ptr<type::Unit> unit_type;
+        type::Unit* unit_type = nullptr;
         if ( while_ ) {
             if ( const auto& field = while_->meta().field() )
                 if ( auto unit = field->parseType()->type()->elementType()->type()->tryAs<type::Unit>() )
@@ -1225,7 +1224,7 @@ struct ProductionVisitor : public production::Visitor {
             const auto synchronize_at = unit_type->propertyItem("%synchronize-at");
             const auto synchronize_after = unit_type->propertyItem("%synchronize-after");
 
-            ExpressionPtr e;
+            Expression* e = nullptr;
 
             if ( synchronize_at )
                 e = synchronize_at->expression();
@@ -1310,8 +1309,8 @@ struct ProductionVisitor : public production::Visitor {
 
     // Adds a method, and its implementation, to the current parsing struct
     // type that has the standard signature for parse methods.
-    void addParseMethod(bool add_decl, const ID& id, const StatementPtr& body,
-                        const hilti::type::function::ParameterPtr& addl_param = {}, const Meta& m = {}) {
+    void addParseMethod(bool add_decl, const ID& id, Statement* body, hilti::type::function::Parameter* addl_param = {},
+                        const Meta& m = {}) {
         auto qualified_id = pb->state().unit_id + id;
         auto ftype = pb->parseMethodFunctionType(addl_param, m);
         auto func = builder()->function(qualified_id, ftype, body, hilti::declaration::Linkage::Struct,
@@ -1325,7 +1324,7 @@ struct ProductionVisitor : public production::Visitor {
 
     // Redirects input to be read from given bytes value next.
     // This function pushes a new parser state which should be popped later.
-    void redirectInputToBytesValue(const ExpressionPtr& value) {
+    void redirectInputToBytesValue(Expression* value) {
         auto pstate = state();
         pstate.trim = builder()->bool_(false);
         pstate.lahead = builder()->addTmp("parse_lah", pb->lookAheadType(), builder()->integer(look_ahead::None));
@@ -1347,7 +1346,7 @@ struct ProductionVisitor : public production::Visitor {
 
     // Redirects input to be read from given stream position next.
     // This function pushes a new parser state which should be popped later.
-    void redirectInputToStreamPosition(const ExpressionPtr& position) {
+    void redirectInputToStreamPosition(Expression* position) {
         auto pstate = state();
         pstate.trim = builder()->bool_(false);
         pstate.lahead = builder()->addTmp("parse_lah", pb->lookAheadType(), builder()->integer(look_ahead::None));
@@ -1464,7 +1463,7 @@ struct ProductionVisitor : public production::Visitor {
     }
 
     void operator()(const production::ForEach* p) final {
-        ExpressionPtr cond;
+        Expression* cond = nullptr;
 
         if ( p->isEodOk() )
             cond = builder()->not_(pb->atEod());
@@ -1496,7 +1495,7 @@ struct ProductionVisitor : public production::Visitor {
         if ( auto a = p->attributes()->find("&parse-at") )
             redirectInputToStreamPosition(*a->valueAsExpression());
 
-        std::optional<ExpressionPtr> ncur;
+        std::optional<Expression*> ncur;
         if ( const auto& a = p->attributes()->find("&size") ) {
             // Limit input to the specified length.
             auto length = *a->valueAsExpression();
@@ -1553,7 +1552,7 @@ struct ProductionVisitor : public production::Visitor {
         // so try to extract both of them and compute the ultimate value. We
         // already reject cases where `&size` and `&max-size` are combined
         // during validation.
-        ExpressionPtr length;
+        Expression* length = nullptr;
         // Only at most one of `&max-size` and `&size` will be set.
         assert(! (p->unitType()->attributes()->find("&size") && p->unitType()->attributes()->find("&max-size")));
         if ( auto a = p->unitType()->attributes()->find("&size") )
@@ -1715,10 +1714,10 @@ struct ProductionVisitor : public production::Visitor {
 
         auto alts1 = hilti::util::filter(lahs.first, [](const auto& p) { return p->isLiteral(); });
         auto alts2 = hilti::util::filter(lahs.second, [](const auto& p) { return p->isLiteral(); });
-        auto exprs_alt1 = hilti::util::transformToVector(alts1, [this](const auto& p) -> ExpressionPtr {
+        auto exprs_alt1 = hilti::util::transformToVector(alts1, [this](const auto& p) -> Expression* {
             return builder()->integer(p->tokenID());
         });
-        auto exprs_alt2 = hilti::util::transformToVector(alts2, [this](const auto& p) -> ExpressionPtr {
+        auto exprs_alt2 = hilti::util::transformToVector(alts2, [this](const auto& p) -> Expression* {
             return builder()->integer(p->tokenID());
         });
 
@@ -1807,7 +1806,7 @@ struct ProductionVisitor : public production::Visitor {
             }
 
             else if ( until_attr ) {
-                ExpressionPtr until_expr =
+                Expression* until_expr =
                     builder()->coerceTo(*until_attr->valueAsExpression(),
                                         builder()->qualifiedType(builder()->typeBytes(), hilti::Constness::Const));
                 auto until_bytes_var = builder()->addTmp("until_bytes", until_expr);
@@ -1929,8 +1928,8 @@ static auto parseMethodIDs(const type::Unit& t) {
 
 ParserBuilder::ParserBuilder(CodeGen* cg) : _cg(cg) {}
 
-hilti::type::FunctionPtr ParserBuilder::parseMethodFunctionType(const hilti::type::function::ParameterPtr& addl_param,
-                                                                const Meta& m) {
+hilti::type::Function* ParserBuilder::parseMethodFunctionType(hilti::type::function::Parameter* addl_param,
+                                                              const Meta& m) {
     auto result = builder()->typeTuple(
         {builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Const), lookAheadType(),
          builder()->qualifiedType(builder()->typeStreamIterator(), hilti::Constness::Const),
@@ -1972,7 +1971,7 @@ std::shared_ptr<Builder> ParserBuilder::pushBuilder() {
     return _builders.back();
 }
 
-void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr& t, bool declare_only) {
+void ParserBuilder::addParserMethods(hilti::type::Struct* s, type::Unit* t, bool declare_only) {
     auto [id_ext_overload1, id_ext_overload2, id_ext_overload3, id_ext_context_new] = parseMethodIDs(*t);
 
     hilti::declaration::Parameters params =
@@ -2067,11 +2066,11 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
         builder()->declarationField(f_ext_overload3->id().local(), hilti::function::CallingConvention::Extern,
                                     f_ext_overload3->function()->ftype(), f_ext_overload3->function()->attributes());
 
-    s->addField(context(), std::move(sf_ext_overload1));
-    s->addField(context(), std::move(sf_ext_overload2));
-    s->addField(context(), std::move(sf_ext_overload3));
+    s->addField(context(), sf_ext_overload1);
+    s->addField(context(), sf_ext_overload2);
+    s->addField(context(), sf_ext_overload3);
 
-    if ( auto ctx = t->contextType() ) {
+    if ( t->contextType() ) {
         auto sf_ext_ctor =
             builder()->declarationField(f_ext_context_new->id().local(), hilti::function::CallingConvention::Extern,
                                         f_ext_context_new->function()->ftype(),
@@ -2114,7 +2113,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
                                 builder()->valueReference(
                                     builder()->default_(builder()->typeName(t->typeID()),
                                                         hilti::node::transform(t->parameters(),
-                                                                               [](const auto& p) -> ExpressionPtr {
+                                                                               [](const auto& p) -> Expression* {
                                                                                    return p->default_();
                                                                                }))));
             builder()
@@ -2149,7 +2148,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
             pushBuilder(builder()->addIf(state().error), [&]() {
                 builder()->addDebugMsg("spicy", "successful sync never confirmed, failing unit");
                 auto original_error = builder()->deref(state().error);
-                parseError("successful synchronization never confirmed: %s", {original_error});
+                parseError("successful synchronization never confirmed: %s", original_error);
             });
 
             builder()->addReturn(state().cur);
@@ -2166,7 +2165,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
                                 builder()->valueReference(
                                     builder()->default_(builder()->typeName(t->typeID()),
                                                         hilti::node::transform(t->parameters(),
-                                                                               [](const auto& p) -> ExpressionPtr {
+                                                                               [](const auto& p) -> Expression* {
                                                                                    return p->default_();
                                                                                }))));
 
@@ -2204,7 +2203,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
             pushBuilder(builder()->addIf(state().error), [&]() {
                 builder()->addDebugMsg("spicy", "successful sync never confirmed, failing unit");
                 auto original_error = builder()->deref(state().error);
-                parseError("successful synchronization never confirmed: %s", {original_error});
+                parseError("successful synchronization never confirmed: %s", original_error);
             });
 
             builder()->addReturn(state().cur);
@@ -2249,7 +2248,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
         pushBuilder(builder()->addIf(state().error), [&]() {
             builder()->addDebugMsg("spicy", "successful sync never confirmed, failing unit");
             auto original_error = builder()->deref(state().error);
-            parseError("successful synchronization never confirmed: %s", {original_error});
+            parseError("successful synchronization never confirmed: %s", original_error);
         });
 
         builder()->addReturn(state().cur);
@@ -2264,7 +2263,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
             pushBuilder();
             auto obj = builder()->new_(ctx);
             auto ti = builder()->typeinfo(builder()->qualifiedType(ctx, hilti::Constness::Const));
-            builder()->addReturn(builder()->call("spicy_rt::createContext", {std::move(obj), std::move(ti)}));
+            builder()->addReturn(builder()->call("spicy_rt::createContext", {obj, ti}));
             auto body_ext_context_new = popBuilder();
 
             f_ext_context_new->function()->setBody(context(), body_ext_context_new->block());
@@ -2272,7 +2271,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
         }
 
         for ( auto f : visitor.new_fields )
-            s->addField(context(), std::move(f));
+            s->addField(context(), f);
     }
 
     s->addField(context(),
@@ -2288,35 +2287,34 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, const type::UnitPtr
 
 Builder* ParserBuilder::builder() const { return _builders.empty() ? _cg->builder() : _builders.back().get(); }
 
-ExpressionPtr ParserBuilder::parseMethodExternalOverload1(const type::Unit& t) {
+Expression* ParserBuilder::parseMethodExternalOverload1(const type::Unit& t) {
     auto id = std::get<0>(parseMethodIDs(t));
     return builder()->expressionName(id);
 }
 
-ExpressionPtr ParserBuilder::parseMethodExternalOverload2(const type::Unit& t) {
+Expression* ParserBuilder::parseMethodExternalOverload2(const type::Unit& t) {
     auto id = std::get<1>(parseMethodIDs(t));
     return builder()->expressionName(id);
 }
 
-ExpressionPtr ParserBuilder::parseMethodExternalOverload3(const type::Unit& t) {
+Expression* ParserBuilder::parseMethodExternalOverload3(const type::Unit& t) {
     auto id = std::get<2>(parseMethodIDs(t));
     return builder()->expressionName(id);
 }
 
-ExpressionPtr ParserBuilder::contextNewFunction(const type::Unit& t) {
+Expression* ParserBuilder::contextNewFunction(const type::Unit& t) {
     auto id = std::get<3>(parseMethodIDs(t));
     return builder()->expressionName(id);
 }
 
 // Helper to heuristically reconstruct the Spicy source code for a given expression.
-std::string prettyPrintExpr(const ExpressionPtr& e) {
+std::string prettyPrintExpr(Expression* e) {
     std::stringstream ss;
     ss << *e;
     return hilti::util::replace(ss.str(), "__dd", "$$");
 }
 
-void ParserBuilder::newValueForField(const production::Meta& meta, const ExpressionPtr& value,
-                                     const ExpressionPtr& dd) {
+void ParserBuilder::newValueForField(const production::Meta& meta, Expression* value, Expression* dd) {
     const auto& field = meta.field();
 
     for ( const auto& a : field->attributes()->findAll("&requires") ) {
@@ -2368,8 +2366,8 @@ void ParserBuilder::newValueForField(const production::Meta& meta, const Express
     }
 }
 
-ExpressionPtr ParserBuilder::newContainerItem(const type::unit::item::Field& field, const ExpressionPtr& self,
-                                              const ExpressionPtr& item, bool need_value) {
+Expression* ParserBuilder::newContainerItem(const type::unit::item::Field& field, Expression* self, Expression* item,
+                                            bool need_value) {
     auto stop = builder()->addTmp("stop", builder()->bool_(false));
 
     auto push_element = [&]() {
@@ -2390,7 +2388,7 @@ ExpressionPtr ParserBuilder::newContainerItem(const type::unit::item::Field& fie
         });
     };
 
-    auto eval_condition = [&](const ExpressionPtr& cond) {
+    auto eval_condition = [&](Expression* cond) {
         pushBuilder(builder()->addBlock(), [&]() {
             builder()->addLocal("__dd", item);
             builder()->addAssign(stop, builder()->or_(stop, cond));
@@ -2422,8 +2420,8 @@ ExpressionPtr ParserBuilder::newContainerItem(const type::unit::item::Field& fie
     return stop;
 }
 
-ExpressionPtr ParserBuilder::applyConvertExpression(const type::unit::item::Field& field, const ExpressionPtr& value,
-                                                    std::optional<ExpressionPtr> dst) {
+Expression* ParserBuilder::applyConvertExpression(const type::unit::item::Field& field, Expression* value,
+                                                  std::optional<Expression*> dst) {
     auto convert = field.convertExpression();
     if ( ! convert )
         return value;
@@ -2466,7 +2464,7 @@ void ParserBuilder::initializeUnit(const Location& l) {
 }
 
 void ParserBuilder::finalizeUnit(bool success, const Location& l) {
-    const auto& unit = state().unit.get();
+    const auto& unit = state().unit;
 
     saveParsePosition();
 
@@ -2504,7 +2502,7 @@ void ParserBuilder::finalizeUnit(bool success, const Location& l) {
     });
 }
 
-ExpressionPtr ParserBuilder::_filters(const ParserState& state) {
+Expression* ParserBuilder::_filters(const ParserState& state) {
     // Since used of a unit's `_filters` member triggers a requirement for
     // filter support, guard access to it behind a feature flag. This allows us
     // to decide with user-written code whether we actually want to enable
@@ -2521,11 +2519,11 @@ ExpressionPtr ParserBuilder::_filters(const ParserState& state) {
                                                            hilti::Constness::Mutable)));
 }
 
-ExpressionPtr ParserBuilder::waitForInputOrEod() {
+Expression* ParserBuilder::waitForInputOrEod() {
     return builder()->call("spicy_rt::waitForInputOrEod", {state().data, state().cur, _filters(state())});
 }
 
-ExpressionPtr ParserBuilder::atEod() {
+Expression* ParserBuilder::atEod() {
     return builder()->call("spicy_rt::atEod", {state().data, state().cur, _filters(state())});
 }
 
@@ -2534,11 +2532,11 @@ void ParserBuilder::waitForInput(std::string_view error_msg, const Meta& locatio
                                                   builder()->expression(location), _filters(state())});
 }
 
-ExpressionPtr ParserBuilder::waitForInputOrEod(const ExpressionPtr& min) {
+Expression* ParserBuilder::waitForInputOrEod(Expression* min) {
     return builder()->call("spicy_rt::waitForInputOrEod", {state().data, state().cur, min, _filters(state())});
 }
 
-void ParserBuilder::waitForInput(const ExpressionPtr& min, std::string_view error_msg, const Meta& location) {
+void ParserBuilder::waitForInput(Expression* min, std::string_view error_msg, const Meta& location) {
     builder()->addCall("spicy_rt::waitForInput", {state().data, state().cur, min, builder()->stringLiteral(error_msg),
                                                   builder()->expression(location), _filters(state())});
 }
@@ -2547,7 +2545,7 @@ void ParserBuilder::waitForEod() {
     builder()->addCall("spicy_rt::waitForEod", {state().data, state().cur, _filters(state())});
 }
 
-void ParserBuilder::parseError(const ExpressionPtr& error_msg, const Meta& meta) {
+void ParserBuilder::parseError(Expression* error_msg, const Meta& meta) {
     builder()->addThrow(builder()->exception(builder()->typeName("spicy_rt::ParseError"), error_msg, meta), meta);
 }
 
@@ -2559,14 +2557,14 @@ void ParserBuilder::parseError(std::string_view fmt, const Expressions& args, co
     parseError(builder()->modulo(builder()->stringLiteral(fmt), builder()->tuple(args)), meta);
 }
 
-void ParserBuilder::parseError(std::string_view fmt, const ExpressionPtr& orig_except) {
+void ParserBuilder::parseError(std::string_view fmt, Expression* orig_except) {
     auto what = builder()->call("hilti::exception_what", {orig_except});
     auto where = builder()->call("hilti::exception_where", {orig_except});
     auto msg = builder()->modulo(builder()->stringLiteral(fmt), builder()->tuple({what}));
     builder()->addThrow(builder()->exception(builder()->typeName("spicy_rt::ParseError"), msg, where));
 }
 
-void ParserBuilder::skip(const ExpressionPtr& size, const Meta& location) {
+void ParserBuilder::skip(Expression* size, const Meta& location) {
     assert(size->type()->type()->isA<hilti::type::UnsignedInteger>());
 
     auto n = builder()->addTmp("skip", size);
@@ -2595,7 +2593,7 @@ void ParserBuilder::advanceToNextData() {
     trimInput();
 }
 
-void ParserBuilder::advanceInput(const ExpressionPtr& i) {
+void ParserBuilder::advanceInput(Expression* i) {
     if ( i->type()->type()->isA<hilti::type::stream::View>() )
         builder()->addAssign(state().cur, i);
     else
@@ -2604,7 +2602,7 @@ void ParserBuilder::advanceInput(const ExpressionPtr& i) {
     trimInput();
 }
 
-void ParserBuilder::setInput(const ExpressionPtr& i) { builder()->addAssign(state().cur, i); }
+void ParserBuilder::setInput(Expression* i) { builder()->addAssign(state().cur, i); }
 
 void ParserBuilder::beforeHook() {
     // Forward the current trial mode state into the unit so hooks see the
@@ -2660,7 +2658,7 @@ void ParserBuilder::saveParsePosition() {
     });
 }
 
-void ParserBuilder::consumeLookAhead(const ExpressionPtr& dst) {
+void ParserBuilder::consumeLookAhead(Expression* dst) {
     builder()->addDebugMsg("spicy-verbose", "- consuming look-ahead token");
 
     if ( dst )
@@ -2688,16 +2686,16 @@ void ParserBuilder::finishBacktracking() {
     trimInput();
 }
 
-ExpressionPtr ParserBuilder::initLoopBody() { return builder()->addTmp("old_begin", builder()->begin(state().cur)); }
+Expression* ParserBuilder::initLoopBody() { return builder()->addTmp("old_begin", builder()->begin(state().cur)); }
 
-void ParserBuilder::finishLoopBody(const ExpressionPtr& cookie, const Location& l) {
+void ParserBuilder::finishLoopBody(Expression* cookie, const Location& l) {
     auto not_moved = builder()->and_(builder()->equal(builder()->begin(state().cur), cookie), builder()->not_(atEod()));
     auto body = builder()->addIf(not_moved);
     pushBuilder(std::move(body),
                 [&]() { parseError("loop body did not change input position, possible infinite loop", l); });
 }
 
-void ParserBuilder::guardFeatureCode(const type::UnitPtr& unit, const std::vector<std::string_view>& features,
+void ParserBuilder::guardFeatureCode(const type::Unit* unit, const std::vector<std::string_view>& features,
                                      const std::function<void()>& f) {
     if ( features.empty() ) {
         f();
@@ -2715,11 +2713,11 @@ void ParserBuilder::guardFeatureCode(const type::UnitPtr& unit, const std::vecto
     popBuilder();
 }
 
-QualifiedTypePtr ParserBuilder::lookAheadType() const {
+QualifiedType* ParserBuilder::lookAheadType() const {
     return builder()->qualifiedType(builder()->typeSignedInteger(64), hilti::Constness::Mutable);
 }
 
-hilti::ExpressionPtr ParserBuilder::featureConstant(const type::UnitPtr& unit, std::string_view feature) {
+hilti::Expression* ParserBuilder::featureConstant(const type::Unit* unit, std::string_view feature) {
     const auto id = hilti::util::replace(unit->canonicalID(), ":", "@");
     return builder()->id(ID(hilti::rt::fmt("::__feat%%%s%%%s", id, feature)));
 }

--- a/spicy/toolchain/src/compiler/codegen/production.cc
+++ b/spicy/toolchain/src/compiler/codegen/production.cc
@@ -59,7 +59,7 @@ std::string codegen::to_string(const Production& p) {
         if ( auto x = f->arguments(); x.size() ) {
             args = hilti::util::fmt(", args: (%s)",
                                     hilti::util::join(hilti::node::transform(x,
-                                                                             [](auto& a) {
+                                                                             [](auto a) {
                                                                                  return hilti::util::fmt("%s", a);
                                                                              }),
                                                       ", "));
@@ -74,7 +74,6 @@ std::string codegen::to_string(const Production& p) {
     auto prefix = "";
     auto postfix = "";
     auto name = p.typename_();
-    ;
     auto render = p.dump();
 
     if ( const auto* ref =

--- a/spicy/toolchain/src/compiler/parser/driver.cc
+++ b/spicy/toolchain/src/compiler/parser/driver.cc
@@ -15,14 +15,15 @@
 using namespace spicy;
 using namespace spicy::detail::parser;
 
-hilti::Result<ModulePtr> detail::parser::parseSource(Builder* builder, std::istream& in, const std::string& filename) {
+hilti::Result<hilti::declaration::Module*> detail::parser::parseSource(Builder* builder, std::istream& in,
+                                                                       const std::string& filename) {
     hilti::util::timing::Collector _("spicy/compiler/ast/parser");
 
     return Driver().parse(builder, in, filename);
 }
 
-hilti::Result<ExpressionPtr> detail::parser::parseExpression(Builder* builder, const std::string& expr,
-                                                             const Meta& meta) {
+hilti::Result<Expression*> detail::parser::parseExpression(Builder* builder, const std::string& expr,
+                                                           const Meta& meta) {
     spicy::detail::parser::Driver driver;
     return driver.parseExpression(builder, expr, meta);
 }
@@ -31,7 +32,8 @@ namespace hilti::logging::debug {
 inline const DebugStream Parser("parser");
 } // namespace hilti::logging::debug
 
-hilti::Result<ModulePtr> Driver::parse(Builder* builder, std::istream& in, const std::string& filename) {
+hilti::Result<hilti::declaration::Module*> Driver::parse(Builder* builder, std::istream& in,
+                                                         const std::string& filename) {
     _builder = builder;
 
     auto old_errors = hilti::logger().errors();
@@ -62,7 +64,7 @@ hilti::Result<ModulePtr> Driver::parse(Builder* builder, std::istream& in, const
     return _module;
 }
 
-hilti::Result<ExpressionPtr> Driver::parseExpression(Builder* builder, const std::string& expression, const Meta& m) {
+hilti::Result<Expression*> Driver::parseExpression(Builder* builder, const std::string& expression, const Meta& m) {
     _builder = builder;
 
     auto old_errors = hilti::logger().errors();

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -49,7 +49,7 @@ static hilti::Meta toMeta(spicy::detail::parser::location l) {
                                        (l.end.column > 0 ? l.end.column - 1 : 0)));
 }
 
-static hilti::QualifiedTypePtr iteratorForType(spicy::Builder* builder, hilti::QualifiedTypePtr t, hilti::Meta m) {
+static hilti::QualifiedType* iteratorForType(spicy::Builder* builder, hilti::QualifiedType* t, hilti::Meta m) {
     if ( auto iter = t->type()->iteratorType() )
         return iter;
     else {
@@ -58,7 +58,7 @@ static hilti::QualifiedTypePtr iteratorForType(spicy::Builder* builder, hilti::Q
         }
 }
 
-static hilti::QualifiedTypePtr viewForType(spicy::Builder* builder, hilti::QualifiedTypePtr t, hilti::Meta m) {
+static hilti::QualifiedType* viewForType(spicy::Builder* builder, hilti::QualifiedType* t, hilti::Meta m) {
     if ( auto v = t->type()->viewType() )
         return v;
     else {
@@ -267,36 +267,36 @@ static std::vector<hilti::DocString> _docs;
 %token WHILE
 
 %type <hilti::ID>                           local_id scoped_id dotted_id unit_hook_id
-%type <hilti::DeclarationPtr>               local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl hook_decl struct_field
+%type <hilti::Declaration*>               local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl hook_decl struct_field
 %type <hilti::Declarations>                 struct_fields
-%type <hilti::UnqualifiedTypePtr>           base_type_no_ref base_type type tuple_type struct_type enum_type unit_type bitfield_type reference_type
-%type <hilti::QualifiedTypePtr>             qtype func_result opt_func_result
-%type <hilti::CtorPtr>                      ctor tuple struct_ regexp list vector map set unit_field_ctor
-%type <hilti::ExpressionPtr>                expr tuple_elem tuple_expr member_expr ctor_expr expr_0 expr_1 expr_2 expr_3 expr_4 expr_5 expr_6 expr_7 expr_8 expr_9 expr_a expr_b expr_c expr_d expr_e expr_f expr_g opt_init_expression opt_unit_field_condition unit_field_repeat opt_unit_field_repeat opt_unit_switch_expr opt_bitfield_range_value
+%type <hilti::UnqualifiedType*>           base_type_no_ref base_type type tuple_type struct_type enum_type unit_type bitfield_type reference_type
+%type <hilti::QualifiedType*>             qtype func_result opt_func_result
+%type <hilti::Ctor*>                      ctor tuple struct_ regexp list vector map set unit_field_ctor
+%type <hilti::Expression*>                expr tuple_elem tuple_expr member_expr ctor_expr expr_0 expr_1 expr_2 expr_3 expr_4 expr_5 expr_6 expr_7 expr_8 expr_9 expr_a expr_b expr_c expr_d expr_e expr_f expr_g opt_init_expression opt_unit_field_condition unit_field_repeat opt_unit_field_repeat opt_unit_switch_expr opt_bitfield_range_value
 %type <hilti::Expressions>                  opt_tuple_elems1 opt_tuple_elems2 exprs opt_exprs opt_unit_field_args opt_unit_field_sinks
-%type <hilti::type::function::ParameterPtr> func_param
+%type <hilti::type::function::Parameter*> func_param
 %type <hilti::parameter::Kind>              opt_func_param_kind
 %type <hilti::type::function::Flavor>       opt_func_flavor
 %type <hilti::function::CallingConvention>  opt_func_cc
 %type <hilti::declaration::Linkage>         opt_linkage
 %type <hilti::declaration::Parameters>      func_params opt_func_params opt_unit_params opt_unit_hook_params
-%type <hilti::StatementPtr>                 stmt stmt_decl stmt_expr block braced_block opt_else_block
+%type <hilti::Statement*>                 stmt stmt_decl stmt_expr block braced_block opt_else_block
 %type <hilti::Statements>                   stmts opt_stmts
-%type <hilti::AttributePtr>                 attribute unit_hook_attribute
-%type <hilti::AttributeSetPtr>              opt_attributes opt_unit_hook_attributes
-%type <hilti::type::tuple::ElementPtr>      tuple_type_elem
+%type <hilti::Attribute*>                 attribute unit_hook_attribute
+%type <hilti::AttributeSet*>              opt_attributes opt_unit_hook_attributes
+%type <hilti::type::tuple::Element*>      tuple_type_elem
 %type <hilti::type::tuple::Elements>        tuple_type_elems
 %type <hilti::ctor::struct_::Fields>        struct_elems
-%type <hilti::ctor::struct_::FieldPtr>      struct_elem
+%type <hilti::ctor::struct_::Field*>      struct_elem
 %type <hilti::ctor::map::Elements>          map_elems opt_map_elems
-%type <hilti::ctor::map::ElementPtr>        map_elem
-%type <hilti::type::enum_::LabelPtr>        enum_label
+%type <hilti::ctor::map::Element*>        map_elem
+%type <hilti::type::enum_::Label*>        enum_label
 %type <hilti::type::enum_::Labels>          enum_labels
 %type <hilti::type::bitfield::BitRanges>    bitfield_bit_ranges opt_bitfield_bit_ranges
-%type <hilti::type::bitfield::BitRangePtr>  bitfield_bit_range
+%type <hilti::type::bitfield::BitRange*>  bitfield_bit_range
 %type <std::vector<std::string>>            re_patterns
 %type <std::string>                         re_pattern_constant
-%type <hilti::statement::switch_::CasePtr>  switch_case
+%type <hilti::statement::switch_::Case*>  switch_case
 %type <hilti::statement::switch_::Cases>    switch_cases
 
 %type <std::pair<hilti::Declarations, hilti::Statements>> global_scope_items
@@ -304,13 +304,13 @@ static std::vector<hilti::DocString> _docs;
 // Spicy-only
 %type <hilti::ID>                            opt_unit_field_id
 %type <spicy::Engine>                        opt_unit_field_engine opt_hook_engine
-%type <spicy::declaration::HookPtr>          unit_hook
+%type <spicy::declaration::Hook*>          unit_hook
 %type <spicy::declaration::Hooks>            opt_unit_item_hooks unit_hooks
-%type <spicy::type::unit::ItemPtr>           unit_item unit_variable unit_field unit_field_in_container unit_wide_hook unit_property unit_switch unit_sink
+%type <spicy::type::unit::Item*>           unit_item unit_variable unit_field unit_field_in_container unit_wide_hook unit_property unit_switch unit_sink
 %type <spicy::type::unit::Items>             unit_items opt_unit_items
-%type <spicy::type::unit::item::switch_::CasePtr>   unit_switch_case
+%type <spicy::type::unit::item::switch_::Case*>   unit_switch_case
 %type <spicy::type::unit::item::switch_::Cases>     unit_switch_cases
-%type <std::pair<hilti::QualifiedTypePtr, hilti::ExpressionPtr>> global_decl_type_and_init
+%type <std::pair<hilti::QualifiedType*, hilti::Expression*>> global_decl_type_and_init
 
 %type <int64_t>  const_sint
 %type <uint64_t> const_uint

--- a/spicy/toolchain/src/compiler/plugin.cc
+++ b/spicy/toolchain/src/compiler/plugin.cc
@@ -35,21 +35,19 @@ hilti::Plugin spicy::detail::createSpicyPlugin() {
             },
 
         .coerce_ctor =
-            [](hilti::Builder* builder, const CtorPtr& c, const QualifiedTypePtr& dst,
-               bitmask<hilti::CoercionStyle> style) {
+            [](hilti::Builder* builder, Ctor* c, QualifiedType* dst, bitmask<hilti::CoercionStyle> style) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 return coercer::coerceCtor(spicy_builder, c, dst, style);
             },
 
         .coerce_type =
-            [](hilti::Builder* builder, const QualifiedTypePtr& t, const QualifiedTypePtr& dst,
-               bitmask<hilti::CoercionStyle> style) {
+            [](hilti::Builder* builder, QualifiedType* t, QualifiedType* dst, bitmask<hilti::CoercionStyle> style) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 return coercer::coerceType(spicy_builder, t, dst, style);
             },
 
         .ast_init =
-            [](hilti::Builder* builder, const ASTRootPtr& root) {
+            [](hilti::Builder* builder, hilti::ASTRoot* root) {
                 hilti::util::timing::Collector _("spicy/compiler/ast/init");
 
                 if ( builder->options().import_standard_modules ) {
@@ -60,35 +58,35 @@ hilti::Plugin spicy::detail::createSpicyPlugin() {
             },
 
         .ast_build_scopes =
-            [](hilti::Builder* builder, const ASTRootPtr& root) {
+            [](hilti::Builder* builder, hilti::ASTRoot* root) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 scope_builder::build(spicy_builder, root);
                 return false;
             },
 
         .ast_resolve =
-            [](hilti::Builder* builder, const NodePtr& root) {
+            [](hilti::Builder* builder, Node* root) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 return resolver::resolve(spicy_builder, root);
             },
 
         .ast_validate_pre =
-            [](hilti::Builder* builder, const ASTRootPtr& m) {
+            [](hilti::Builder* builder, hilti::ASTRoot* m) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 validator::validatePre(spicy_builder, m);
                 return false;
             },
 
         .ast_validate_post =
-            [](hilti::Builder* builder, const ASTRootPtr& root) {
+            [](hilti::Builder* builder, hilti::ASTRoot* root) {
                 auto spicy_builder = static_cast<spicy::Builder*>(builder);
                 validator::validatePost(spicy_builder, root);
                 return false;
             },
 
-        .ast_print = [](const NodePtr& node, hilti::printer::Stream& out) { return printer::print(out, node); },
+        .ast_print = [](Node* node, hilti::printer::Stream& out) { return printer::print(out, node); },
 
-        .ast_transform = [](hilti::Builder* builder, const ASTRootPtr& m) -> bool {
+        .ast_transform = [](hilti::Builder* builder, hilti::ASTRoot* m) -> bool {
             auto spicy_builder = static_cast<spicy::Builder*>(builder);
             return CodeGen(spicy_builder).compileAST(m);
         },

--- a/spicy/toolchain/src/compiler/printer.cc
+++ b/spicy/toolchain/src/compiler/printer.cc
@@ -55,7 +55,7 @@ struct VisitorPrinter : visitor::PreOrder {
 
 } // anonymous namespace
 
-bool spicy::detail::printer::print(hilti::printer::Stream& stream, const NodePtr& root) {
+bool spicy::detail::printer::print(hilti::printer::Stream& stream, Node* root) {
     hilti::util::timing::Collector _("spicy/printer");
 
     return visitor::dispatch(VisitorPrinter(stream), root, [](const auto& v) { return v.result; });

--- a/spicy/toolchain/src/compiler/resolver.cc
+++ b/spicy/toolchain/src/compiler/resolver.cc
@@ -23,8 +23,8 @@ namespace {
 
 // Copy a range of nodes into an actual vector.
 template<typename T>
-auto copy_vector = [](const auto& in) -> std::vector<std::shared_ptr<T>> {
-    std::vector<std::shared_ptr<T>> out;
+auto copy_vector = [](const auto& in) -> std::vector<T*> {
+    std::vector<T*> out;
     for ( const auto& i : in )
         out.push_back(i);
 
@@ -62,10 +62,10 @@ enum class FieldType {
 };
 
 struct VisitorPass2 : visitor::MutatingPostOrder {
-    VisitorPass2(Builder* builder, const NodePtr& root)
+    VisitorPass2(Builder* builder, Node* root)
         : visitor::MutatingPostOrder(builder, logging::debug::Resolver), root(root) {}
 
-    const NodePtr& root;
+    Node* root = nullptr;
     std::set<Node*> seen;
 
     // Sets a declaration fully qualified ID
@@ -76,8 +76,8 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     // Helper method to compute one of several kinds of a field's types.
-    QualifiedTypePtr fieldType(const type::unit::item::Field& f, const QualifiedTypePtr& type, FieldType ft,
-                               bool is_container, const Meta& meta) {
+    QualifiedType* fieldType(const type::unit::item::Field& f, QualifiedType* type, FieldType ft, bool is_container,
+                             const Meta& meta) {
         // Visitor determining a unit field type.
         struct FieldTypeVisitor : public visitor::PreOrder {
             explicit FieldTypeVisitor(Builder* builder, FieldType ft) : builder(builder), ft(ft) {}
@@ -85,19 +85,19 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             Builder* builder;
             FieldType ft;
 
-            QualifiedTypePtr result = nullptr;
+            QualifiedType* result = nullptr;
 
             void operator()(hilti::type::RegExp* n) final {
                 result = builder->qualifiedType(builder->typeBytes(), hilti::Constness::Mutable);
             }
         };
 
-        QualifiedTypePtr nt;
+        QualifiedType* nt = nullptr;
         FieldTypeVisitor v(builder(), ft);
         v.dispatch(type->type());
 
         if ( v.result )
-            nt = std::move(v.result);
+            nt = v.result;
         else
             nt = type;
 
@@ -226,7 +226,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 }
 
                 if ( auto x = resolved->first->as<hilti::declaration::Type>()->type()->type()->tryAs<type::Unit>() )
-                    unit_type = x.get();
+                    unit_type = x;
                 else {
                     n->addError(hilti::util::fmt("'%s' is not a unit type", ns));
                     return;
@@ -249,7 +249,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                     return;
                 }
 
-                unit_field = unit_type->as<type::Unit>()->itemByName(n->id().local()).get();
+                unit_field = unit_type->as<type::Unit>()->itemByName(n->id().local());
                 if ( ! unit_field )
                     // We do not record an error here because we'd need to account
                     // for %init/%done/etc. We'll leave that to the validator.
@@ -273,7 +273,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         if ( n->unitFieldIndex() && ! n->dd() ) {
             auto unit_field = context()->lookup(n->unitFieldIndex())->as<type::unit::item::Field>();
 
-            QualifiedTypePtr dd;
+            QualifiedType* dd = nullptr;
 
             if ( n->isForEach() ) {
                 dd = unit_field->ddType();
@@ -310,7 +310,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
                 auto i = builder()->typeUnitItemProperty(prop->id(), prop->expression(), {}, true, prop->meta());
                 recordChange(n, hilti::util::fmt("add module-level property %s", prop->id()));
-                u->addItems(context(), {std::move(i)});
+                u->addItems(context(), {i});
             }
         }
     }
@@ -370,8 +370,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 auto access_field =
                     unit_member->instantiate(builder(), {n->op0(), builder()->expressionMember(field->id())},
                                              n->meta());
-                auto access_bits =
-                    bitfield_member->instantiate(builder(), {std::move(*access_field), n->op1()}, n->meta());
+                auto access_bits = bitfield_member->instantiate(builder(), {*access_field, n->op1()}, n->meta());
                 replaceNode(n, *access_bits);
             }
         }
@@ -392,8 +391,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 auto access_field =
                     unit_member->instantiate(builder(), {n->op0(), builder()->expressionMember(field->id())},
                                              n->meta());
-                auto access_bits =
-                    bitfield_member->instantiate(builder(), {std::move(*access_field), n->op1()}, n->meta());
+                auto access_bits = bitfield_member->instantiate(builder(), {*access_field, n->op1()}, n->meta());
                 replaceNode(n, *access_bits);
             }
         }
@@ -414,8 +412,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
                 auto try_field =
                     try_member->instantiate(builder(), {n->op0(), builder()->expressionMember(field->id())}, n->meta());
-                auto access_bits =
-                    bitfield_member->instantiate(builder(), {std::move(*try_field), n->op1()}, n->meta());
+                auto access_bits = bitfield_member->instantiate(builder(), {*try_field, n->op1()}, n->meta());
                 replaceNode(n, *access_bits);
             }
         }
@@ -481,7 +478,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                  ->isA<hilti::type::Auto>() ) { // do not use isResolved(), so that we can deal with loops
             if ( auto t = fieldType(*n, n->originalType(), FieldType::ParseType, n->isContainer(), n->meta()) ) {
                 recordChange(n, "parse type");
-                n->setParseType(context(), std::move(t));
+                n->setParseType(context(), t);
             }
         }
 
@@ -496,7 +493,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
              ! n->parseType()
                    ->type()
                    ->isA<hilti::type::Auto>() ) { // do not use isResolved(), so that we can deal with loops
-            QualifiedTypePtr t;
+            QualifiedType* t = nullptr;
 
             if ( auto x = n->convertExpression() ) {
                 if ( x->second ) {
@@ -504,7 +501,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                     auto u = x->second->type()->as<type::Unit>();
                     auto a = u->attributes()->find("&convert");
                     assert(a);
-                    auto e = a->valueAsExpression()->get();
+                    auto e = *a->valueAsExpression();
                     if ( e->isResolved() )
                         t = e->type();
                 }
@@ -527,7 +524,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
             if ( t ) {
                 recordChange(n, "item type");
-                n->setItemType(context(), std::move(t));
+                n->setItemType(context(), t);
             }
         }
     }
@@ -562,7 +559,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
             }
 
             if ( auto t = resolved->first->template tryAs<hilti::declaration::Type>() ) {
-                QualifiedTypePtr tt = builder()->qualifiedType(builder()->typeName(id), hilti::Constness::Mutable);
+                QualifiedType* tt = builder()->qualifiedType(builder()->typeName(id), hilti::Constness::Mutable);
 
                 // If a unit comes with a &convert attribute, we wrap it into a
                 // subitem so that we have our recursive machinery available
@@ -573,14 +570,13 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                                                                     {}, {}, {}, {}, {}, n->meta());
                     inner_field->setIndex(*n->index());
 
-                    auto outer_field =
-                        builder()->typeUnitItemField(n->fieldID(), std::move(inner_field), n->engine(), n->isSkip(), {},
-                                                     n->repeatCount(), n->sinks(), n->attributes(), n->condition(),
-                                                     n->hooks(), n->meta());
+                    auto outer_field = builder()->typeUnitItemField(n->fieldID(), inner_field, n->engine(), n->isSkip(),
+                                                                    {}, n->repeatCount(), n->sinks(), n->attributes(),
+                                                                    n->condition(), n->hooks(), n->meta());
 
                     outer_field->setIndex(*n->index());
 
-                    replaceNode(n, std::move(outer_field));
+                    replaceNode(n, outer_field);
                 }
 
                 else
@@ -626,7 +622,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
 } // anonymous namespace
 
-bool detail::resolver::resolve(Builder* builder, const NodePtr& root) {
+bool detail::resolver::resolve(Builder* builder, Node* root) {
     hilti::util::timing::Collector _("spicy/compiler/ast/resolver");
 
     bool hilti_modified = (*hilti::plugin::registry().hiltiPlugin().ast_resolve)(builder, root);

--- a/spicy/toolchain/src/compiler/resolver.cc
+++ b/spicy/toolchain/src/compiler/resolver.cc
@@ -23,8 +23,8 @@ namespace {
 
 // Copy a range of nodes into an actual vector.
 template<typename T>
-auto copy_vector = [](const auto& in) -> std::vector<T*> {
-    std::vector<T*> out;
+auto copy_vector = [](const auto& in) -> NodeVector<T> {
+    NodeVector<T> out;
     for ( const auto& i : in )
         out.push_back(i);
 

--- a/spicy/toolchain/src/compiler/scope-builder.cc
+++ b/spicy/toolchain/src/compiler/scope-builder.cc
@@ -15,17 +15,17 @@ using namespace spicy;
 namespace {
 
 struct VisitorScopeBuilder : visitor::PostOrder {
-    explicit VisitorScopeBuilder(Builder* builder, const ASTRootPtr& root) : root(root), builder(builder) {}
+    explicit VisitorScopeBuilder(Builder* builder, hilti::ASTRoot* root) : root(root), builder(builder) {}
 
-    const ASTRootPtr& root;
+    hilti::ASTRoot* root = nullptr;
     Builder* builder;
 
     void operator()(type::Unit* n) final {
         if ( auto d = n->self() )
-            n->getOrCreateScope()->insert(std::move(d));
+            n->getOrCreateScope()->insert(d);
 
         for ( auto&& x : n->parameters() )
-            n->getOrCreateScope()->insert(std::move(x));
+            n->getOrCreateScope()->insert(x);
     }
 
     void operator()(type::unit::item::Field* n) final {
@@ -43,7 +43,7 @@ struct VisitorScopeBuilder : visitor::PostOrder {
                 n->getOrCreateScope()->insert(u->self());
 
             for ( auto&& x : u->parameters() )
-                n->getOrCreateScope()->insert(std::move(x));
+                n->getOrCreateScope()->insert(x);
         }
     }
 
@@ -56,7 +56,7 @@ struct VisitorScopeBuilder : visitor::PostOrder {
             n->getOrCreateScope()->insertNotFound(ID("__dd"));
 
         for ( auto&& x : n->ftype()->parameters() )
-            n->getOrCreateScope()->insert(std::move(x));
+            n->getOrCreateScope()->insert(x);
 
         if ( auto t = builder->context()->lookup(n->unitTypeIndex()) ) {
             auto u = t->as<type::Unit>();
@@ -64,7 +64,7 @@ struct VisitorScopeBuilder : visitor::PostOrder {
                 n->getOrCreateScope()->insert(u->self());
 
             for ( auto&& x : u->parameters() )
-                n->getOrCreateScope()->insert(std::move(x));
+                n->getOrCreateScope()->insert(x);
         }
     }
 
@@ -80,14 +80,14 @@ struct VisitorScopeBuilder : visitor::PostOrder {
 
             auto dd = hilti::expression::Keyword::createDollarDollarDeclaration(builder->context(),
                                                                                 pt->type()->elementType());
-            n->getOrCreateScope()->insert(std::move(dd));
+            n->getOrCreateScope()->insert(dd);
         }
     }
 };
 
 } // anonymous namespace
 
-void detail::scope_builder::build(Builder* builder, const ASTRootPtr& root) {
+void detail::scope_builder::build(Builder* builder, hilti::ASTRoot* root) {
     hilti::util::timing::Collector _("spicy/compiler/ast/scope-builder");
 
     (*hilti::plugin::registry().hiltiPlugin().ast_build_scopes)(builder, root);

--- a/spicy/toolchain/tests/grammar.cc
+++ b/spicy/toolchain/tests/grammar.cc
@@ -31,13 +31,13 @@ static auto sequence(hilti::ASTContext* ctx, const std::string& symbol, Ps l) {
     return std::make_unique<spicy::detail::codegen::production::Sequence>(ctx, symbol, std::move(l));
 }
 
-static auto variable(hilti::ASTContext* ctx, const std::string& symbol, const hilti::UnqualifiedTypePtr& t) {
+static auto variable(hilti::ASTContext* ctx, const std::string& symbol, hilti::UnqualifiedType* t) {
     return std::make_unique<
         spicy::detail::codegen::production::Variable>(ctx, symbol,
                                                       hilti::QualifiedType::create(ctx, t, hilti::Constness::Mutable));
 }
 
-static auto type_literal(hilti::ASTContext* ctx, const std::string& symbol, const spicy::UnqualifiedTypePtr& t) {
+static auto type_literal(hilti::ASTContext* ctx, const std::string& symbol, spicy::UnqualifiedType* t) {
     return std::make_unique<
         spicy::detail::codegen::production::TypeLiteral>(ctx, symbol,
                                                          hilti::QualifiedType::create(ctx, t, hilti::Constness::Const));


### PR DESCRIPTION
Rework memory management for AST nodes.

We switch memory management of AST nodes to an arena/bump allocator
that releases them as a whole once the AST gets destroyed, not
individually/continiously through their own life-time scoping. This
then allows us to also switch them from `shared_ptr` to raw pointers
throughout the AST code. The result is a compiler speed up of about
20% for some complex analyzer.
