### PR TITLE
Guard access to sink hooks.

### DIFF
--- a/spicy/runtime/src/tests/parser.cc
+++ b/spicy/runtime/src/tests/parser.cc
@@ -140,6 +140,7 @@ TEST_CASE("registerParser") {
         parser.mime_types = {MIMEType("foo/bar"), MIMEType("foo/*")};
         REQUIRE_FALSE(parser.__parse_sink);
         REQUIRE_FALSE(parser.__hook_gap);
+        REQUIRE_FALSE(parser.__hook_overlap);
         REQUIRE_FALSE(parser.__hook_skipped);
         REQUIRE_FALSE(parser.__hook_undelivered);
 
@@ -151,6 +152,7 @@ TEST_CASE("registerParser") {
         CHECK_EQ(parser.linker_scope, "xyz");
         CHECK_FALSE(parser.__parse_sink);
         CHECK_FALSE(parser.__hook_gap);
+        CHECK_FALSE(parser.__hook_overlap);
         CHECK_FALSE(parser.__hook_skipped);
         CHECK_FALSE(parser.__hook_undelivered);
     }
@@ -163,6 +165,7 @@ TEST_CASE("registerParser") {
         parser.mime_types = {MIMEType("foo/bar"), MIMEType("foo/*")};
         REQUIRE_FALSE(parser.__parse_sink);
         REQUIRE_FALSE(parser.__hook_gap);
+        CHECK_FALSE(parser.__hook_overlap);
         REQUIRE_FALSE(parser.__hook_skipped);
         REQUIRE_FALSE(parser.__hook_undelivered);
 
@@ -174,6 +177,7 @@ TEST_CASE("registerParser") {
         CHECK_EQ(parser.linker_scope, "xyz");
         CHECK(parser.__parse_sink);
         CHECK(parser.__hook_gap);
+        CHECK(parser.__hook_overlap);
         CHECK(parser.__hook_skipped);
         CHECK(parser.__hook_undelivered);
     }

--- a/tests/Baseline/spicy.types.sink.reassembler.overlap/output
+++ b/tests/Baseline/spicy.types.sink.reassembler.overlap/output
@@ -11,3 +11,7 @@ Overlap at 4: D vs 4
 
 Overlap at 2: 23 vs 2A
 0123B56
+Without hooks
+
+
+

--- a/tests/spicy/types/sink/reassembler/overlap.spicy
+++ b/tests/spicy/types/sink/reassembler/overlap.spicy
@@ -1,4 +1,11 @@
-# @TEST-EXEC: spicy-driver -p Mini::Main %INPUT >output </dev/null
+# @TEST-DOC: Check that sink hooks are correctly set up.
+#
+# @TEST-EXEC: spicy-driver -d -p Mini::Main %INPUT hooks.spicy -f /dev/zero >>output
+#
+# @TEST-EXEC: echo "Without hooks" >>output
+# Running without hooks defined behaves as expected, regression test for #1804.
+# @TEST-EXEC: spicy-driver -d -p Mini::Main %INPUT -f /dev/zero >>output
+#
 # @TEST-EXEC: btest-diff output
 
 module Mini;
@@ -48,25 +55,33 @@ public type Main = unit {
 
 public type Sub = unit {
     s: bytes &eod;
-
-    on %done {
-        print self.s;
-    }
-
-    on %gap(seq: uint64, len: uint64)  {
-        print "Gap at input position %u, length %u" % (seq, len);
-        }
-
-    on %skipped(seq: uint64){
-        print "Skipped to position %u" % seq;
-        }
-
-    on %undelivered(seq: uint64, data: bytes) {
-        print "Undelivered data at position %u: %s" % (seq, data);
-        }
-
-    # Intentionally using custom parameter names here
-    on %overlap(seq: uint64, b1: bytes, b2: bytes) {
-        print "Overlap at %u: %s vs %s" % (seq, b1, b2);
-        }
 };
+
+# @TEST-START-FILE hooks.spicy
+
+module Hooks;
+
+import Mini;
+
+on Mini::Sub::%done {
+    print self.s;
+}
+
+on Mini::Sub::%gap(seq: uint64, len: uint64) {
+    print "Gap at input position %u, length %u" % (seq, len);
+}
+
+on Mini::Sub::%skipped(seq: uint64) {
+    print "Skipped to position %u" % seq;
+}
+
+on Mini::Sub::%undelivered(seq: uint64, data: bytes) {
+    print "Undelivered data at position %u: %s" % (seq, data);
+}
+
+# Intentionally using custom parameter names here
+on Mini::Sub::%overlap(seq: uint64, b1: bytes, b2: bytes) {
+    print "Overlap at %u: %s vs %s" % (seq, b1, b2);
+}
+
+# @TEST-END-FILE


### PR DESCRIPTION
If no sink hooks were specified by the user trying to invoke them would raise a `std::bad_function_call` previously since we did not have explicitly guard the code. With #1736 we us infrastructure with less implicit checks so we need to handle the absence of a value ourself since otherwise we might end up dereferencing a nullptr.