### PR TITLE
Fix non-converging optimizer pass for used functions.

### DIFF
--- a/tests/spicy/optimization/issue-1808.spicy
+++ b/tests/spicy/optimization/issue-1808.spicy
@@ -1,0 +1,12 @@
+# @TEST-DOC: Regression test for #1808.
+# We expect this call to terminate.
+# @TEST-EXEC: spicyc -dj %INPUT
+
+module test;
+
+type X = unit {
+    # Field with name identical to type name below.
+    foo: uint8;
+};
+
+type foo = unit {};


### PR DESCRIPTION
The optimizer's `FunctionVisitor` computes whether a function is used or required by any feature. Since recently we now hold all modules in a single AST. This means that we need at least one full pass through the AST to collect feature constants so we can decided whether a function is required by a feature and cannot be elided. The initial implementation of this used explicit control flow, but this is error-prone like seen in #1808.

This patch removes the explicit control flow and instead checks whether we have discovered any new feature constants. With that the optimizer pass converges again.

Closes #1808.