### PR TITLE
rTopic/bbannier/diagrams pre commit hooks

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     python3-sphinx \
     python3-sphinx-rtd-theme \
     python3-wheel \
+    rsync \
     zlib1g-dev \
  && pip3 install --no-cache-dir "btest>=0.66" pre-commit \
  # Spicy doc dependencies.

--- a/doc/scripts/autogen-docs
+++ b/doc/scripts/autogen-docs
@@ -20,6 +20,12 @@ if ! command -v rsync >/dev/null 2>&1; then
     exit 0
 fi
 
+# autogen-architecture-diagram needs the diagrams package
+if ! command -v python -c 'import diagrams' >/dev/null 2>&1; then
+    >&2 echo "Warning: Need Python diagrams to run autogen-docs, aborting"
+    exit 0
+fi
+
 if [[ ! -x ${BUILDDIR}/bin/spicy-doc ]]; then
     >&2 echo "Warning: Could not find required executable ${BUILDDIR}/bin/spicy-doc, aborting"
     exit 0


### PR DESCRIPTION
If the `diagrams` package was not installed this hook would now fails.
Since it runs for changes to any type of file this was not ideal.

This patch adds a check for that dependency and stops the docs update
script if it is missing.