### PR TITLE
Prevent defining already forwarded constants.

### DIFF
--- a/hilti/toolchain/include/base/cache.h
+++ b/hilti/toolchain/include/base/cache.h
@@ -4,7 +4,6 @@
 
 #include <map>
 #include <optional>
-#include <string>
 #include <utility>
 
 namespace hilti::util {

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -375,8 +375,11 @@ void Unit::importDeclarations(const Unit& other) {
     for ( const auto& i : other._constants_forward )
         add(i.second, m);
 
-    for ( const auto& i : other._constants )
-        add(i.second, m);
+    for ( const auto& i : other._constants ) {
+        // If we added a forward declaration for a constant do not add a definition as well.
+        if ( ! other._constants_forward.count(i.first) )
+            add(i.second, m);
+    }
 
     for ( const auto& i : other._types_forward )
         add(i.second, m);

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -378,9 +378,6 @@ void Unit::importDeclarations(const Unit& other) {
     for ( const auto& i : other._constants )
         add(i.second, m);
 
-    for ( const auto& i : other._types )
-        add(i.second, m);
-
     for ( const auto& i : other._types_forward )
         add(i.second, m);
 


### PR DESCRIPTION
Closes #1785.