### PR TITLE
Fix a typo in pack/unpack docs

### DIFF
--- a/doc/programming/language/packing.rst
+++ b/doc/programming/language/packing.rst
@@ -53,7 +53,7 @@ operators expect for each:
 
     * - :ref:`type_real`
       - ``pack(VALUE, spicy::RealType, spicy::ByteOrder)``
-      - ``unpack<uintX|intX>(DATA, spicy::RealType, spicy::ByteOrder)``
+      - ``unpack<real>(DATA, spicy::RealType, spicy::ByteOrder)``
       - :ref:`Real Type <spicy_realtype>` [1], :ref:`Byte Order <spicy_byteorder>`
 
 .. note::


### PR DESCRIPTION
Fix a typo in the `unpack` docs for `real` values where the template argument to `unpack` was `uintX|intX` instead of `real`.