### PR TITLE
Update RTD config to latest version.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,15 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  system_packages: false
   install:
     - requirements: doc/requirements.txt
+
+search:
+  ignore:
+    - "doxygen-output/*"
+    - "_static/*"
+    # Defaults.
+    - search.html
+    - search/index.html
+    - 404.html
+    - 404/index.html


### PR DESCRIPTION
Since this version was first released readthedocs has revamped their approach to project configuration and also become much stricter in what they allow. Due to that the docs for the latest 1.8 release do not build anymore.

This copies the RTD config from `main` into this branch.