### PR TITLE
Use a checked cast for `map`'s `in` operator.

### DIFF
--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -1398,7 +1398,11 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     // passed `map` and perform the coercion automatically when resolving the
     // function call.
     void operator()(operator_::map::In* n) final {
-        if ( auto x = coerceTo(n, n->op0(), n->op1()->type()->type()->as<type::Map>()->keyType(), true, false) ) {
+        auto op0 = n->op0()->type()->type()->tryAs<type::Map>();
+        if ( ! op0 )
+            return;
+
+        if ( auto x = coerceTo(n, n->op0(), op0->keyType(), true, false) ) {
             recordChange(n, x, "call argument");
             n->setOp0(context(), x);
         }


### PR DESCRIPTION
We would previously assume that operand types in `map`'s `in` operator were always resolved which is not the case, e.g., for this code `x.b` might be unresolved:

```ruby
public type X = unit {
    var a: map<bytes, bytes>;
    : Y(self);
};

type Y = unit(x: X) {
    on %done { b"" in x.a; }
};
```

The implementation of `set`'s `in` operator already accommodated this by defering until all types are resolved. This changes the implementation for `map`'s `in` to follow a similar pattern.

Closes #1743.