### PR TITLE
Fix Flex linker error when building as part of Zeek.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/parser/driver.h
+++ b/hilti/toolchain/include/compiler/detail/parser/driver.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <utility>
-#include <vector>
 #ifdef yylex
 #undef yylex
 // Work-around for bison messing up the function name by adding the local namespace.

--- a/hilti/toolchain/include/compiler/detail/parser/driver.h
+++ b/hilti/toolchain/include/compiler/detail/parser/driver.h
@@ -27,11 +27,11 @@
                                         hilti::detail::parser::Driver* driver)
 
 #ifndef __FLEX_LEXER_H
+
 // NOLINTNEXTLINE
 #define yyFlexLexer HiltiFlexLexer
 #include <FlexLexer.h>
 
-#undef yyFlexLexer
 #endif
 
 namespace hilti {


### PR DESCRIPTION
When building Spicy as part of Zeek against the Homebrew flex-2.6.4 I
saw linker errors after f523256,

```
ld: Undefined symbols:
  HiltiFlexLexer::LexerInput(char*, unsigned long), referenced from:
      vtable for hilti::detail::parser::Scanner in driver.cc.o
  HiltiFlexLexer::LexerOutput(char const*, unsigned long), referenced from:
      vtable for hilti::detail::parser::Scanner in driver.cc.o
```

It is still not clear to me how this error comes about, but the change in
this patch seems to address the issue.