### PR TITLE
to_int() ubsan fixes

### DIFF
--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -375,6 +375,17 @@ TEST_CASE("toInt") {
         CHECK_EQ("100"_b.toInt(Enum(ByteOrder::Network)), 3223600);
         CHECK_EQ("100"_b.toInt(Enum(ByteOrder::Little)), 3158065);
 
+        CHECK_EQ("\x00\x00\x00\x01\x01"_b.toInt(Enum(ByteOrder::Big)), 257);
+        CHECK_EQ("\xff"_b.toInt(Enum(ByteOrder::Big)), -1);
+        CHECK_EQ("\xff\xff"_b.toInt(Enum(ByteOrder::Big)), -1);
+        CHECK_EQ("\xff\xff\xff\xff"_b.toInt(Enum(ByteOrder::Big)), -1);
+        CHECK_EQ("\xff\xff\xff\xff\xff\xff"_b.toInt(Enum(ByteOrder::Big)), -1);
+        CHECK_EQ("\xff\xff\xff\xff\xff\xff\xff\xff"_b.toInt(Enum(ByteOrder::Big)), -1);
+
+        // 2er complement according to Wikipedia: -(2**39) + 2**8 + 2**0 = -549755813631
+        CHECK_EQ("\x80\x00\x00\x01\x01"_b.toInt(Enum(ByteOrder::Big)), -549755813631);
+        CHECK_EQ("\x01\x01\x00\x00\x80"_b.toInt(Enum(ByteOrder::Little)), -549755813631);
+
         if ( systemByteOrder().value() == ByteOrder::Little )
             CHECK_EQ("100"_b.toInt(Enum(ByteOrder::Host)), 3158065);
         else

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -366,6 +366,7 @@ TEST_CASE("toInt") {
         CHECK_EQ("100"_b.toInt(2), 4);
         CHECK_EQ("-100"_b.toInt(2), -4);
 
+        CHECK_THROWS_WITH_AS(""_b.toInt(16), "cannot decode from empty range", const RuntimeError&);
         CHECK_THROWS_WITH_AS("12a"_b.toInt(), "cannot parse bytes as signed integer", const RuntimeError&);
     }
 
@@ -379,11 +380,14 @@ TEST_CASE("toInt") {
         else
             CHECK_EQ("100"_b.toInt(ByteOrder::Big), 3223600);
 
+        CHECK_THROWS_WITH_AS(""_b.toInt(Enum(ByteOrder::Big)), "not enough bytes for conversion to integer",
+                             const InvalidValue&);
+
         CHECK_THROWS_WITH_AS("1234567890"_b.toInt(Enum(ByteOrder::Big)),
-                             "more than max of 8 bytes for conversion to integer (have 10)", const RuntimeError&);
+                             "more than max of 8 bytes for conversion to integer (have 10)", const InvalidValue&);
 
         CHECK_THROWS_WITH_AS("100"_b.toInt(Enum(ByteOrder::Undef)), "cannot convert value to undefined byte order",
-                             const RuntimeError&);
+                             const InvalidArgument&);
     }
 }
 
