### PR TITLE
Rework order of C++ module codegen.

### DIFF
--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -213,8 +213,7 @@ public:
      * dependent units, vs just direct dependencies of the specified unit
      * @return set of dependencies
      */
-    std::set<declaration::module::UID> dependencies(const declaration::module::UID& uid,
-                                                       bool recursive = false) const;
+    std::set<declaration::module::UID> dependencies(const declaration::module::UID& uid, bool recursive = false) const;
 
     /**
      * Updates an existing UID with new information.

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -213,7 +213,7 @@ public:
      * dependent units, vs just direct dependencies of the specified unit
      * @return set of dependencies
      */
-    std::vector<declaration::module::UID> dependencies(const declaration::module::UID& uid,
+    std::set<declaration::module::UID> dependencies(const declaration::module::UID& uid,
                                                        bool recursive = false) const;
 
     /**

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/hilti/toolchain/include/ast/declarations/module.h
+++ b/hilti/toolchain/include/ast/declarations/module.h
@@ -87,7 +87,7 @@ public:
      */
     void add(ASTContext* ctx, Statement* s) { child<statement::Block>(0)->add(ctx, s); }
 
-    void addDependency(declaration::module::UID uid) { _dependencies.emplace_back(std::move(uid)); }
+    void addDependency(declaration::module::UID uid) { _dependencies.insert(std::move(uid)); }
     void setScopePath(const ID& scope) { _scope_path = scope; }
     void setUID(declaration::module::UID uid) { _uid = std::move(uid); }
 
@@ -136,7 +136,7 @@ protected:
 private:
     declaration::module::UID _uid;
     ID _scope_path;
-    std::vector<declaration::module::UID> _dependencies;
+    std::set<declaration::module::UID> _dependencies;
     bool _skip_implementation = true;
     std::shared_ptr<::hilti::detail::cxx::Unit> _cxx_unit = {};
 };

--- a/hilti/toolchain/include/ast/declarations/module.h
+++ b/hilti/toolchain/include/ast/declarations/module.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -17,7 +18,13 @@
 #include <hilti/ast/node.h>
 #include <hilti/ast/statements/block.h>
 
