### PR TITLE
Fix behavior for unset accept and decline hooks.

### DIFF
--- a/spicy/runtime/include/configuration.h
+++ b/spicy/runtime/include/configuration.h
@@ -20,7 +20,7 @@ struct Configuration {
      * Optional callback to execute when a Spicy parser calls
      * `spicy::accept_input()`.
      **/
-    HookAcceptInput hook_accept_input;
+    HookAcceptInput hook_accept_input = nullptr;
 
     using HookDeclineInput = void (*)(const std::string&);
 
@@ -29,7 +29,7 @@ struct Configuration {
      * `spicy::decline_input()`. This string argument is the reason provided by
      * the caller.
      */
-    HookDeclineInput hook_decline_input;
+    HookDeclineInput hook_decline_input = nullptr;
 };
 
 namespace configuration {


### PR DESCRIPTION
We did not properly initialize pointer values for accept and decline hooks. In downstream code they then appeared to be set when they were in fact not.

With this patch we initialize them with proper defaults.