@@ -402,11 +406,14 @@ TEST_CASE("toUInt") {
         CHECK_EQ("100"_b.toUInt(Enum(ByteOrder::Little)), 3158065U);
         CHECK_EQ("100"_b.toUInt(Enum(ByteOrder::Host)), 3158065U);
 
+        CHECK_THROWS_WITH_AS(""_b.toUInt(Enum(ByteOrder::Big)), "not enough bytes for conversion to integer",
+                             const InvalidValue&);
+
         CHECK_THROWS_WITH_AS("1234567890"_b.toUInt(Enum(ByteOrder::Big)),
-                             "more than max of 8 bytes for conversion to integer (have 10)", const RuntimeError&);
+                             "more than max of 8 bytes for conversion to integer (have 10)", const InvalidValue&);
 
         CHECK_THROWS_WITH_AS("100"_b.toInt(Enum(ByteOrder::Undef)), "cannot convert value to undefined byte order",
-                             const RuntimeError&);
+                             const InvalidArgument&);
     }
 }
 

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -186,15 +186,18 @@ int64_t Bytes::toInt(ByteOrder byte_order) const {
 
 uint64_t Bytes::toUInt(ByteOrder byte_order) const {
     switch ( byte_order.value() ) {
-        case ByteOrder::Undef: throw RuntimeError("cannot convert value to undefined byte order");
+        case ByteOrder::Undef: throw InvalidArgument("cannot convert value to undefined byte order");
         case ByteOrder::Host: return toInt(systemByteOrder());
         case ByteOrder::Little: [[fallthrough]];
         case ByteOrder::Network: [[fallthrough]];
         case ByteOrder::Big: break;
     }
 
+    if ( isEmpty() )
+        throw InvalidValue("not enough bytes for conversion to integer");
+
     if ( auto size_ = size(); size_ > 8 )
-        throw RuntimeError(fmt("more than max of 8 bytes for conversion to integer (have %" PRIu64 ")", size_));
+        throw InvalidValue(fmt("more than max of 8 bytes for conversion to integer (have %" PRIu64 ")", size_));
 
     uint64_t i = 0;
 

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -2,6 +2,7 @@
 
 #include <utf8proc/utf8proc.h>
 
+#include <cstdint>
 #include <cstdlib>
 
 #include <hilti/rt/types/bytes.h>
@@ -171,14 +172,14 @@ integer::safe<uint64_t> Bytes::toUInt(uint64_t base) const {
 }
 
 int64_t Bytes::toInt(ByteOrder byte_order) const {
-    auto i = toUInt(byte_order);
+    auto i = toUInt(byte_order); // throws on size == 0 or size > 8
     auto size_ = static_cast<uint64_t>(size());
 
-    if ( i & (1U << (size_ * 8 - 1)) ) {
+    if ( i & (UINT64_C(1) << (size_ * 8 - 1)) ) {
         if ( size() == 8 )
             return static_cast<int64_t>(-(~i + 1));
 
-        return static_cast<int64_t>(-(i ^ ((1U << (size_ * 8)) - 1)) - 1);
+        return static_cast<int64_t>(-(i ^ ((UINT64_C(1) << (size_ * 8)) - 1)) - 1);
     }
 
     return static_cast<int64_t>(i);

--- a/hilti/toolchain/src/ast/operators/bytes.cc
+++ b/hilti/toolchain/src/ast/operators/bytes.cc
@@ -787,7 +787,8 @@ public:
                 R"(
 Interprets the data as representing an ASCII-encoded number and converts that
 into a signed integer, using a base of *base*. *base* must be between 2 and 36.
-If *base* is not given, the default is 10.
+If *base* is not given, the default is 10. If the conversion fails, throws
+a `RuntimeError` exception, this includes calling `to_int()` on empty ``bytes``.
 )",
         };
     }
@@ -815,7 +816,8 @@ public:
                 R"(
 Interprets the data as representing an ASCII-encoded number and converts that
 into an unsigned integer, using a base of *base*. *base* must be between 2 and
-36. If *base* is not given, the default is 10.
+36. If *base* is not given, the default is 10. If the conversion fails, throws
+a `RuntimeError` exception, this includes calling `to_uint()` on empty ``bytes``.
 )",
         };
     }
@@ -841,7 +843,9 @@ public:
             .doc =
                 R"(
 Interprets the ``bytes`` as representing an binary number encoded with the given
-byte order, and converts it into signed integer.
+byte order, and converts it into signed integer. If the conversion fails, throws
+a `RuntimeError` exception, this can happen when ``bytes`` is empty or its
+size is larger than 8 bytes.
 )",
         };
     }
@@ -867,7 +871,9 @@ public:
             .doc =
                 R"(
 Interprets the ``bytes`` as representing an binary number encoded with the given
-byte order, and converts it into an unsigned integer.
+byte order, and converts it into an unsigned integer. If the conversion fails,
+throws a `RuntimeError` exception, this can happen when ``bytes`` is empty or
+its size is larger than 8 bytes.
 )",
         };
     }

--- a/tests/hilti/types/bytes/to-int.hlt
+++ b/tests/hilti/types/bytes/to-int.hlt
@@ -16,6 +16,9 @@ assert-exception(b"0".to_int(1));
 assert(b"\x01\x02\x03\x04".to_int(hilti::ByteOrder::Big) == 0x1020304);
 assert(b"\x01\x02\x03\x04".to_int(hilti::ByteOrder::Little) == 0x4030201);
 
+assert-exception(b"".to_int(hilti::ByteOrder::Big));
+assert-exception(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09".to_int(hilti::ByteOrder::Little));
+
 # TODO: Some problems with the escaping & typing here.
 # assert(b"\x81".to_int(hilti::ByteOrder::Big) == 0x81);
 # assert(b"\x81".to_int(hilti::ByteOrder::Big) == 0xffffffffffffff81);

--- a/tests/hilti/types/bytes/to-int.hlt
+++ b/tests/hilti/types/bytes/to-int.hlt
@@ -16,6 +16,13 @@ assert-exception(b"0".to_int(1));
 assert(b"\x01\x02\x03\x04".to_int(hilti::ByteOrder::Big) == 0x1020304);
 assert(b"\x01\x02\x03\x04".to_int(hilti::ByteOrder::Little) == 0x4030201);
 
+assert(b"\xff\xff".to_int(hilti::ByteOrder::Big) == -1);
+assert(b"\xff\xff".to_int(hilti::ByteOrder::Little) == -1);
+assert(b"\xff\xff\xff\xff".to_int(hilti::ByteOrder::Big) == -1);
+assert(b"\xff\xff\xff\xff".to_int(hilti::ByteOrder::Little) == -1);
+assert(b"\x80\x00\x00\x01".to_int(hilti::ByteOrder::Big) == -2147483647);
+assert(b"\x01\x00\x00\x80".to_int(hilti::ByteOrder::Little) == -2147483647);
+
 assert-exception(b"".to_int(hilti::ByteOrder::Big));
 assert-exception(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09".to_int(hilti::ByteOrder::Little));
 


### PR DESCRIPTION
* Reject empty byte ranges for `to_uint(ByteOrder)`.
* Fix shifting of 32bit value, causing `to_int(ByteOrder)` to return bogus values.
