### PR TITLE
Fix GCC false positive around `strncpy` use.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
+#include <cstring>
+
 #include <hilti/rt/json.h>
 
 #include <hilti/base/logger.h>
@@ -155,19 +157,19 @@ std::optional<std::string> cxx::normalizeID(std::string_view id) {
         switch ( c ) {
             // We normalize only characters that we expected to see here during codegen.
             case '%': {
-                strncpy(p, "0x25", 4);
+                memcpy(p, "0x25", 4); // NOLINT(bugprone-not-null-terminated-result)
                 p += 4;
                 break;
             }
 
             case '@': {
-                strncpy(p, "0x40", 4);
+                memcpy(p, "0x40", 4); // NOLINT(bugprone-not-null-terminated-result)
                 p += 4;
                 break;
             }
 
-            case '~': { // we expect to see this only at the beginning (for "~finally")
-                strncpy(p, "_0x7e_", 6);
+            case '~': {                 // we expect to see this only at the beginning (for "~finally")
+                memcpy(p, "_0x7e_", 6); // NOLINT(bugprone-not-null-terminated-result)
                 p += 6;
                 break;
             }


### PR DESCRIPTION
GCC's analysis assumes that `strncpy` should always produce null-terminated strings. For the use case here this is not the case as we store the resulting string into a hand-sized `std::string` later.

Work around the diagnostic by using `memcpy` (and surpressing a `clang-tidy` warning triggered by that).