### PR TITLE
Bring back `DeferredExpression`

### DIFF
--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -139,6 +139,7 @@ add_executable(
     src/tests/bytes.cc
     src/tests/context.cc
     src/tests/debug-logger.cc
+    src/tests/deferred-expression.cc
     src/tests/enum.cc
     src/tests/exception.cc
     src/tests/fiber.cc

--- a/hilti/runtime/include/deferred-expression.h
+++ b/hilti/runtime/include/deferred-expression.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <utility>
+
+#include <hilti/rt/extension-points.h>
+#include <hilti/rt/types/result.h>
+
+namespace hilti::rt {
+
+/**
+ * Wrapper for an expression that's evaluation is deferred until requested.
+ * The expression must be wrapped into a function call, and it's evaluation
+ * is requested through the wrapper's call operator.
+ *
+ * The function should be stateless as it might be invoked an unspecified
+ * number of times.
+ */
+template<typename Result>
+class DeferredExpression {
+public:
+    DeferredExpression(std::function<Result()> expr) : _expr(std::move(expr)) {}
+    DeferredExpression() = delete;
+    DeferredExpression(const DeferredExpression&) = default;
+    DeferredExpression(DeferredExpression&&) noexcept = default;
+
+    ~DeferredExpression() = default;
+
+    DeferredExpression& operator=(const DeferredExpression&) = default;
+    DeferredExpression& operator=(DeferredExpression&&) noexcept = default;
+
+    Result operator()() const { return _expr(); }
+
+private:
+    std::function<Result()> _expr;
+};
+
+namespace detail::adl {
+template<typename Result>
+inline std::string to_string(const DeferredExpression<Result>& x, adl::tag /*unused*/) {
+    return hilti::rt::to_string(x());
+}
+} // namespace detail::adl
+
+// This function is declared as an overload since we cannot partially specialize
+// `hilti::detail::to_string_for_print` for `DeferredExpression<T>`.
+template<typename Result>
+inline std::string to_string_for_print(const DeferredExpression<Result>& x) {
+    return hilti::rt::to_string_for_print(x());
+}
+
+template<typename Result>
+inline std::ostream& operator<<(std::ostream& out, const DeferredExpression<Result>& x) {
+    return out << to_string_for_print(x);
+}
+
+} // namespace hilti::rt

--- a/hilti/runtime/include/libhilti.h
+++ b/hilti/runtime/include/libhilti.h
@@ -10,6 +10,7 @@
 #include <hilti/rt/autogen/version.h>
 #include <hilti/rt/configuration.h>
 #include <hilti/rt/context.h>
+#include <hilti/rt/deferred-expression.h>
 #include <hilti/rt/exception.h>
 #include <hilti/rt/extension-points.h>
 #include <hilti/rt/fiber-check-stack.h>

--- a/hilti/runtime/src/tests/deferred-expression.cc
+++ b/hilti/runtime/src/tests/deferred-expression.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
+
+#include <cstddef>
+#include <type_traits>
+
+#include <hilti/rt/deferred-expression.h>
+#include <hilti/rt/doctest.h>
+#include <hilti/rt/types/integer.h>
+
+using namespace hilti::rt;
+
+TEST_SUITE_BEGIN("DeferredExpression");
+
+TEST_CASE("assign") {
+    int i = 0;
+    auto expr = DeferredExpression<int32_t>([&]() { return ++i; });
+    REQUIRE_EQ(i, 0);
+
+    CHECK_EQ(expr(), 1);
+    CHECK_EQ(i, 1);
+
+    SUBCASE("rvalue") {
+        expr = DeferredExpression<int32_t>([]() { return 0; });
+        CHECK_EQ(expr(), 0);
+        CHECK_EQ(i, 1); // Not incrementing anymore.
+    }
+
+    SUBCASE("lvalue") {
+        const auto expr2 = DeferredExpression<int32_t>([]() { return 0; });
+        expr = expr2;
+        CHECK_EQ(expr(), 0);
+        CHECK_EQ(i, 1); // Not incrementing anymore.
+    }
+}
+
+TEST_CASE("construct") {
+    int i = 0;
+    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+
+    SUBCASE("default") {
+        // Construction does not evaluate passed function.
+        CHECK_EQ(i, 0);
+    }
+
+    SUBCASE("copy") {
+        auto expr2 = DeferredExpression(expr);
+        // Copy construction does not evaluate passed function.
+        CHECK_EQ(i, 0);
+
+        // Copies share any data dependencies of original function.
+        REQUIRE_EQ(expr(), 1);
+        CHECK_EQ(i, 1);
+
+        REQUIRE_EQ(expr2(), 2);
+        CHECK_EQ(i, 2);
+    }
+
+    SUBCASE("move") {
+        auto expr2 = DeferredExpression(std::move(expr));
+        // Move construction does not evaluate passed function.
+        CHECK_EQ(i, 0);
+
+        REQUIRE_EQ(expr2(), 1);
+        CHECK_EQ(i, 1);
+    }
+}
+
+TEST_CASE("evaluate") {
+    int i = 0;
+    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+
+    CHECK_EQ(expr(), 1);
+    CHECK_EQ(expr(), 2);
+}
+
+TEST_CASE("fmt") {
+    int i = 0;
+    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+
+    // Stringification evaluates the expression.
+    CHECK_EQ(fmt("%s", expr), "1");
+    CHECK_EQ(fmt("%s", expr), "2");
+}
+
+TEST_CASE("to_string") {
+    int i = 0;
+    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+
+    // Stringification evaluates the expression.
+    CHECK_EQ(to_string(expr), "1");
+    CHECK_EQ(to_string(expr), "2");
+}
+
+TEST_CASE("to_string_for_print") {
+    int i = 0;
+    auto expr = DeferredExpression<Bytes>([&i]() { return Bytes(fmt("\\x0%d", ++i)); });
+
+    // Stringification evaluates the expression.
+    CHECK_EQ(to_string_for_print(expr), R"#(\\x01)#");
+    CHECK_EQ(to_string_for_print(expr), R"#(\\x02)#");
+}
+
+TEST_SUITE_END();

--- a/hilti/runtime/src/tests/deferred-expression.cc
+++ b/hilti/runtime/src/tests/deferred-expression.cc
@@ -13,21 +13,14 @@ TEST_SUITE_BEGIN("DeferredExpression");
 
 TEST_CASE("assign") {
     int i = 0;
-    auto expr = DeferredExpression<int32_t>([&]() { return ++i; });
+    auto expr = make_deferred<int32_t>([&]() { return ++i; });
     REQUIRE_EQ(i, 0);
 
     CHECK_EQ(expr(), 1);
     CHECK_EQ(i, 1);
 
     SUBCASE("rvalue") {
-        expr = DeferredExpression<int32_t>([]() { return 0; });
-        CHECK_EQ(expr(), 0);
-        CHECK_EQ(i, 1); // Not incrementing anymore.
-    }
-
-    SUBCASE("lvalue") {
-        const auto expr2 = DeferredExpression<int32_t>([]() { return 0; });
-        expr = expr2;
+        auto expr = make_deferred<int32_t>([]() { return 0; });
         CHECK_EQ(expr(), 0);
         CHECK_EQ(i, 1); // Not incrementing anymore.
     }
@@ -35,7 +28,7 @@ TEST_CASE("assign") {
 
 TEST_CASE("construct") {
     int i = 0;
-    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+    auto expr = make_deferred<int>([&i]() { return ++i; });
 
     SUBCASE("default") {
         // Construction does not evaluate passed function.
@@ -67,7 +60,7 @@ TEST_CASE("construct") {
 
 TEST_CASE("evaluate") {
     int i = 0;
-    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+    auto expr = make_deferred<int>([&i]() { return ++i; });
 
     CHECK_EQ(expr(), 1);
     CHECK_EQ(expr(), 2);
@@ -75,7 +68,7 @@ TEST_CASE("evaluate") {
 
 TEST_CASE("fmt") {
     int i = 0;
-    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+    auto expr = make_deferred<int>([&i]() { return ++i; });
 
     // Stringification evaluates the expression.
     CHECK_EQ(fmt("%s", expr), "1");
@@ -84,7 +77,7 @@ TEST_CASE("fmt") {
 
 TEST_CASE("to_string") {
     int i = 0;
-    auto expr = DeferredExpression<int>([&i]() { return ++i; });
+    auto expr = make_deferred<int>([&i]() { return ++i; });
 
     // Stringification evaluates the expression.
     CHECK_EQ(to_string(expr), "1");
@@ -93,7 +86,7 @@ TEST_CASE("to_string") {
 
 TEST_CASE("to_string_for_print") {
     int i = 0;
-    auto expr = DeferredExpression<Bytes>([&i]() { return Bytes(fmt("\\x0%d", ++i)); });
+    auto expr = make_deferred<Bytes>([&i]() { return Bytes(fmt("\\x0%d", ++i)); });
 
     // Stringification evaluates the expression.
     CHECK_EQ(to_string_for_print(expr), R"#(\\x01)#");

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -383,6 +383,8 @@ public:
         return expressionUnresolvedOperator(operator_::Kind::SumAssign, {op1, op2}, m);
     }
 
+    auto deferred(Expression* e, const Meta& m = Meta()) { return expressionDeferred(e, m); }
+
     auto differenceAssign(Expression* op1, Expression* op2, const Meta& m = Meta()) {
         return expressionUnresolvedOperator(operator_::Kind::DifferenceAssign, {op1, op2}, m);
     }

--- a/hilti/toolchain/include/ast/builder/node-factory.h
+++ b/hilti/toolchain/include/ast/builder/node-factory.h
@@ -288,6 +288,12 @@ public:
     auto expressionCtor(Ctor* ctor, Meta meta = {}) {
         return hilti::expression::Ctor::create(context(), ctor, std::move(meta));
     }
+    auto expressionDeferred(Expression* expr, bool catch_exception, const Meta& meta = {}) {
+        return hilti::expression::Deferred::create(context(), expr, catch_exception, meta);
+    }
+    auto expressionDeferred(Expression* expr, const Meta& meta = {}) {
+        return hilti::expression::Deferred::create(context(), expr, meta);
+    }
     auto expressionGrouping(Expression* expr, Meta meta = {}) {
         return hilti::expression::Grouping::create(context(), expr, std::move(meta));
     }

--- a/hilti/toolchain/include/ast/expressions/all.h
+++ b/hilti/toolchain/include/ast/expressions/all.h
@@ -6,6 +6,7 @@
 #include <hilti/ast/expressions/builtin-function.h>
 #include <hilti/ast/expressions/coerced.h>
 #include <hilti/ast/expressions/ctor.h>
+#include <hilti/ast/expressions/deferred.h>
 #include <hilti/ast/expressions/grouping.h>
 #include <hilti/ast/expressions/keyword.h>
 #include <hilti/ast/expressions/list-comprehension.h>

--- a/hilti/toolchain/include/ast/expressions/deferred.h
+++ b/hilti/toolchain/include/ast/expressions/deferred.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <hilti/ast/expression.h>
+#include <hilti/ast/type.h>
+
+namespace hilti::expression {
+
+/**
+ * AST node for an expression for which evaluation is deferred at runtime to
+ * a later point when explicitly requested by the runtime system. Optionally,
+ * that later evaluation can catch any exceptions and return a corresponding
+ * ``result<T>``.
+ */
+class Deferred : public Expression {
+public:
+    auto expression() const { return child<Expression>(0); }
+    bool catchException() const { return _catch_exception; }
+
+    QualifiedType* type() const final { return child<QualifiedType>(1); }
+
+    node::Properties properties() const final {
+        auto p = node::Properties{{"catch_exception", _catch_exception}};
+        return Expression::properties() + p;
+    }
+
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 1, t); }
+
+    static auto create(ASTContext* ctx, Expression* expr, bool catch_exception, const Meta& meta = {}) {
+        return ctx->make<Deferred>(ctx, {expr, QualifiedType::createAuto(ctx, meta)}, catch_exception, meta);
+    }
+
+    static auto create(ASTContext* ctx, Expression* expr, const Meta& meta = {}) {
+        return create(ctx, expr, false, meta);
+    }
+
+protected:
+    Deferred(ASTContext* ctx, Nodes children, bool catch_exception, Meta meta)
+        : Expression(ctx, NodeTags, std::move(children), std::move(meta)), _catch_exception(catch_exception) {}
+
+    HILTI_NODE_1(expression::Deferred, Expression, final);
+
+private:
+    bool _catch_exception;
+};
+
+} // namespace hilti::expression

--- a/hilti/toolchain/include/ast/visitor-dispatcher.h
+++ b/hilti/toolchain/include/ast/visitor-dispatcher.h
@@ -90,6 +90,7 @@ public:
     virtual void operator()(hilti::expression::BuiltInFunction*) {}
     virtual void operator()(hilti::expression::Coerced*) {}
     virtual void operator()(hilti::expression::Ctor*) {}
+    virtual void operator()(hilti::expression::Deferred*) {}
     virtual void operator()(hilti::expression::Grouping*) {}
     virtual void operator()(hilti::expression::Keyword*) {}
     virtual void operator()(hilti::expression::ListComprehension*) {}

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -64,6 +64,21 @@ struct Visitor : hilti::visitor::PreOrder {
 
     void operator()(expression::Ctor* n) final { result = cg->compile(n->ctor(), lhs); }
 
+    void operator()(expression::Deferred* n) final {
+        auto type = cg->compile(n->type(), codegen::TypeUsage::Storage);
+        auto value = cg->compile(n->expression());
+
+        if ( n->catchException() )
+            // We can't pass the exception through here, so we just return a
+            // default constructed return value.
+            result =
+                fmt("::hilti::rt::DeferredExpression<%s>([=]() -> %s { try { return %s; } catch ( ... ) { return "
+                    "{}; } })",
+                    type, type, value);
+        else
+            result = fmt("::hilti::rt::DeferredExpression<%s>([=]() -> %s { return %s; })", type, type, value);
+    }
+
     void operator()(expression::Grouping* n) final { result = fmt("(%s)", cg->compile(n->expression(), lhs)); }
 
     void operator()(expression::Keyword* n) final {

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -72,11 +72,11 @@ struct Visitor : hilti::visitor::PreOrder {
             // We can't pass the exception through here, so we just return a
             // default constructed return value.
             result =
-                fmt("::hilti::rt::DeferredExpression<%s>([=]() -> %s { try { return %s; } catch ( ... ) { return "
+                fmt("::hilti::rt::make_deferred<%s>([=]() -> %s { try { return %s; } catch ( ... ) { return "
                     "{}; } })",
                     type, type, value);
         else
-            result = fmt("::hilti::rt::DeferredExpression<%s>([=]() -> %s { return %s; })", type, type, value);
+            result = fmt("::hilti::rt::make_deferred<%s>([=]() -> %s { return %s; })", type, type, value);
     }
 
     void operator()(expression::Grouping* n) final { result = fmt("(%s)", cg->compile(n->expression(), lhs)); }

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -12,6 +12,7 @@
 #include <hilti/ast/declarations/imported-module.h>
 #include <hilti/ast/declarations/local-variable.h>
 #include <hilti/ast/declarations/parameter.h>
+#include <hilti/ast/expressions/deferred.h>
 #include <hilti/ast/expressions/keyword.h>
 #include <hilti/ast/expressions/list-comprehension.h>
 #include <hilti/ast/expressions/name.h>
@@ -1138,6 +1139,13 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
         if ( auto coerced = coerceCallArguments(n->arguments(), n->parameters()); coerced && *coerced ) {
             recordChange(n, builder()->ctorTuple(**coerced), "call arguments");
             n->setArguments(context(), **coerced);
+        }
+    }
+
+    void operator()(expression::Deferred* n) final {
+        if ( ! n->type()->isResolved() && n->expression()->isResolved() ) {
+            recordChange(n, n->expression()->type());
+            n->setType(context(), n->expression()->type());
         }
     }
 


### PR DESCRIPTION
This reverts and updates the previous change to remove
`rt::DeferredExpression`. Turns out we still need it for the Zeek
integration.

- **Revert "Remove support for deferred expressions."**
- **Remove `std::functional` from `DeferredExpression`.**
