### PR TITLE
Fix `&convert` on bit range

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,6 +66,8 @@ Checks: '
   -readability-qualified-auto,
   -readability-simplify-boolean-expr,
   -readability-use-anyofallof,
+  -readability-identifier-length,
+  -readability-implicit-bool-conversion,
   '
 
 HeaderFilterRegex: '(hilti|spicy)/[a-zA-Z]+/include/([a-zA-Z]+/)*[a-zA-Z]+\.h'

--- a/hilti/runtime/include/types/bitfield.h
+++ b/hilti/runtime/include/types/bitfield.h
@@ -23,7 +23,18 @@ struct isBitfield {};
 /// printing.
 template<typename... Ts>
 struct Bitfield : public trait::isBitfield {
-    std::tuple<std::optional<Ts>...> value;
+    using value_type = std::tuple<std::optional<Ts>...>;
+
+    Bitfield(value_type v = {}) : value(std::move(v)) {}
+
+    /**
+     * Support instantiation from another bitfield type as long as all types
+     * convert over.
+     */
+    template<typename... Us>
+    Bitfield(Bitfield<Us...> other) : value(std::move(other.value)) {}
+
+    value_type value;
 };
 
 /// Construct a Bitfield.
@@ -31,7 +42,7 @@ struct Bitfield : public trait::isBitfield {
 /// Since a bitfield always owns its values this takes all fields by value.
 template<typename... Ts>
 Bitfield<Ts...> make_bitfield(Ts... args) {
-    return Bitfield<Ts...>{{}, std::make_tuple(std::move(args)...)};
+    return {typename Bitfield<Ts...>::value_type(std::move(args)...)};
 }
 
 namespace bitfield {

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -39,8 +39,7 @@ struct Visitor : hilti::visitor::PreOrder {
                 values.emplace_back("std::nullopt");
         }
 
-        result =
-            fmt("hilti::rt::Bitfield<%s>{{}, std::make_tuple(%s)}", util::join(types, ", "), util::join(values, ", "));
+        result = fmt("hilti::rt::Bitfield<%s>(std::make_tuple(%s))", util::join(types, ", "), util::join(values, ", "));
     }
     void operator()(ctor::Bool* n) final { result = fmt("::hilti::rt::Bool(%s)", n->value() ? "true" : "false"); }
 

--- a/tests/Baseline/spicy.types.bitfield.parse-and-convert/output
+++ b/tests/Baseline/spicy.types.bitfield.parse-and-convert/output
@@ -15,4 +15,7 @@ mini::Y {
   d: {
     d: foo
   }
+  e: {
+    d: True
+  }
 }

--- a/tests/hilti/types/bitfield/convert.hlt
+++ b/tests/hilti/types/bitfield/convert.hlt
@@ -8,10 +8,14 @@ import hilti;
 type X = bitfield(32) {
     a: 0..4 &convert="string";
     b: 1..2 &convert=(2 * $$);
+    c: 3..4 &convert=($$ == 2);
+    d: 5..6;
 };
 
 global X x = 255;
 assert x.a == "string";
 assert x.b == 6;
+#assert x.c == True;
+assert x.d == 3;
 
 }

--- a/tests/spicy/types/bitfield/parse-and-convert.spicy
+++ b/tests/spicy/types/bitfield/parse-and-convert.spicy
@@ -1,6 +1,6 @@
 # @TEST-EXEC: spicyc -dj %INPUT -o mini.hlto >>output
-# @TEST-EXEC: printf '\377\377\377\377' | spicy-dump -p mini::X mini.hlto >>output
-# @TEST-EXEC: printf '\377\377\377\377' | spicy-dump -p mini::Y mini.hlto >>output
+# @TEST-EXEC: printf '\377\377\377\377\377' | spicy-dump -p mini::X mini.hlto >>output
+# @TEST-EXEC: printf '\377\377\377\377\377' | spicy-dump -p mini::Y mini.hlto >>output
 # @TEST-EXEC: btest-diff output
 
 module mini;
@@ -29,6 +29,10 @@ public type Y = unit {
 
     d: bitfield(8) {
         d: 0..7 &convert="foo";
+    };
+
+    e: bitfield(8) {
+        d: 0..7 &convert=($$ == 255); # regression test for #1664
     };
 };
 


### PR DESCRIPTION
- **Suppress new clang-tidy warnings.**
- **Fix `&convert` typing issue with bit ranges.**