-namespace hilti::declaration {
+namespace hilti {
+
+namespace detail::cxx {
+class Unit;
+}
+
+namespace declaration {
 
 /** AST node for a module declaration. */
 class Module : public Declaration {
@@ -40,6 +47,9 @@ public:
 
     /** Sets the module's `%skip-implementation` flag. */
     void setSkipImplementation(bool skip_implementation) { _skip_implementation = skip_implementation; }
+
+    auto cxxUnit() const { return _cxx_unit; }
+    void setCxxUnit(std::shared_ptr<::hilti::detail::cxx::Unit> unit) { _cxx_unit = std::move(unit); }
 
     /**
      * Removes any content from the module. The result is an empty module just
@@ -128,6 +138,8 @@ private:
     ID _scope_path;
     std::vector<declaration::module::UID> _dependencies;
     bool _skip_implementation = true;
+    std::shared_ptr<::hilti::detail::cxx::Unit> _cxx_unit = {};
 };
 
-} // namespace hilti::declaration
+} // namespace declaration
+} // namespace hilti

--- a/hilti/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/hilti/toolchain/include/compiler/detail/codegen/codegen.h
@@ -65,11 +65,11 @@ public:
     CodeGen(const std::shared_ptr<Context>& context);
 
     /** Entry point for code generation. */
-    Result<cxx::Unit> compileModule(declaration::Module* module,
-                                    bool include_implementation); // NOLINT(google-runtime-references)
+    Result<std::shared_ptr<cxx::Unit>> compileModule(declaration::Module* module,
+                                                     bool include_implementation); // NOLINT(google-runtime-references)
 
     /** Entry point for generating additional cross-unit C++ code through HILTI's linker. */
-    Result<cxx::Unit> linkUnits(const std::vector<cxx::linker::MetaData>& mds);
+    Result<std::shared_ptr<cxx::Unit>> linkUnits(const std::vector<cxx::linker::MetaData>& mds);
 
     std::shared_ptr<Context> context() const { return _context.lock(); }
     const Options& options() const { return context()->options(); }
@@ -155,7 +155,7 @@ private:
     std::weak_ptr<Context> _context;
     std::unique_ptr<Builder> _builder;
 
-    std::unique_ptr<cxx::Unit> _cxx_unit;
+    std::shared_ptr<cxx::Unit> _cxx_unit;
     hilti::declaration::Module* _hilti_module = nullptr;
     std::vector<detail::cxx::Expression> _self = {{"__self", Side::LHS}};
     std::vector<detail::cxx::Expression> _dd = {{"__dd", Side::LHS}};

--- a/hilti/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/hilti/toolchain/include/compiler/detail/codegen/codegen.h
@@ -65,8 +65,7 @@ public:
     CodeGen(const std::shared_ptr<Context>& context);
 
     /** Entry point for code generation. */
-    Result<std::shared_ptr<cxx::Unit>> compileModule(declaration::Module* module,
-                                                     bool include_implementation); // NOLINT(google-runtime-references)
+    Result<std::shared_ptr<cxx::Unit>> compileModule(declaration::Module* module);
 
     /** Entry point for generating additional cross-unit C++ code through HILTI's linker. */
     Result<std::shared_ptr<cxx::Unit>> linkUnits(const std::vector<cxx::linker::MetaData>& mds);

--- a/hilti/toolchain/include/compiler/detail/cxx/linker.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/linker.h
@@ -31,11 +31,11 @@ public:
 
     void add(const linker::MetaData& md);
     void finalize();
-    Result<cxx::Unit> linkerUnit(); // only after finalize and at least one module
+    Result<std::shared_ptr<cxx::Unit>> linkerUnit(); // only after finalize and at least one module
 
 private:
     CodeGen* _codegen;
-    std::optional<cxx::Unit> _linker_unit;
+    std::shared_ptr<cxx::Unit> _linker_unit;
 
     std::set<std::pair<std::string, std::string>> _modules;
     std::map<std::string, std::vector<cxx::linker::Join>> _joins;

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -105,7 +105,7 @@ public:
      * @param recursive if true, return the transitive closure of all
      * dependent units, vs just direct dependencies of the current unit
      */
-    std::vector<declaration::module::UID> dependencies(bool recursive = false) const;
+    std::set<declaration::module::UID> dependencies(bool recursive = false) const;
 
     /**
      * Returns the unit's meta data for the internal HILTI linker.
@@ -164,7 +164,8 @@ public:
      * @param path path associated with the C++ code, if any
      * @return instantiated unit, or an appropriate error result if operation failed
      */
-    static Result<std::shared_ptr<Unit>> fromCXX(const std::shared_ptr<Context>& context, std::shared_ptr<detail::cxx::Unit> cxx,
+    static Result<std::shared_ptr<Unit>> fromCXX(const std::shared_ptr<Context>& context,
+                                                 std::shared_ptr<detail::cxx::Unit> cxx,
                                                  const hilti::rt::filesystem::path& path = "");
 
     // Must already be part of AST.

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -163,7 +164,7 @@ public:
      * @param path path associated with the C++ code, if any
      * @return instantiated unit, or an appropriate error result if operation failed
      */
-    static Result<std::shared_ptr<Unit>> fromCXX(const std::shared_ptr<Context>& context, const detail::cxx::Unit& cxx,
+    static Result<std::shared_ptr<Unit>> fromCXX(const std::shared_ptr<Context>& context, std::shared_ptr<detail::cxx::Unit> cxx,
                                                  const hilti::rt::filesystem::path& path = "");
 
     // Must already be part of AST.
@@ -207,15 +208,16 @@ private:
     // `from*()` factory functions instead to instantiate a unit.
     Unit(const std::shared_ptr<Context>& context, declaration::module::UID uid)
         : _context(context), _uid(std::move(uid)) {}
-    Unit(const std::shared_ptr<Context>& context, declaration::module::UID uid, const detail::cxx::Unit& cxx_unit)
-        : _context(context), _uid(std::move(uid)), _cxx_unit(cxx_unit) {}
+    Unit(const std::shared_ptr<Context>& context, declaration::module::UID uid,
+         std::shared_ptr<detail::cxx::Unit> cxx_unit)
+        : _context(context), _uid(std::move(uid)), _cxx_unit(std::move(cxx_unit)) {}
 
-    Result<detail::cxx::Unit> _codegenModule(const declaration::module::UID& uid);
+    Result<std::shared_ptr<detail::cxx::Unit>> _codegenModule(const declaration::module::UID& uid);
 
-    std::weak_ptr<Context> _context;            // global context
-    declaration::module::UID _uid;              // module's globally unique ID
-    std::optional<detail::cxx::Unit> _cxx_unit; // compiled C++ code for this unit, once available
-    bool _requires_compilation = false;         // mark explicitly as requiring compilation to C++
+    std::weak_ptr<Context> _context;              // global context
+    declaration::module::UID _uid;                // module's globally unique ID
+    std::shared_ptr<detail::cxx::Unit> _cxx_unit; // compiled C++ code for this unit, once available
+    bool _requires_compilation = false;           // mark explicitly as requiring compilation to C++
 };
 
 } // namespace hilti

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -682,25 +682,24 @@ void ASTContext::_saveIterationAST(const Plugin& plugin, const std::string& pref
 }
 
 static void _recursiveDependencies(const ASTContext* ctx, declaration::Module* module,
-                                   std::vector<declaration::module::UID>* seen) {
-    if ( std::find(seen->begin(), seen->end(), module->uid()) != seen->end() )
+                                   std::set<declaration::module::UID>* seen) {
+    if ( seen->count(module->uid()) )
         return;
 
     for ( const auto& uid : module->dependencies() ) {
-        seen->push_back(uid);
+        seen->insert(uid);
         auto dep = ctx->module(uid);
         assert(dep);
         _recursiveDependencies(ctx, dep, seen);
     }
 }
 
-std::vector<declaration::module::UID> ASTContext::dependencies(const declaration::module::UID& uid,
-                                                               bool recursive) const {
+std::set<declaration::module::UID> ASTContext::dependencies(const declaration::module::UID& uid, bool recursive) const {
     auto m = module(uid);
     assert(m);
 
     if ( recursive ) {
-        std::vector<declaration::module::UID> seen;
+        std::set<declaration::module::UID> seen;
         _recursiveDependencies(this, m, &seen);
         return seen;
     }

--- a/hilti/toolchain/src/ast/declarations/module.cc
+++ b/hilti/toolchain/src/ast/declarations/module.cc
@@ -4,6 +4,7 @@
 #include <hilti/ast/declarations/property.h>
 #include <hilti/ast/statements/block.h>
 #include <hilti/ast/visitor.h>
+#include <hilti/compiler/detail/cxx/unit.h>
 
 using namespace hilti;
 

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -751,7 +751,7 @@ std::vector<cxx::Expression> CodeGen::compileCallArguments(const node::Range<Exp
     return x;
 }
 
-Result<std::shared_ptr<cxx::Unit>> CodeGen::compileModule(declaration::Module* module, bool include_implementation) {
+Result<std::shared_ptr<cxx::Unit>> CodeGen::compileModule(declaration::Module* module) {
     if ( auto cxx = module->cxxUnit() )
         return cxx;
 
@@ -769,7 +769,7 @@ Result<std::shared_ptr<cxx::Unit>> CodeGen::compileModule(declaration::Module* m
         v.dispatch(i);
 
     GlobalsVisitor::addDeclarations(this, module, ID(std::string(_cxx_unit->moduleID())), _cxx_unit.get(),
-                                    include_implementation);
+                                    ! module->skipImplementation());
 
     auto x = _need_decls;
     for ( const auto& t : x ) {

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -25,6 +25,10 @@ using util::fmt;
 using namespace hilti::detail;
 using namespace hilti::detail::codegen;
 
+namespace hilti::logging::debug {
+inline const DebugStream Compiler("compiler");
+} // namespace hilti::logging::debug
+
 namespace {
 
 // This visitor will only receive AST nodes of the first two levels (i.e.,
@@ -747,7 +751,12 @@ std::vector<cxx::Expression> CodeGen::compileCallArguments(const node::Range<Exp
     return x;
 }
 
-Result<cxx::Unit> CodeGen::compileModule(declaration::Module* module, bool include_implementation) {
+Result<std::shared_ptr<cxx::Unit>> CodeGen::compileModule(declaration::Module* module, bool include_implementation) {
+    if ( auto cxx = module->cxxUnit() )
+        return cxx;
+
+    HILTI_DEBUG(logging::debug::Compiler, fmt("generating C++ for module %s", module->uid()));
+    logging::DebugPushIndent __(logging::debug::Compiler);
     util::timing::Collector _("hilti/compiler/codegen");
 
     _cxx_unit = std::make_unique<cxx::Unit>(context());
@@ -768,14 +777,14 @@ Result<cxx::Unit> CodeGen::compileModule(declaration::Module* module, bool inclu
             unit()->add(*dt);
     }
 
-    cxx::Unit u = *_cxx_unit;
+    module->setCxxUnit(std::move(_cxx_unit));
     _cxx_unit.reset();
     _hilti_module = nullptr;
 
-    return std::move(u);
+    return module->cxxUnit();
 }
 
-Result<cxx::Unit> CodeGen::linkUnits(const std::vector<cxx::linker::MetaData>& mds) {
+Result<std::shared_ptr<cxx::Unit>> CodeGen::linkUnits(const std::vector<cxx::linker::MetaData>& mds) {
     util::timing::Collector _("hilti/linker");
 
     cxx::Linker linker(this);

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -621,8 +621,6 @@ Result<Nothing> Driver::_codegenUnits() {
         // No need to kick off code generation.
         return Nothing();
 
-    logging::DebugPushIndent _(logging::debug::Compiler);
-
     for ( auto& [uid, unit] : _units ) {
         if ( ! unit->isCompiledHILTI() )
             continue;

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -119,7 +119,7 @@ Result<Nothing> Unit::codegen() {
     return Nothing();
 }
 
-std::vector<declaration::module::UID> Unit::dependencies(bool recursive) const {
+std::set<declaration::module::UID> Unit::dependencies(bool recursive) const {
     return context()->astContext()->dependencies(_uid, recursive);
 }
 

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -31,10 +31,11 @@ Result<std::shared_ptr<Unit>> Unit::fromSource(const std::shared_ptr<Context>& c
     return std::shared_ptr<Unit>(new Unit(context, *uid));
 }
 
-Result<std::shared_ptr<Unit>> Unit::fromCXX(const std::shared_ptr<Context>& context, const detail::cxx::Unit& cxx,
+Result<std::shared_ptr<Unit>> Unit::fromCXX(const std::shared_ptr<Context>& context,
+                                            std::shared_ptr<detail::cxx::Unit> cxx,
                                             const hilti::rt::filesystem::path& path) {
     auto uid = declaration::module::UID("<from-cpp-code>", path.native());
-    return std::shared_ptr<Unit>(new Unit(context, uid, cxx));
+    return std::shared_ptr<Unit>(new Unit(context, uid, std::move(cxx)));
 }
 
 std::shared_ptr<Unit> Unit::fromExistingUID(const std::shared_ptr<Context>& context, declaration::module::UID uid) {
@@ -68,12 +69,9 @@ Result<Nothing> Unit::createPrototypes(std::ostream& out) {
     return _cxx_unit->createPrototypes(out);
 }
 
-Result<detail::cxx::Unit> Unit::_codegenModule(const declaration::module::UID& uid) {
+Result<std::shared_ptr<detail::cxx::Unit>> Unit::_codegenModule(const declaration::module::UID& uid) {
     auto module = context()->astContext()->module(uid);
     assert(module);
-
-    HILTI_DEBUG(logging::debug::Compiler, fmt("compiling module %s to C++", uid));
-    logging::DebugPushIndent _(logging::debug::Compiler);
 
     auto cxx = detail::CodeGen(context()).compileModule(module, ! module->skipImplementation());
 
@@ -91,6 +89,9 @@ Result<Nothing> Unit::codegen() {
     if ( ! _uid )
         return Nothing();
 
+    HILTI_DEBUG(logging::debug::Compiler, fmt("codegen module %s to C++", _uid));
+    logging::DebugPushIndent __(logging::debug::Compiler);
+
     auto cxx = _codegenModule(_uid);
     if ( ! cxx )
         return cxx.error();
@@ -102,14 +103,16 @@ Result<Nothing> Unit::codegen() {
     // only generated declarations.
     for ( const auto& d : dependencies(true) ) {
         HILTI_DEBUG(logging::debug::Compiler, fmt("importing declarations from module %s", d));
+        logging::DebugPushIndent _(logging::debug::Compiler);
+
         if ( auto other_cxx = _codegenModule(d) )
-            cxx->importDeclarations(*other_cxx);
+            (*cxx)->importDeclarations(**other_cxx);
         else
             return other_cxx.error();
     }
 
     HILTI_DEBUG(logging::debug::Compiler, fmt("finalizing module %s", _uid));
-    if ( auto x = cxx->finalize(); ! x )
+    if ( auto x = (*cxx)->finalize(); ! x )
         return x.error();
 
     _cxx_unit = *cxx;

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -73,7 +73,7 @@ Result<std::shared_ptr<detail::cxx::Unit>> Unit::_codegenModule(const declaratio
     auto module = context()->astContext()->module(uid);
     assert(module);
 
-    auto cxx = detail::CodeGen(context()).compileModule(module, ! module->skipImplementation());
+    auto cxx = detail::CodeGen(context()).compileModule(module);
 
     if ( logger().errors() )
         return result::Error("errors encountered during code generation");

--- a/tests/Baseline/hilti.ast.basic-module/output
+++ b/tests/Baseline/hilti.ast.basic-module/output
@@ -955,7 +955,8 @@
 [debug/compiler] [HILTI] validating (post)
 [debug/compiler] performing global transformations
 [debug/compiler] [HILTI] validating (post)
-[debug/compiler]   compiling module Foo to C++
+[debug/compiler] codegen module Foo to C++
+[debug/compiler]   generating C++ for module Foo
 [debug/compiler]   finalizing module Foo
 // Begin of Foo (from "<...>/basic-module.hlt")
 // Compiled by HILTI version X.X.X

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -1321,9 +1321,10 @@
 [debug/compiler] performing global transformations
 [debug/compiler] [HILTI] validating (post)
 [debug/driver] codegen for input unit Foo
-[debug/compiler]   compiling module Foo to C++
+[debug/compiler] codegen module Foo to C++
+[debug/compiler]   generating C++ for module Foo
 [debug/compiler]   importing declarations from module Bar
-[debug/compiler]   compiling module Bar to C++
+[debug/compiler]     generating C++ for module Bar
 [debug/compiler]   finalizing module Foo
 [debug/driver] saving C++ code for module Foo to /dev/stdout
 // Begin of Foo (from "foo.hlt")

--- a/tests/Baseline/hilti.hiltic.print.import/output
+++ b/tests/Baseline/hilti.hiltic.print.import/output
@@ -75,6 +75,8 @@ namespace __hlt::Bar {
     inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __init_module();
+    extern void __register_module();
 }
 
 namespace __hlt::Foo {

--- a/tests/Baseline/hilti.hiltic.print.import/output2
+++ b/tests/Baseline/hilti.hiltic.print.import/output2
@@ -56,6 +56,8 @@ namespace __hlt::Bar {
     extern std::optional<std::string> bar;
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __init_module();
+    extern void __register_module();
 }
 
 namespace __hlt::Foo {


### PR DESCRIPTION
We used to potentially codegen modules multiple times. Now we cache a
module's generated C++ code inside the AST node the first time we
create it. From there, we can then easily reuse it later, in
particular when needing to import its declarations into another
module. Internally, we switch storage for `cxx::Unit` to shared
pointers, and tweak the debug logging a bit for better readability in
this new model.
