### PR TITLE
Fix equality implementation of module UID.

### DIFF
--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -168,8 +168,7 @@ public:
                                                   std::vector<hilti::rt::filesystem::path> search_dirs);
 
     /** Adds a new, empty module to the AST. */
-    declaration::Module* newModule(Builder* builder, const ID& id,
-                                   const hilti::rt::filesystem::path& process_extension);
+    declaration::Module* newModule(Builder* builder, ID id, const hilti::rt::filesystem::path& process_extension);
 
     /**
      * Retrieves a module node from the AST given its UID. Returns null if no

--- a/hilti/toolchain/include/ast/declarations/module-uid.h
+++ b/hilti/toolchain/include/ast/declarations/module-uid.h
@@ -64,7 +64,8 @@ struct UID {
           in_memory(true) {
         assert(this->id && ! parse_extension.empty() && ! process_extension.empty());
         //  just make up a path
-        path = util::fmt("/tmp/hilti/%s.%" PRIu64 ".%s.%s", id, ++_no_file_counter, process_extension, parse_extension);
+        path = util::fmt("/tmp/hilti/%s.%" PRIu64 ".%s.%s", unique, ++_no_file_counter, process_extension,
+                         parse_extension);
     }
 
     UID(const UID& other) = default;
@@ -73,7 +74,8 @@ struct UID {
 
     /** Hashes the UID. */
     size_t hash() const {
-        return rt::hashCombine(std::hash<std::string_view>{}(id.str()), std::hash<std::string>{}(path.native()),
+        return rt::hashCombine(std::hash<std::string>{}(id.str()), std::hash<std::string_view>{}(unique.str()),
+                               std::hash<std::string>{}(path.native()),
                                std::hash<std::string>{}(parse_extension.native()),
                                std::hash<std::string>{}(process_extension.native()));
     }
@@ -82,14 +84,14 @@ struct UID {
     UID& operator=(UID&& other) = default;
 
     bool operator==(const UID& other) const {
-        return id == other.id && path == other.path && parse_extension == other.parse_extension &&
-               process_extension == other.process_extension;
+        return std::tie(id, unique, path, parse_extension, process_extension) ==
+               std::tie(other.id, other.unique, other.path, other.parse_extension, other.process_extension);
     }
 
     bool operator!=(const UID& other) const { return ! (*this == other); }
     bool operator<(const UID& other) const {
-        return std::make_tuple(id, path, parse_extension, process_extension) <
-               std::make_tuple(other.id, other.path, other.parse_extension, other.process_extension);
+        return std::tie(id, unique, path, parse_extension, process_extension) <
+               std::tie(other.id, other.unique, other.path, other.parse_extension, other.process_extension);
     }
 
     /** Returns the module's globally uniqued name. */

--- a/hilti/toolchain/include/ast/declarations/module-uid.h
+++ b/hilti/toolchain/include/ast/declarations/module-uid.h
@@ -55,12 +55,11 @@ struct UID {
      * @param parse_extension language extension determining how to *parse* this module
      * @param process_extension language extension determining how to process this module *after* parsing
      **/
-    UID(const ID& id, const hilti::rt::filesystem::path& parse_extension,
-        const hilti::rt::filesystem::path& process_extension)
-        : id(id),
+    UID(ID id, hilti::rt::filesystem::path parse_extension, hilti::rt::filesystem::path process_extension)
+        : id(std::move(id)),
           unique(_makeUnique(this->id)),
-          parse_extension(parse_extension),
-          process_extension(process_extension),
+          parse_extension(std::move(parse_extension)),
+          process_extension(std::move(process_extension)),
           in_memory(true) {
         assert(this->id && ! parse_extension.empty() && ! process_extension.empty());
         //  just make up a path

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -128,9 +128,9 @@ Result<declaration::module::UID> ASTContext::importModule(
     return uid;
 }
 
-declaration::Module* ASTContext::newModule(Builder* builder, const ID& id,
+declaration::Module* ASTContext::newModule(Builder* builder, ID id,
                                            const hilti::rt::filesystem::path& process_extension) {
-    auto uid = declaration::module::UID(id, process_extension, process_extension);
+    auto uid = declaration::module::UID(std::move(id), process_extension, process_extension);
     auto m = builder->declarationModule(uid);
     _addModuleToAST(m);
     return module(uid);

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -573,8 +573,6 @@ Result<Nothing> Driver::addInput(const hilti::rt::filesystem::path& path) {
 
         (*unit)->setRequiresCompilation();
         _addUnit(*unit);
-
-        return Nothing();
     }
 
     else if ( path.extension() == ".cc" || path.extension() == ".cxx" ) {
@@ -612,11 +610,13 @@ Result<Nothing> Driver::addInput(const hilti::rt::filesystem::path& path) {
         } catch ( const hilti::rt::EnvironmentError& e ) {
             hilti::rt::fatalError(e.what());
         }
-
-        return Nothing();
     }
 
-    return error("unsupported file type", path);
+    _processed_paths.insert(path);
+
+    _processed_paths.insert(path.native());
+
+    return Nothing();
 }
 
 Result<Nothing> Driver::addInput(declaration::module::UID uid) {

--- a/tests/hilti/ast/imported-twice.hlt
+++ b/tests/hilti/ast/imported-twice.hlt
@@ -1,0 +1,7 @@
+# @TEST-DOC: Test that we handle the same module declared twice fine, regression test for #1813.
+#
+# @TEST-EXEC: hiltic -dj %INPUT %INPUT
+# @TEST-EXEC: hiltic -dj %INPUT $(basename %INPUT)
+# @TEST-EXEC: hiltic -dj $(basename %INPUT) %INPUT
+
+module foo {}


### PR DESCRIPTION
We already computed a `unique` `ID` value for each module to allow
declaring the same `ID` name multiple times; we however did not
consistently use that value in the implementation of `module::UID`
equality and hash operators which is addressed by this patch.

Closes #1813.