### PR TITLE
Add CMAKE_CXX_FLAGS to HILTI_CONFIG_RUNTIME_LD_FLAGS.

### DIFF
--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -189,10 +189,14 @@ set_config_val(HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS
                "!BUILD!${CMAKE_LIBRARY_OUTPUT_DIRECTORY} !INSTALL!${CMAKE_INSTALL_FULL_LIBDIR}")
 
 # LD flags
-set_config_val(HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG
-               "${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}")
-set_config_val(HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE
-               "${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}")
+set_config_val(
+    HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG
+    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}"
+)
+set_config_val(
+    HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE
+    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}"
+)
 
 configure_file(include/config.h.in ${AUTOGEN_H}/config.h)
 configure_file(src/config.cc.in ${AUTOGEN_CC}/config.cc)


### PR DESCRIPTION
When building Spicy with CXXFLAGS='--coverage', a subsequent spicy-driver invocation fails with:

    $ ./build/bin/spicy-driver ./x.spicy
    [error] failed to load library "/tmp/__library__c2d0d689ca0dbabb.hlto":
    /tmp/__library__c2d0d689ca0dbabb.hlto: undefined symbol: __gcov_merge_add

Similarly for `spicyz` and Zeek.

CMake adds CMAKE_CXX_FLAGS to all its linker invocations [1] which is why building Spicy's executables itself works out. Prepend EXTRA_CXX_FLAGS and CMAKE_CXX_FLAGS to HILTI_CONFIG_RUNTIME_LD_FLAGS as a fix.

Unclear if building Spicy with `--coverage` should imply building produced `.hlto` files with coverage, too, but that's what is done with other CXXFLAGS already today.

Relates to zeek/zeek#3865.

[1] https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html