### PR TITLE
Fix Spicy's support for `network` type.

### DIFF
--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -213,7 +213,6 @@ static std::vector<hilti::DocString> _docs;
 %token MOD
 %token MODULE
 %token NEQ
-%token NET
 %token NETWORK
 %token NEW
 %token NONE

--- a/spicy/toolchain/src/compiler/parser/scanner.ll
+++ b/spicy/toolchain/src/compiler/parser/scanner.ll
@@ -153,7 +153,7 @@ map                   return token::MAP;
 mark                  return token::MARK;
 mod                   return token::MOD;
 module                return token::MODULE;
-net                   return token::NET;
+network               return token::NETWORK;
 new                   return token::NEW;
 object                return token::OBJECT;
 on                    return token::ON;

--- a/tests/spicy/types/network/ops.spicy
+++ b/tests/spicy/types/network/ops.spicy
@@ -8,7 +8,7 @@ module Test;
 import spicy;
 
 global n1 = [2001:0db8::1428:57ab]/48;
-global n2 = 192.168.1.0/24;
+global n2: network = 192.168.1.0/24;
 global n3 = [::192.168.1.0]/24;
 
 print n1;


### PR DESCRIPTION
`network` was not recognized by the scanner.
