### PR TITLE
Fix import HILTI vs Spicy confusion.

### DIFF
--- a/hilti/toolchain/include/ast/declarations/imported-module.h
+++ b/hilti/toolchain/include/ast/declarations/imported-module.h
@@ -35,6 +35,7 @@ public:
 
     auto uid() const { return _uid; }
     void setUID(declaration::module::UID uid) { _uid = std::move(uid); }
+    void clearUID() { _uid.reset(); }
     void setSearchDirectories(std::vector<hilti::rt::filesystem::path> dirs) { _dirs = std::move(dirs); }
 
     std::string_view displayName() const final { return "imported module"; }

--- a/hilti/toolchain/include/ast/declarations/module.h
+++ b/hilti/toolchain/include/ast/declarations/module.h
@@ -88,6 +88,7 @@ public:
     void add(ASTContext* ctx, Statement* s) { child<statement::Block>(0)->add(ctx, s); }
 
     void addDependency(declaration::module::UID uid) { _dependencies.insert(std::move(uid)); }
+    void clearDependencies() { _dependencies.clear(); }
     void setScopePath(const ID& scope) { _scope_path = scope; }
     void setUID(declaration::module::UID uid) { _uid = std::move(uid); }
 

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -770,7 +770,7 @@ static void _recursiveDependencies(const ASTContext* ctx, declaration::Module* m
     for ( const auto& uid : module->dependencies() ) {
         seen->insert(uid);
         auto dep = ctx->module(uid);
-        assert(dep);
+        assert(dep && dep->uid() == uid);
         _recursiveDependencies(ctx, dep, seen);
     }
 }

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -102,7 +102,8 @@ Result<Nothing> Unit::codegen() {
     // TODO(robin): Would be nice if we had a "cheap" compilation mode that
     // only generated declarations.
     for ( const auto& d : dependencies(true) ) {
-        HILTI_DEBUG(logging::debug::Compiler, fmt("importing declarations from module %s", d));
+        HILTI_DEBUG(logging::debug::Compiler,
+                    fmt("importing declarations from module %s (%s)", d, d.process_extension));
         logging::DebugPushIndent _(logging::debug::Compiler);
 
         if ( auto other_cxx = _codegenModule(d) )

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -1376,7 +1376,7 @@
 [debug/driver] codegen for input unit Foo
 [debug/compiler] codegen module Foo to C++
 [debug/compiler]   generating C++ for module Foo
-[debug/compiler]   importing declarations from module Bar
+[debug/compiler]   importing declarations from module Bar (".hlt")
 [debug/compiler]     generating C++ for module Bar
 [debug/compiler]   finalizing module Foo
 [debug/driver] saving C++ code for module Foo to /dev/stdout

--- a/tests/Baseline/spicy.types.unit.hooks-across-imports/.stderr
+++ b/tests/Baseline/spicy.types.unit.hooks-across-imports/.stderr
@@ -32,9 +32,9 @@
 [debug/ast-stats]     - type::bytes::Iterator: 175
 [debug/ast-stats]     - type::operand_list::Operand: 1224
 [debug/ast-stats]     - type::stream::Iterator: 133
-[debug/ast-stats] garbage collected 10030 nodes in 14 rounds, 21414 left retained
-[debug/ast-stats] garbage collected 2444 nodes in 16 rounds, 25295 left retained
-[debug/ast-stats] garbage collected 2224 nodes in 8 rounds, 26645 left retained
+[debug/ast-stats] garbage collected 10026 nodes in 14 rounds, 21409 left retained
+[debug/ast-stats] garbage collected 2318 nodes in 16 rounds, 25227 left retained
+[debug/ast-stats] garbage collected 2354 nodes in 8 rounds, 26645 left retained
 [debug/ast-stats] garbage collected 4558 nodes in 11 rounds, 27837 left retained
 [debug/ast-stats] garbage collected 420 nodes in 3 rounds, 27837 left retained
 [debug/ast-stats] # [HILTI] AST statistics:
@@ -42,7 +42,7 @@
 [debug/ast-stats]   - max tree depth: 27
 [debug/ast-stats]   - # context declarations: 262
 [debug/ast-stats]   - # context types: 55
-[debug/ast-stats]   - # context modules: 7
+[debug/ast-stats]   - # context modules: 8
 [debug/ast-stats]   - # nodes reachable in AST: 19057
 [debug/ast-stats]   - # nodes live: 27837
 [debug/ast-stats]   - # nodes retained: 27837

--- a/tests/spicy/codegen/import-cycle.spicy
+++ b/tests/spicy/codegen/import-cycle.spicy
@@ -1,0 +1,13 @@
+# @TEST-EXEC: spicyc -j f1.spicy f2.spicy
+#
+# @TEST-DOC: Two modules importing each other
+
+@TEST-START-FILE f1.spicy
+module f1;
+import f2;
+@TEST-END-FILE
+
+@TEST-START-FILE f2.spicy
+module f2;
+import f1;
+@TEST-END-FILE


### PR DESCRIPTION
Our tracking of module dependencies could end up mixing `.spicy` and `.hlt`
modules when the former transitioned into the latter. Closes #1784.
