### PR TITLE
Add missing include.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,14 +37,14 @@ repos:
     stages: ["commit"]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v18.1.1'
+  rev: 'v18.1.8'
   hooks:
   - id: clang-format
     types_or: ["c", "c++"]
     stages: ["commit"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
     exclude: '^tests/Baseline'
@@ -93,14 +93,14 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.3.2
+  rev: v0.5.1
   hooks:
   - id: ruff
     args: [ --fix ]
   - id: ruff-format
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.10.1
+  rev: v3.16.0
   hooks:
   - id: pyupgrade
     args: ["--py37-plus"]

--- a/hilti/runtime/include/global-state.h
+++ b/hilti/runtime/include/global-state.h
@@ -3,6 +3,7 @@
 #pragma once
 #include <sys/resource.h>
 
+#include <clocale>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/spicy/toolchain/bin/spicy-dump/printer-json.h
+++ b/spicy/toolchain/bin/spicy-dump/printer-json.h
@@ -20,7 +20,7 @@ public:
      * @param output stream to send output to
      * @param options output controlling specifics of the output
      */
-    JSONPrinter(std::ostream& output, OutputOptions options) : _output(output), _options(options){};
+    JSONPrinter(std::ostream& output, OutputOptions options) : _output(output), _options(options) {}
 
     /**
      * Render one parsed value into JSON.

--- a/spicy/toolchain/bin/spicy-dump/printer-text.h
+++ b/spicy/toolchain/bin/spicy-dump/printer-text.h
@@ -20,7 +20,7 @@ public:
      * @param output stream to send output to
      * @param options output controlling specifics of the output
      */
-    TextPrinter(std::ostream& output, OutputOptions options) : _output(output), _options(options){};
+    TextPrinter(std::ostream& output, OutputOptions options) : _output(output), _options(options) {}
 
     /**
      * Render one parsed value into text.


### PR DESCRIPTION
Add a missing include for `locale_t`. Without this patch this fails to build with e.g., gcc-12 on macos.