### PR TITLE
Defer start of feature-dependent transformations to a later point.

### DIFF
--- a/tests/spicy/optimization/file-order.spicy
+++ b/tests/spicy/optimization/file-order.spicy
@@ -1,0 +1,20 @@
+# @TEST-DOC: Checks that the order in which modules are compiled is irrelevant for optimizations, regression test for #1789.
+#
+# @TEST-EXEC: spicyc -dj y.spicy x.spicy
+# @TEST-EXEC: spicyc -dj x.spicy y.spicy
+
+# @TEST-START-FILE x.spicy
+module x;
+
+public type X = unit {
+    on %synced {
+        confirm;
+    }
+};
+# @TEST-END-FILE
+
+# @TEST-START-FILE y.spicy
+module y;
+
+type Y = unit {};
+# @TEST-END-FILE


### PR DESCRIPTION
We previously would evaluate whether a unit field or method was required
by an optional feature before we had finished collecting all feature
requirements. This behavior was fine when we were visiting individual
modules' AST one by one, but breaks with #1462 were we changed using a
single AST to hold all modules.

This patch defers transformations until all feature requirements have
been collected.