### PR TITLE
Fix inout unit parameter with reference

### DIFF
--- a/hilti/toolchain/include/ast/expressions/resolved-operator.h
+++ b/hilti/toolchain/include/ast/expressions/resolved-operator.h
@@ -40,7 +40,7 @@ public:
 
     std::string printSignature() const { return operator_::detail::printSignature(kind(), operands(), meta()); }
 
-    node::Properties properties() const final {
+    node::Properties properties() const override {
         auto p = node::Properties{{"kind", to_string(_operator->kind())}};
         return Expression::properties() + p;
     }

--- a/hilti/toolchain/include/ast/operators/common.h
+++ b/hilti/toolchain/include/ast/operators/common.h
@@ -10,9 +10,9 @@
 #include <hilti/ast/expressions/resolved-operator.h>
 #include <hilti/ast/forward.h>
 
-#define HILTI_NODE_OPERATOR(ns, cls)                                                                                   \
+#define HILTI_NODE_OPERATOR_CUSTOM_BASE(ns, cls, base)                                                                 \
     namespace ns {                                                                                                     \
-    class cls : public hilti::expression::ResolvedOperator {                                                           \
+    class cls : public base {                                                                                          \
     public:                                                                                                            \
         static cls* create(hilti::ASTContext* ctx, const hilti::Operator* op, hilti::QualifiedType* result,            \
                            const hilti::Expressions& operands, hilti::Meta meta) {                                     \
@@ -23,6 +23,8 @@
                                                                                                                        \
     private:                                                                                                           \
         cls(ASTContext* ctx, const hilti::Operator* op, QualifiedType* result, const Expressions& operands, Meta meta) \
-            : ResolvedOperator(ctx, NodeTags, op, result, operands, std::move(meta)) {}                                \
+            : base(ctx, NodeTags, op, result, operands, std::move(meta)) {}                                            \
     };                                                                                                                 \
     } // namespace ns
+
+#define HILTI_NODE_OPERATOR(ns, cls) HILTI_NODE_OPERATOR_CUSTOM_BASE(ns, cls, hilti::expression::ResolvedOperator)

--- a/hilti/toolchain/include/ast/operators/reference.h
+++ b/hilti/toolchain/include/ast/operators/reference.h
@@ -9,13 +9,39 @@
 
 namespace hilti::operator_ {
 
-HILTI_NODE_OPERATOR(strong_reference, Deref)
+namespace reference {
+
+/** Joint base class for all the references' `Deref` AST nodes. */
+class DerefBase : public expression::ResolvedOperator {
+public:
+    using expression::ResolvedOperator::ResolvedOperator;
+
+    /**
+     * Returns true if the operator has been marked as automatically created by
+     * the coercer.
+     */
+    auto isAutomaticCoercion() const { return _is_coercion; }
+
+    /** Marks the operators as automatically created by the coercer. */
+    void setIsAutomaticCoercion(bool is_coercion) { _is_coercion = is_coercion; }
+
+    node::Properties properties() const final {
+        auto p = node::Properties{{"auto", _is_coercion}};
+        return expression::ResolvedOperator::properties() + p;
+    }
+
+private:
+    bool _is_coercion = false;
+};
+} // namespace reference
+
+HILTI_NODE_OPERATOR_CUSTOM_BASE(strong_reference, Deref, reference::DerefBase)
 HILTI_NODE_OPERATOR(strong_reference, Equal)
 HILTI_NODE_OPERATOR(strong_reference, Unequal)
-HILTI_NODE_OPERATOR(weak_reference, Deref)
+HILTI_NODE_OPERATOR_CUSTOM_BASE(weak_reference, Deref, reference::DerefBase)
 HILTI_NODE_OPERATOR(weak_reference, Equal)
 HILTI_NODE_OPERATOR(weak_reference, Unequal)
-HILTI_NODE_OPERATOR(value_reference, Deref)
+HILTI_NODE_OPERATOR_CUSTOM_BASE(value_reference, Deref, reference::DerefBase)
 HILTI_NODE_OPERATOR(value_reference, Equal)
 HILTI_NODE_OPERATOR(value_reference, Unequal)
 

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -525,7 +525,15 @@ struct Visitor : hilti::visitor::PreOrder {
         auto t = n->op0()->type()->type();
 
         if ( auto tv = t->tryAs<type::Type_>() ) {
-            auto args = util::join(tupleArguments(n, n->op1()), ", ");
+            auto ctor = n->op1()->as<expression::Ctor>()->ctor();
+
+            if ( auto x = ctor->tryAs<ctor::Coerced>() )
+                ctor = x->coercedCtor();
+
+            auto args = util::join(cg->compileCallArguments(ctor->as<ctor::Tuple>()->value(),
+                                                            tv->typeValue()->type()->parameters()),
+                                   ", ");
+
             result = fmt("::hilti::rt::reference::make_strong<%s>(%s)",
                          cg->compile(tv->typeValue(), codegen::TypeUsage::Ctor), args);
         }

--- a/hilti/toolchain/src/compiler/coercer.cc
+++ b/hilti/toolchain/src/compiler/coercer.cc
@@ -914,14 +914,22 @@ Expression* skipReferenceValue(Builder* builder, Expression* op) {
     if ( ! op->type()->type()->isReferenceType() )
         return op;
 
+    operator_::reference::DerefBase* deref = nullptr;
+
     if ( op->type()->type()->isA<type::ValueReference>() )
-        return *value_reference_deref->instantiate(builder, {op}, op->meta());
+        deref = static_cast<operator_::reference::DerefBase*>(
+            *value_reference_deref->instantiate(builder, {op}, op->meta()));
     else if ( op->type()->type()->isA<type::StrongReference>() )
-        return *strong_reference_deref->instantiate(builder, {op}, op->meta());
+        deref = static_cast<operator_::reference::DerefBase*>(
+            *strong_reference_deref->instantiate(builder, {op}, op->meta()));
     else if ( op->type()->type()->isA<type::WeakReference>() )
-        return *weak_reference_deref->instantiate(builder, {op}, op->meta());
+        deref = static_cast<operator_::reference::DerefBase*>(
+            *weak_reference_deref->instantiate(builder, {op}, op->meta()));
     else
         logger().internalError("unknown reference type");
+
+    deref->setIsAutomaticCoercion(true);
+    return deref;
 }
 
 static CoercedExpression _coerceExpression(Builder* builder, Expression* e, QualifiedType* src_, QualifiedType* dst_,

--- a/tests/spicy/types/unit/context-inout.spicy
+++ b/tests/spicy/types/unit/context-inout.spicy
@@ -11,6 +11,11 @@ type X = unit(inout ctx: Ctx) {
 
 public type Y = unit {
 	%context = Ctx;
+
+	on %init {
+		new X(self.context()); # make sure this compiles as well (regression test for #1719)
+	}
+
 	: X(self.context());
 
 	on %done() { print self.context(); }


### PR DESCRIPTION
- **Unify code generation for `new`.**
- **Mark automatic derefs inside the operator's AST node.**
- **Fix `new` passing a unit reference to an `inout` unit parameter.**

Closes #1719.