### PR TITLE
Fix a few instances where codegen was non-deterministic.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -882,8 +882,6 @@ cxx::Expression CodeGen::unsignedIntegerToBitfield(type::Bitfield* t, const cxx:
 
 
 cxx::ID CodeGen::uniqueID(const std::string& prefix, Node* n) {
-    std::string x;
-
     if ( ! n->location() )
         // We rely on the location for creating a unique ID. If we ever arrive
         // here, it shouldn't be too difficult to get location information into

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/counter.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/counter.h
@@ -33,7 +33,7 @@ public:
     Expression* expression() const final { return _expression; }
 
     std::vector<std::vector<Production*>> rhss() const final { return {{_body.get()}}; };
-    std::string dump() const override { return hilti::util::fmt("counter(%s): %s", _expression, _body->symbol()); }
+    std::string dump() const override { return hilti::util::fmt("counter(%s): %s", *_expression, _body->symbol()); }
 
     SPICY_PRODUCTION
 

--- a/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
@@ -315,7 +315,7 @@ struct Visitor : public visitor::PreOrder {
     }
 
     void operator()(hilti::type::Vector* n) final {
-        auto sub = productionForType(n->elementType(), ID(fmt("%s", n->elementType())));
+        auto sub = productionForType(n->elementType(), ID(fmt("%s", *n->elementType())));
         result = productionForLoop(std::move(sub), n);
     }
 };

--- a/spicy/toolchain/src/compiler/codegen/production.cc
+++ b/spicy/toolchain/src/compiler/codegen/production.cc
@@ -60,7 +60,7 @@ std::string codegen::to_string(const Production& p) {
             args = hilti::util::fmt(", args: (%s)",
                                     hilti::util::join(hilti::node::transform(x,
                                                                              [](auto a) {
-                                                                                 return hilti::util::fmt("%s", a);
+                                                                                 return hilti::util::fmt("%s", *a);
                                                                              }),
                                                       ", "));
 

--- a/spicy/toolchain/src/compiler/codegen/production.cc
+++ b/spicy/toolchain/src/compiler/codegen/production.cc
@@ -43,7 +43,6 @@ bool codegen::production::isNullable(const std::vector<std::vector<Production*>>
 
 std::string codegen::to_string(const Production& p) {
     std::string can_sync;
-    std::string sync_at;
     std::string kind;
     std::string field;
     std::string container;

--- a/spicy/toolchain/src/compiler/codegen/productions/switch.cc
+++ b/spicy/toolchain/src/compiler/codegen/productions/switch.cc
@@ -26,7 +26,7 @@ std::string codegen::production::Switch::dump() const {
 
         exprs.reserve(c.first.size());
         for ( const auto& e : c.first )
-            exprs.push_back(hilti::util::fmt("%s", e));
+            exprs.push_back(hilti::util::fmt("%s", *e));
 
         if ( r.size() )
             r += " | ";


### PR DESCRIPTION
When switching to the new AST implementation a few instances snuck in
where codegen became non-deterministic. This seems to have exclusively
affected symbol indentifiers generated from productions where we would
accicentially output addresses instead of values. This patch fixes these
instances.