### PR TITLE
Avoid copying input data where we can

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -185,7 +185,7 @@ public:
     // Creates a new copy of the data internally if the chunk is currently not
     // owning it. On return, is guaranteed to now own the data.
     void makeOwning() {
-        if ( _allocated > 0 || ! _data )
+        if ( _size == 0 || _allocated > 0 || ! _data )
             return;
 
         auto* data = new Byte[_size];

--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -1720,6 +1720,13 @@ public:
     /** Returns true if the instance is currently frozen. */
     bool isFrozen() const { return _chain->isFrozen(); }
 
+    /**
+     * Returns the stream into a freshly initialized state, as if it was just
+     * created. (This concerns only externally visible state, it retains any
+     * potentially cached resources for reuse.)
+     */
+    void reset() { _chain->reset(); }
+
     /** Ensure the stream fully owns all its data. */
     void makeOwning() {
         // Only the final chunk can be non-owning, that's guaranteed by

--- a/hilti/runtime/src/types/stream.cc
+++ b/hilti/runtime/src/types/stream.cc
@@ -10,6 +10,12 @@ using namespace hilti::rt;
 using namespace hilti::rt::stream;
 using namespace hilti::rt::stream::detail;
 
+namespace {
+// Provide a valid non-null pointer for zero-size data. We initialize it to an
+// actual string for easier debugging.
+const Byte* EmptyData = reinterpret_cast<const Byte*>("<empty>");
+} // namespace
+
 Chunk::~Chunk() {
     if ( _allocated > 0 )
         delete[] _data;
@@ -23,18 +29,33 @@ Chunk::~Chunk() {
 }
 
 Chunk::Chunk(const Offset& offset, const View& d) : _offset(offset), _size(d.size()), _allocated(_size) {
+    if ( _size == 0 ) {
+        _data = EmptyData;
+        return;
+    }
+
     auto data = new Byte[_size];
     d.copyRaw(data);
     _data = data;
 }
 
 Chunk::Chunk(const Offset& offset, std::string s) : _offset(offset), _size(s.size()), _allocated(_size) {
+    if ( _size == 0 ) {
+        _data = EmptyData;
+        return;
+    }
+
     auto data = new Byte[_size];
     memcpy(data, s.data(), _size);
     _data = data;
 }
 
 Chunk::Chunk(const Offset& offset, const Byte* b, size_t size) : _offset(offset), _size(size), _allocated(_size) {
+    if ( _size == 0 ) {
+        _data = EmptyData;
+        return;
+    }
+
     auto data = new Byte[_size];
     memcpy(data, b, _size);
     _data = data;


### PR DESCRIPTION
This is a bit experimental still. It seems to work as intended,
however I'm not sure yet if it's worth the complexity. On the traces
I've been trying so far (some DNS and TLS traffic), CPU usage actually
remains about the same (not worse, not better). But memory usage
improves about 4-5% for TLS (while it remains about the same for DNS).
However, this could all be different with larger, more realistic
input; and also better handle some degenerated corner cases. Plus, if
nothing else this addresses the occasional concern of "Spicy copying
all data" ...


- **Extend stream API to allow for chunks that don't own their data.**
- **Cache previously trimmed chunks inside stream for reuse.**
- **Give stream a method to reset it into freshly initialized state.**
- **Update Spicy runtime driver to use new stream features for improved performance.**
