### PR TITLE
Do not search for Python in CMake setup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ project(spicy LANGUAGES C CXX)
 
 set(flex_minimum_version "2.5.37")
 set(bison_minimum_version "3.0")
-set(python_minimum_version "3.2")
 set(macos_minimum_version "19.0.0") # macOS 10.15.0 (Catalina)
 
 ## Initialize defaults & global options
@@ -136,7 +135,6 @@ if (BISON_ROOT)
         NO_DEFAULT_PATH)
 endif ()
 
-find_package(Python ${python_minimum_version} COMPONENTS Interpreter)
 find_package(FLEX REQUIRED)
 find_package(BISON REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -163,7 +161,6 @@ if (APPLE)
     require_version("macOS" MACOS_FOUND ${CMAKE_SYSTEM_VERSION} "${macos_minimum_version}" true)
 endif ()
 
-require_version("Python" Python_FOUND Python_VERSION "${python_minimum_version}" true)
 require_version("Flex" FLEX_FOUND FLEX_VERSION "${flex_minimum_version}" true)
 require_version("Bison" BISON_FOUND BISON_VERSION "${bison_minimum_version}" true)
 
@@ -340,7 +337,6 @@ message(
     "\nBison version:         ${BISON_VERSION}"
     "\nCMake version:         ${CMAKE_VERSION}"
     "\nFlex version:          ${FLEX_VERSION}"
-    "\nPython version:        ${Python_VERSION}"
     "\nzlib version:          ${ZLIB_VERSION_STRING}"
     "\n"
     "\n================================================================\n")

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -211,16 +211,17 @@ To build Spicy from source, you will need:
         * `CMake <https://cmake.org>`_  >= 3.15
         * `Bison <https://www.gnu.org/software/bison>`_  >= 3.0
         * `Flex <https://www.gnu.org/software/flex>`_  >= 2.6
-        * `Python <https://www.python.org/downloads/>`_ >= 3.4
         * `Zlib <https://www.zlib.net>`_ (no particular version)
 
     - For testing:
 
+        * `Python <https://www.python.org/downloads/>`_ >= 3.4
         * `BTest <https://github.com/zeek/btest>`_  >= 0.66 (``pip install btest``)
         * Bash (for BTest)
 
     - For building the documentation:
 
+        * `Python <https://www.python.org/downloads/>`_ >= 3.4
         * `Sphinx <https://www.sphinx-doc.org/en/master>`_  >= 1.8
         * `Pygments <https://pygments.org/>`_  >= 2.5
         * `Read the Docs Sphinx Theme <https://sphinx-rtd-theme.readthedocs.io/en/stable/>`_  (``pip install sphinx_rtd_theme``)


### PR DESCRIPTION
We previously needed this since during the build we were generating files with Python. This is not the case anymore.