### PR TITLE
Fix C++ initialization of global constants through global functions.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -249,6 +249,21 @@ void Unit::_generateCode(Formatter& f, bool prototypes_only) {
                 f << t.second;
         }
 
+        for ( const auto& i : _function_declarations ) {
+            if ( i.second.id.namespace_() != ns )
+                continue;
+
+            auto needs_separator = (i.second.inline_body && i.second.inline_body->size() > 1);
+
+            if ( needs_separator )
+                f << separator();
+
+            f << i.second;
+
+            if ( needs_separator )
+                f << separator();
+        }
+
         if ( ! prototypes_only || ! util::endsWith(ns, "::") ) { // skip anonymous namespace
             if ( ID(ns) == cxx::ID(context()->options().cxx_namespace_intern, "type_info::") )
                 // We force this to come last later below because creating the type information needs access to all
@@ -264,21 +279,6 @@ void Unit::_generateCode(Formatter& f, bool prototypes_only) {
                 if ( i.second.id.namespace_() == ns )
                     f << i.second;
             }
-        }
-
-        for ( const auto& i : _function_declarations ) {
-            if ( i.second.id.namespace_() != ns )
-                continue;
-
-            auto needs_separator = (i.second.inline_body && i.second.inline_body->size() > 1);
-
-            if ( needs_separator )
-                f << separator();
-
-            f << i.second;
-
-            if ( needs_separator )
-                f << separator();
         }
     }
 

--- a/tests/Baseline/hilti.hiltic.print.globals/output
+++ b/tests/Baseline/hilti.hiltic.print.globals/output
@@ -14,11 +14,11 @@ namespace __hlt::Foo {
         template<typename F> void __visit(F _) const { _("X", X); }
     };
 
-    inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.globals/output2
+++ b/tests/Baseline/hilti.hiltic.print.globals/output2
@@ -9,11 +9,11 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    static std::optional<std::string> X = {};
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    static std::optional<std::string> X = {};
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.import/output
+++ b/tests/Baseline/hilti.hiltic.print.import/output
@@ -14,11 +14,11 @@ namespace __hlt::Bar {
         template<typename F> void __visit(F _) const { _("bar", bar); }
     };
 
-    inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    inline unsigned int __globals_index;
 }
 
 namespace __hlt::Foo {
@@ -27,12 +27,12 @@ namespace __hlt::Foo {
         template<typename F> void __visit(F _) const { _("foo", foo); }
     };
 
-    inline unsigned int __globals_index;
     static inline auto __globals() {
         return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index);
     }
 
     extern void __init_globals(::hilti::rt::Context* ctx);
+    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Bar::__register_module)
@@ -67,11 +67,11 @@ namespace __hlt::Bar {
         template<typename F> void __visit(F _) const { _("bar", bar); }
     };
 
-    inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    inline unsigned int __globals_index;
 }
 
 namespace __hlt::Foo {
@@ -80,7 +80,6 @@ namespace __hlt::Foo {
         template<typename F> void __visit(F _) const { _("foo", foo); }
     };
 
-    inline unsigned int __globals_index;
     static inline auto __globals() {
         return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index);
     }
@@ -88,6 +87,7 @@ namespace __hlt::Foo {
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.import/output2
+++ b/tests/Baseline/hilti.hiltic.print.import/output2
@@ -9,17 +9,17 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Bar {
-    std::optional<std::string> bar = {};
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    std::optional<std::string> bar = {};
 }
 
 namespace __hlt::Foo {
-    extern std::optional<std::string> foo;
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
+    extern std::optional<std::string> foo;
 }
 
 HILTI_PRE_INIT(__hlt::Bar::__register_module)
@@ -48,19 +48,19 @@ extern void __hlt::Bar::__register_module() { ::hilti::rt::detail::registerModul
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Bar {
-    extern std::optional<std::string> bar;
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    extern std::optional<std::string> bar;
 }
 
 namespace __hlt::Foo {
-    std::optional<std::string> foo = {};
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    std::optional<std::string> foo = {};
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.types.real.nops/output
+++ b/tests/Baseline/hilti.types.real.nops/output
@@ -17,12 +17,12 @@ assert 0x1.999999999999ap-4 == 0x1.999999999999ap-4;
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    static std::optional<double> d = {};
-    static std::optional<double> r = {};
     extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
+    static std::optional<double> d = {};
+    static std::optional<double> r = {};
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/hilti/expressions/const-from-func.hlt
+++ b/tests/hilti/expressions/const-from-func.hlt
@@ -1,0 +1,17 @@
+# @TEST-EXEC: hiltic -j %INPUT >output
+#
+# @TEST-DOC: Check that globals can be initialized from calls to functions.
+
+module Foo {
+
+function uint<16> bar() {
+    return 4711;
+}
+
+global x = bar();
+const y = bar();
+
+assert x == 4711;
+assert y == 4711;
+
+}


### PR DESCRIPTION
The changes ordering of the emitted global declarations so that
functions now come first, allowing them be used inside subsequent
constant initializations.

Closes #1745.
