### PR TITLE
Rework emission of C++ code.

### DIFF
--- a/doc/autogen/types/bytes.rst
+++ b/doc/autogen/types/bytes.rst
@@ -90,11 +90,15 @@
     Interprets the data as representing an ASCII-encoded number and
     converts that into a signed integer, using a base of *base*. *base*
     must be between 2 and 36. If *base* is not given, the default is 10.
+    If the conversion fails, throws a `RuntimeError` exception, this
+    includes calling `to_int()` on empty ``bytes``.
 
 .. spicy:method:: bytes::to_int bytes to_int False int<64> (byte_order: spicy::ByteOrder)
 
     Interprets the ``bytes`` as representing an binary number encoded with
-    the given byte order, and converts it into signed integer.
+    the given byte order, and converts it into signed integer. If the
+    conversion fails, throws a `RuntimeError` exception, this can happen
+    when ``bytes`` is empty or its size is larger than 8 bytes.
 
 .. spicy:method:: bytes::to_real bytes to_real False real ()
 
@@ -122,11 +126,15 @@
     Interprets the data as representing an ASCII-encoded number and
     converts that into an unsigned integer, using a base of *base*. *base*
     must be between 2 and 36. If *base* is not given, the default is 10.
+    If the conversion fails, throws a `RuntimeError` exception, this
+    includes calling `to_uint()` on empty ``bytes``.
 
 .. spicy:method:: bytes::to_uint bytes to_uint False uint<64> (byte_order: spicy::ByteOrder)
 
     Interprets the ``bytes`` as representing an binary number encoded with
-    the given byte order, and converts it into an unsigned integer.
+    the given byte order, and converts it into an unsigned integer. If the
+    conversion fails, throws a `RuntimeError` exception, this can happen
+    when ``bytes`` is empty or its size is larger than 8 bytes.
 
 .. spicy:method:: bytes::upper bytes upper False bytes ([ charset: spicy::Charset = hilti::Charset::UTF8 ], [ errors: spicy::DecodeErrorStrategy = hilti::DecodeErrorStrategy::REPLACE ])
 

--- a/hilti/toolchain/include/ast/declarations/imported-module.h
+++ b/hilti/toolchain/include/ast/declarations/imported-module.h
@@ -62,7 +62,7 @@ public:
     }
 
     static auto create(ASTContext* ctx, ID id, hilti::rt::filesystem::path path, Meta meta = {}) {
-        return ctx->make<ImportedModule>(ctx, std::move(id), std::move(path), std::string{}, ID{}, std::move(meta));
+        return ctx->make<ImportedModule>(ctx, std::move(id), std::move(path), path.extension(), ID{}, std::move(meta));
     }
 
 protected:

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -674,9 +674,9 @@ public:
      * necessary.
      */
     template<typename T>
-    const T* tryAs_() {
-        if ( isA<T>() )
-            return static_cast<const T*>(this);
+    T* tryAs_() {
+        if ( isA_<T>() )
+            return static_cast<T*>(this);
         else
             return nullptr;
     }

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -1058,6 +1058,7 @@ class CycleDetector {
 public:
     void recordSeen(const Node* n) { _seen.insert(n); }
     bool haveSeen(const Node* n) const { return _seen.find(n) != _seen.end(); }
+    void clear() { _seen.clear(); }
 
 private:
     std::unordered_set<const Node*> _seen;

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/hilti/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/hilti/toolchain/include/compiler/detail/codegen/codegen.h
@@ -82,7 +82,7 @@ public:
     cxx::Expression compile(hilti::Ctor* c, bool lhs = false);
     cxx::Expression compile(hilti::expression::ResolvedOperator* o, bool lhs = false);
     cxx::Block compile(hilti::Statement* s, cxx::Block* b = nullptr);
-    cxx::declaration::Function compile(const ID& id, type::Function* ft, declaration::Linkage linkage,
+    cxx::declaration::Function compile(Declaration* decl, type::Function* ft, declaration::Linkage linkage,
                                        function::CallingConvention cc = function::CallingConvention::Standard,
                                        AttributeSet* fattrs = {}, std::optional<cxx::ID> namespace_ = {});
     std::vector<cxx::Expression> compileCallArguments(const hilti::node::Range<Expression>& args,
@@ -103,7 +103,7 @@ public:
                            bool throw_on_error);
     cxx::Expression unpack(QualifiedType* t, QualifiedType* data_type, const cxx::Expression& data,
                            const std::vector<cxx::Expression>& args, bool throw_on_error);
-    void addDeclarationFor(QualifiedType* t) { _need_decls.push_back(t); }
+    void addDeclarationForType(QualifiedType* t) { _need_decls.push_back(t); }
 
     cxx::Expression addTmp(const std::string& prefix, const cxx::Type& t);
     cxx::Expression addTmp(const std::string& prefix, const cxx::Expression& init);
@@ -136,10 +136,6 @@ public:
     void pushCxxBlock(cxx::Block* b) { _cxx_blocks.push_back(b); }
     void popCxxBlock() { _cxx_blocks.pop_back(); }
 
-    void enablePrioritizeTypes() { ++_prioritize_types; }
-    void disablePrioritizeTypes() { --_prioritize_types; }
-    bool prioritizeTypes() const { return _prioritize_types > 0; }
-
     cxx::Unit* unit() const;                         // will abort if not compiling a module.
     hilti::declaration::Module* hiltiModule() const; // will abort if not compiling a module.
 
@@ -150,6 +146,9 @@ private:
     // LHS, it's returned directly. Otherwise it assigns it over into a
     // temporary, which is then returned.
     cxx::Expression _makeLhs(cxx::Expression expr, QualifiedType* type);
+
+    // Add all required C++ declarations to a unit.
+    void _addCxxDeclarations(cxx::Unit* unit, bool include_implementation);
 
     std::weak_ptr<Context> _context;
     std::unique_ptr<Builder> _builder;
@@ -165,7 +164,6 @@ private:
     hilti::util::Cache<cxx::ID, codegen::CxxTypes> _cache_types_storage;
     hilti::util::Cache<cxx::ID, codegen::CxxTypeInfo> _cache_type_info;
     hilti::util::Cache<cxx::ID, cxx::declaration::Type> _cache_types_declarations;
-    int _prioritize_types = 0;
 };
 
 } // namespace detail

--- a/hilti/toolchain/include/compiler/detail/cxx/elements.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/elements.h
@@ -218,19 +218,16 @@ struct Constant : public DeclarationBase {
 /** Declaration of a C++ type. */
 struct Type : public DeclarationBase {
     cxx::Type type;
-    std::string inline_code;
+    std::string code;
     bool no_using = false; // turned on automatically for types starting with "struct"
 
-    Type(cxx::ID id = {}, cxx::Type type = {}, std::string inline_code = {}, bool no_using = false)
-        : DeclarationBase(std::move(id)),
-          type(std::move(type)),
-          inline_code(std::move(inline_code)),
-          no_using(no_using) {}
+    Type(cxx::ID id = {}, cxx::Type type = {}, std::string code = {}, bool no_using = false)
+        : DeclarationBase(std::move(id)), type(std::move(type)), code(std::move(code)), no_using(no_using) {}
 
     void emit(Formatter& f) const final;
 
     bool operator==(const Type& other) const {
-        return type == other.type && inline_code == other.inline_code && no_using == other.no_using &&
+        return type == other.type && code == other.code && no_using == other.no_using &&
                DeclarationBase::operator==(other);
     }
 
@@ -397,7 +394,7 @@ struct Struct {
     cxx::Block ctor;
     bool add_ctors = false;
     std::string str() const;
-    std::string inlineCode() const;
+    std::string code() const;
 
     operator std::string() const { return str(); }
     operator cxx::Type() const { return str(); }

--- a/hilti/toolchain/include/compiler/detail/cxx/elements.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/elements.h
@@ -50,6 +50,7 @@ public:
     explicit operator bool() const { return ! _s.empty(); }
     bool operator<(const Element& s) const { return _s < s._s; }
     bool operator==(const Element& s) const { return _s == s._s; }
+    bool operator!=(const Element& s) const { return ! operator==(s); }
 
 private:
     std::string _s;
@@ -76,7 +77,7 @@ public:
     explicit operator bool() const { return ! _s.empty(); }
     bool operator<(const Expression& s) const { return _s < s._s; }
     bool operator==(const Expression& s) const { return _s == s._s; }
-    bool operator!=(const Expression& s) const { return _s != s._s; }
+    bool operator!=(const Expression& s) const { return ! operator==(s); }
 
 private:
     std::string _s;
@@ -103,32 +104,43 @@ public:
 
 namespace declaration {
 
-class DeclarationBase {}; // TODO: We will expand this later
+// Joint base class for all C++ declarations.
+struct DeclarationBase {
+    DeclarationBase(cxx::ID id) : id(std::move(id)) {}
+    virtual ~DeclarationBase() = default;
+
+    cxx::ID id;
+
+    // Outputs the C++ representation of the declaration.
+    virtual void emit(Formatter& f) const = 0;
+
+protected:
+    bool operator==(const DeclarationBase& other) const { return id == other.id; } // for derived classes to use
+};
 
 /** A C++ `@include` specific action. */
 struct IncludeFile : public DeclarationBase {
+    IncludeFile(std::string file) : DeclarationBase({}), file(std::move(file)) {}
+
     std::string file;
 
-    IncludeFile(std::string file) : file(std::move(file)) {}
+    void emit(Formatter& f) const final;
 
-    bool operator<(const IncludeFile& o) const { return file < o.file; }
+    bool operator<(const IncludeFile& other) const { return file < other.file; }
+    bool operator==(const IncludeFile& other) const { return file == other.file && DeclarationBase::operator==(other); }
+    bool operator!=(const IncludeFile& other) const { return ! operator==(other); }
 };
 
 /** Declaration of a local C++ variable. */
 struct Local : public DeclarationBase {
-    Local(Local&&) = default;
-    Local(const Local&) = default;
-    Local& operator=(Local&&) = default;
-    Local& operator=(const Local&) = default;
     Local(cxx::ID id = {}, cxx::Type type = {}, std::vector<cxx::Expression> args = {},
           std::optional<cxx::Expression> init = {}, Linkage linkage = {})
-        : id(std::move(id)),
+        : DeclarationBase(std::move(id)),
           type(std::move(type)),
           args(std::move(args)),
           init(std::move(init)),
           linkage(std::move(linkage)) {}
 
-    cxx::ID id;
     cxx::Type type;
     std::vector<cxx::Expression> args;
     std::optional<cxx::Expression> init;
@@ -142,13 +154,21 @@ struct Local : public DeclarationBase {
     // for anonymous fields that make it out into the generated struct.
     bool isAnonymous() const { return util::startsWith(id.local(), "_anon"); }
 
+    void emit(Formatter& f) const final;
+
+    bool operator==(const Local& other) const {
+        return type == other.type && args == other.args && init == other.init && linkage == other.linkage &&
+               DeclarationBase::operator==(other);
+    }
+
+    bool operator!=(const Local& other) const { return ! operator==(other); }
+
     std::string str() const;
     operator std::string() const { return str(); }
 };
 
 /** Declaration of a global C++ variable. */
 struct Global : public DeclarationBase {
-    cxx::ID id;
     cxx::Type type;
     std::vector<cxx::Expression> args;
     std::optional<cxx::Expression> init;
@@ -156,15 +176,20 @@ struct Global : public DeclarationBase {
 
     Global(cxx::ID id = {}, cxx::Type type = {}, std::vector<cxx::Expression> args = {},
            std::optional<cxx::Expression> init = {}, Linkage linkage = {})
-        : id(std::move(id)),
+        : DeclarationBase(std::move(id)),
           type(std::move(type)),
           args(std::move(args)),
           init(std::move(init)),
           linkage(std::move(linkage)) {}
 
+    void emit(Formatter& f) const final;
+
     bool operator==(const Global& other) const {
-        return id == other.id && type == other.type && init == other.init && linkage == other.linkage;
+        return type == other.type && args == other.args && init == other.init && linkage == other.linkage &&
+               DeclarationBase::operator==(other);
     }
+
+    bool operator!=(const Global& other) const { return ! operator==(other); }
 
     std::string str() const;
     operator std::string() const { return str(); }
@@ -172,54 +197,48 @@ struct Global : public DeclarationBase {
 
 /** Declaration of a C++ constant. */
 struct Constant : public DeclarationBase {
-    cxx::ID id;
     cxx::Type type;
     std::optional<cxx::Expression> init;
     Linkage linkage;
-    bool forward_decl = false;
 
-    Constant(cxx::ID id = {}, cxx::Type type = {}, std::optional<cxx::Expression> init = {}, Linkage linkage = {},
-             bool forward_decl = false)
-        : id(std::move(id)),
-          type(std::move(type)),
-          init(std::move(init)),
-          linkage(std::move(linkage)),
-          forward_decl(forward_decl) {}
+    Constant(cxx::ID id = {}, cxx::Type type = {}, std::optional<cxx::Expression> init = {}, Linkage linkage = {})
+        : DeclarationBase(std::move(id)), type(std::move(type)), init(std::move(init)), linkage(std::move(linkage)) {}
+
+    void emit(Formatter& f) const final;
 
     bool operator<(const Constant& s) const { return id < s.id; }
     bool operator==(const Constant& other) const {
-        return id == other.id && type == other.type && init == other.init && linkage == other.linkage;
+        return type == other.type && init == other.init && linkage == other.linkage &&
+               DeclarationBase::operator==(other);
     }
+
+    bool operator!=(const Constant& other) const { return ! operator==(other); }
 };
 
 /** Declaration of a C++ type. */
 struct Type : public DeclarationBase {
-    cxx::ID id;
     cxx::Type type;
     std::string inline_code;
-    bool forward_decl = false;
-    bool forward_decl_prio = false;
     bool no_using = false; // turned on automatically for types starting with "struct"
 
-    Type(cxx::ID id = {}, cxx::Type type = {}, std::string inline_code = {}, bool forward_decl = false,
-         bool forward_decl_prio = false, bool no_using = false)
-        : id(std::move(id)),
+    Type(cxx::ID id = {}, cxx::Type type = {}, std::string inline_code = {}, bool no_using = false)
+        : DeclarationBase(std::move(id)),
           type(std::move(type)),
           inline_code(std::move(inline_code)),
-          forward_decl(forward_decl),
-          forward_decl_prio(forward_decl_prio),
           no_using(no_using) {}
 
+    void emit(Formatter& f) const final;
+
     bool operator==(const Type& other) const {
-        return id == other.id && type == other.type && inline_code == other.inline_code &&
-               forward_decl == other.forward_decl && forward_decl_prio == other.forward_decl_prio &&
-               no_using == other.no_using;
+        return type == other.type && inline_code == other.inline_code && no_using == other.no_using &&
+               DeclarationBase::operator==(other);
     }
+
+    bool operator!=(const Type& other) const { return ! operator==(other); }
 };
 
 /** Declaration of a C++ function argument. */
 struct Argument : public DeclarationBase {
-    cxx::ID id;
     cxx::Type type;
     std::optional<cxx::Expression> default_;
     cxx::Type internal_type = "";
@@ -227,12 +246,19 @@ struct Argument : public DeclarationBase {
 
     Argument(cxx::ID id = {}, cxx::Type type = {}, std::optional<cxx::Expression> default_ = {},
              cxx::Type internal_type = "")
-        : id(std::move(id)),
+        : DeclarationBase(std::move(id)),
           type(std::move(type)),
           default_(std::move(default_)),
           internal_type(std::move(internal_type)) {}
 
-    bool operator==(const Argument& other) const { return type == other.type && id == other.id; }
+    void emit(Formatter& f) const final;
+
+    bool operator==(const Argument& other) const {
+        return type == other.type && default_ == other.default_ && internal_type == other.internal_type &&
+               DeclarationBase::operator==(other);
+    }
+
+    bool operator!=(const Argument& other) const { return ! operator==(other); }
 };
 
 } // namespace declaration
@@ -279,6 +305,7 @@ public:
     friend ::hilti::detail::cxx::Formatter& operator<<(Formatter& f, const Block& x);
 
     bool operator==(const Block& other) const { return _stmts == other._stmts; }
+    bool operator!=(const Block& other) const { return ! operator==(other); }
 
 private:
     using Flags = unsigned int;
@@ -289,45 +316,57 @@ private:
 
 namespace declaration {
 
+
 /** Declaration of a C++ function. */
 struct Function : public DeclarationBase {
+    /** Tag marking an inline function for overload resolution. */
+    using Inline = struct {};
+
+    /** Type of function being declared. */
+    enum Type {
+        Free,  // global, free function
+        Method // struct method
+    };
+
+    Type ftype;
     cxx::Type result;
-    cxx::ID id;
     std::vector<Argument> args;
-    bool const_ = false;
-    Linkage linkage = "static";
-    Attribute attribute = "";
+    Linkage linkage;
+    std::optional<Block> body;
     std::optional<Block> inline_body;
 
     std::string prototype(bool qualify) const;
     std::string parameters() const;
 
-    Function(cxx::Type result = {}, cxx::ID id = {}, std::vector<Argument> args = {}, bool const_ = false,
-             Linkage linkage = "static", Attribute attribute = "", std::optional<Block> inline_body = {})
-        : result(std::move(result)),
-          id(std::move(id)),
+    Function(Type ftype, cxx::Type result, cxx::ID id, std::vector<Argument> args, Linkage linkage,
+             std::optional<Block> body = {})
+        : DeclarationBase(std::move(id)),
+          ftype(ftype),
+          result(std::move(result)),
           args(std::move(args)),
-          const_(const_),
           linkage(std::move(linkage)),
-          attribute(std::move(attribute)),
+          body(std::move(body)) {}
+
+    Function(Type ftype, cxx::Type result, cxx::ID id, std::vector<Argument> args, Linkage linkage, Inline,
+             Block inline_body)
+        : DeclarationBase(std::move(id)),
+          ftype(ftype),
+          result(std::move(result)),
+          args(std::move(args)),
+          linkage(std::move(linkage)),
           inline_body(std::move(inline_body)) {}
 
+    void emit(Formatter& f) const final;
+
     bool operator==(const Function& other) const {
-        return result == other.result && id == other.id && args == other.args && linkage == other.linkage &&
-               attribute == other.attribute && inline_body == other.inline_body;
+        return ftype == other.ftype && result == other.result && args == other.args && linkage == other.linkage &&
+               inline_body == other.inline_body && body == other.body && DeclarationBase::operator==(other);
     }
+
+    bool operator!=(const Function& other) const { return ! operator==(other); }
 };
 
 } // namespace declaration
-
-/** A C++ function. */
-struct Function {
-    declaration::Function declaration;
-    Block body;
-    bool default_ = false;
-
-    bool operator==(const Function& other) const { return declaration == other.declaration && body == other.body; }
-};
 
 namespace type {
 namespace struct_ {
@@ -404,11 +443,10 @@ extern Formatter& operator<<(Formatter& f, const Expression& x);
 extern Formatter& operator<<(Formatter& f, const ID& x);
 extern Formatter& operator<<(Formatter& f, const Function& x);
 extern Formatter& operator<<(Formatter& f, const Type& x);
-extern Formatter& operator<<(Formatter& f, const declaration::Type& x);
-extern Formatter& operator<<(Formatter& f, const declaration::IncludeFile& x);
-extern Formatter& operator<<(Formatter& f, const declaration::Local& x);
-extern Formatter& operator<<(Formatter& f, const declaration::Global& x);
-extern Formatter& operator<<(Formatter& f, const declaration::Function& x);
-extern Formatter& operator<<(Formatter& f, const declaration::Constant& x);
+
+inline Formatter& operator<<(Formatter& f, const declaration::DeclarationBase& x) {
+    x.emit(f);
+    return f;
+}
 
 } // namespace hilti::detail::cxx

--- a/hilti/toolchain/include/compiler/detail/cxx/unit.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/unit.h
@@ -74,6 +74,8 @@ public:
     };
 
     const auto& cxxModuleID() const { return _module_id; }
+    cxx::ID cxxInternalNamespace() const;
+    cxx::ID cxxExternalNamespace() const;
 
     void setUsesGlobals() { _uses_globals = true; }
 
@@ -87,12 +89,13 @@ public:
     void addInitialization(cxx::Block block) { _init_module.appendFromBlock(std::move(block)); }
     void addPreInitialization(cxx::Block block) { _preinit_module.appendFromBlock(std::move(block)); }
 
-    Result<Nothing> finalize();
+    // @param include_all_implementations if true, do not filter out function
+    // implementations that aren't within the module's own namespace.
+    Result<Nothing> finalize(bool include_all_implementations = false);
 
     Result<Nothing> print(std::ostream& out) const;      // only after finalize
     Result<Nothing> createPrototypes(std::ostream& out); // only after finalize
     Result<linker::MetaData> linkerMetaData() const;     // only after finalize
-    cxx::ID cxxNamespace() const;
 
     std::shared_ptr<Context> context() const { return _context.lock(); }
 
@@ -105,8 +108,8 @@ private:
     using cxxDeclaration = std::variant<declaration::IncludeFile, declaration::Global, declaration::Constant,
                                         declaration::Type, declaration::Function>;
 
-    void _generateCode(Formatter& f, bool prototypes_only);
-    void _emitDeclarations(const cxxDeclaration& decl, Formatter& f, Phase phase);
+    void _generateCode(Formatter& f, bool prototypes_only, bool include_all_implementations);
+    void _emitDeclarations(const cxxDeclaration& decl, Formatter& f, Phase phase, bool include_all_implementations);
     void _addHeader(Formatter& f);
     void _addModuleInitFunction();
 

--- a/hilti/toolchain/include/compiler/detail/cxx/unit.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/unit.h
@@ -109,7 +109,8 @@ private:
                                         declaration::Type, declaration::Function>;
 
     void _generateCode(Formatter& f, bool prototypes_only, bool include_all_implementations);
-    void _emitDeclarations(const cxxDeclaration& decl, Formatter& f, Phase phase, bool include_all_implementations);
+    void _emitDeclarations(const cxxDeclaration& decl, Formatter& f, Phase phase, bool prototypes_only,
+                           bool include_all_implementations);
     void _addHeader(Formatter& f);
     void _addModuleInitFunction();
 

--- a/hilti/toolchain/include/compiler/unit.h
+++ b/hilti/toolchain/include/compiler/unit.h
@@ -97,14 +97,6 @@ public:
     Result<CxxCode> cxxCode() const;
 
     /**
-     * Returns the list of dependencies registered for the unit so far.
-     *
-     * @param recursive if true, return the transitive closure of all
-     * dependent units, vs just direct dependencies of the current unit
-     */
-    std::set<declaration::module::UID> dependencies(bool recursive = false) const;
-
-    /**
      * Returns the unit's meta data for the internal HILTI linker.
      *
      * @return meta data, or an error if no code has been compiled yet

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -935,32 +935,6 @@ void ASTContext::_saveIterationAST(const Plugin& plugin, const std::string& pref
     _dumpAST(out, plugin, prefix, 0);
 }
 
-static void _recursiveDependencies(const ASTContext* ctx, declaration::Module* module,
-                                   std::set<declaration::module::UID>* seen) {
-    if ( seen->count(module->uid()) )
-        return;
-
-    for ( const auto& uid : module->dependencies() ) {
-        seen->insert(uid);
-        auto dep = ctx->module(uid);
-        assert(dep && dep->uid() == uid);
-        _recursiveDependencies(ctx, dep, seen);
-    }
-}
-
-std::set<declaration::module::UID> ASTContext::dependencies(const declaration::module::UID& uid, bool recursive) const {
-    auto m = module(uid);
-    assert(m);
-
-    if ( recursive ) {
-        std::set<declaration::module::UID> seen;
-        _recursiveDependencies(this, m, &seen);
-        return seen;
-    }
-    else
-        return m->dependencies();
-}
-
 const std::unordered_set<Declaration*>& ASTContext::dependentDeclarations(Declaration* n) {
     if ( _dependency_tracker )
         return _dependency_tracker->dependentDeclarations(n);

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -530,7 +530,7 @@ struct Visitor : hilti::visitor::PreOrder {
                 fmts.emplace_back("%s");
             }
 
-            auto dbg = fmt("HILTI_RT_DEBUG(\"hilti-flow\", hilti::rt::fmt(\"%s: %s(%s)\"%s))", f->meta().location(),
+            auto dbg = fmt("HILTI_RT_DEBUG(\"hilti-flow\", ::hilti::rt::fmt(\"%s: %s(%s)\"%s))", f->meta().location(),
                            d.id, util::join(fmts, ", "), util::join(args, ""));
 
             cxx_func.body.addStatementAtFront(std::move(dbg));
@@ -577,8 +577,9 @@ struct Visitor : hilti::visitor::PreOrder {
                 cb.addReturn("::hilti::rt::Nothing()");
             }
 
-            body.addLambda("cb", "[args_on_heap](hilti::rt::resumable::Handle* r) -> hilti::rt::any", std::move(cb));
-            body.addLocal({"r", "auto", {}, "std::make_unique<hilti::rt::Resumable>(std::move(cb))"});
+            body.addLambda("cb", "[args_on_heap](::hilti::rt::resumable::Handle* r) -> ::hilti::rt::any",
+                           std::move(cb));
+            body.addLocal({"r", "auto", {}, "std::make_unique<::hilti::rt::Resumable>(std::move(cb))"});
             body.addStatement("r->run()");
             body.addReturn("std::move(*r)");
 
@@ -835,8 +836,8 @@ cxx::Expression CodeGen::startProfiler(const std::string& name, cxx::Block* bloc
 
     assert(block);
     pushCxxBlock(block);
-    auto id = addTmp("profiler", cxx::Type("std::optional<hilti::rt::Profiler>"));
-    auto stmt = cxx::Expression(fmt("%s = hilti::rt::profiler::start(\"%s\")", id, name));
+    auto id = addTmp("profiler", cxx::Type("std::optional<::hilti::rt::Profiler>"));
+    auto stmt = cxx::Expression(fmt("%s = ::hilti::rt::profiler::start(\"%s\")", id, name));
 
     if ( insert_at_front )
         cxxBlock()->addStatementAtFront(stmt);
@@ -855,14 +856,14 @@ void CodeGen::stopProfiler(const cxx::Expression& profiler, cxx::Block* block) {
         block = cxxBlock();
 
     assert(block);
-    block->addStatement(cxx::Expression(fmt("hilti::rt::profiler::stop(%s)", profiler)));
+    block->addStatement(cxx::Expression(fmt("::hilti::rt::profiler::stop(%s)", profiler)));
 }
 
 cxx::Expression CodeGen::unsignedIntegerToBitfield(type::Bitfield* t, const cxx::Expression& value,
                                                    const cxx::Expression& bitorder) {
     std::vector<cxx::Expression> bits;
     for ( const auto& b : t->bits(false) ) {
-        auto x = fmt("hilti::rt::integer::bits(%s, %d, %d, %s)", value, b->lower(), b->upper(), bitorder);
+        auto x = fmt("::hilti::rt::integer::bits(%s, %d, %d, %s)", value, b->lower(), b->upper(), bitorder);
 
         if ( auto a = b->attributes()->find("&convert") ) {
             pushDollarDollar(x);
@@ -875,9 +876,9 @@ cxx::Expression CodeGen::unsignedIntegerToBitfield(type::Bitfield* t, const cxx:
 
     // `noop()` just returns the same value passed in. Without it, the compiler
     // doesn't like the expression we are building, not sure why.
-    bits.emplace_back(fmt("hilti::rt::integer::noop(%s)", value));
+    bits.emplace_back(fmt("::hilti::rt::integer::noop(%s)", value));
 
-    return fmt("hilti::rt::make_bitfield(%s)", util::join(bits, ", "));
+    return fmt("::hilti::rt::make_bitfield(%s)", util::join(bits, ", "));
 }
 
 

--- a/hilti/toolchain/src/compiler/codegen/coercions.cc
+++ b/hilti/toolchain/src/compiler/codegen/coercions.cc
@@ -68,7 +68,7 @@ struct Visitor : public hilti::visitor::PreOrder {
     void operator()(type::Interval* n) final {
         if ( dst->type()->isA<type::Bool>() ) {
             auto id = cg->compile(src, codegen::TypeUsage::Storage);
-            result = fmt("(%s != hilti::rt::Interval())", expr);
+            result = fmt("(%s != ::hilti::rt::Interval())", expr);
         }
 
         else
@@ -85,7 +85,7 @@ struct Visitor : public hilti::visitor::PreOrder {
 
             std::string allocator;
             if ( auto def = cg->typeDefaultValue(x->elementType()) )
-                allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", y, *def);
+                allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", y, *def);
 
             result = fmt("::hilti::rt::Vector<%s%s>(%s)", y, allocator, expr);
         }
@@ -137,7 +137,7 @@ struct Visitor : public hilti::visitor::PreOrder {
     void operator()(type::Time* n) final {
         if ( dst->type()->isA<type::Bool>() ) {
             auto id = cg->compile(src, codegen::TypeUsage::Storage);
-            result = fmt("(%s != hilti::rt::Time())", expr);
+            result = fmt("(%s != ::hilti::rt::Time())", expr);
         }
 
         else
@@ -246,7 +246,7 @@ struct Visitor : public hilti::visitor::PreOrder {
             result = fmt("::hilti::rt::integer::safe<uint%d_t>(%s)", x->width(), expr);
 
         else if ( auto t = dst->type()->tryAs<type::Bitfield>() )
-            result = cg->unsignedIntegerToBitfield(t, expr, cxx::Expression("hilti::rt::integer::BitOrder::LSB0"));
+            result = cg->unsignedIntegerToBitfield(t, expr, cxx::Expression("::hilti::rt::integer::BitOrder::LSB0"));
         else
             logger().internalError(
                 fmt("codegen: unexpected type coercion from unsigned integer to %s", dst->type()->typename_()));

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -44,7 +44,8 @@ struct Visitor : hilti::visitor::PreOrder {
                 values.emplace_back("std::nullopt");
         }
 
-        result = fmt("hilti::rt::Bitfield<%s>(std::make_tuple(%s))", util::join(types, ", "), util::join(values, ", "));
+        result =
+            fmt("::hilti::rt::Bitfield<%s>(std::make_tuple(%s))", util::join(types, ", "), util::join(values, ", "));
     }
     void operator()(ctor::Bool* n) final { result = fmt("::hilti::rt::Bool(%s)", n->value() ? "true" : "false"); }
 
@@ -80,8 +81,8 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     void operator()(ctor::Interval* n) final {
-        result = fmt("::hilti::rt::Interval(hilti::rt::integer::safe<int64_t>(%" PRId64
-                     "), hilti::rt::Interval::NanosecondTag())",
+        result = fmt("::hilti::rt::Interval(::hilti::rt::integer::safe<int64_t>(%" PRId64
+                     "), ::hilti::rt::Interval::NanosecondTag())",
                      n->value().nanoseconds());
     }
 
@@ -268,7 +269,7 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     void operator()(ctor::Time* n) final {
-        result = fmt("::hilti::rt::Time(%" PRId64 ", hilti::rt::Time::NanosecondTag())", n->value().nanoseconds());
+        result = fmt("::hilti::rt::Time(%" PRId64 ", ::hilti::rt::Time::NanosecondTag())", n->value().nanoseconds());
     }
 
     void operator()(ctor::Enum* n) final {
@@ -292,7 +293,7 @@ struct Visitor : hilti::visitor::PreOrder {
 
         std::string allocator;
         if ( auto def = cg->typeDefaultValue(n->elementType()) )
-            allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+            allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", x, *def);
 
         if ( const auto size = n->value().size(); size > ThresholdBigContainerCtrUnroll ) {
             auto elems = util::join(node::transform(n->value(),

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -88,8 +88,7 @@ struct Visitor : hilti::visitor::PreOrder {
             case expression::keyword::Kind::Captures: result = {"__captures", Side::LHS}; break;
             case expression::keyword::Kind::Scope: {
                 auto scope = fmt("%s_hlto_scope", cg->options().cxx_namespace_intern);
-                auto extern_scope =
-                    cxx::declaration::Global{.id = cxx::ID(scope), .type = "const char*", .linkage = "extern"};
+                auto extern_scope = cxx::declaration::Global(cxx::ID(scope), "const char*", {}, {}, "extern");
                 cg->unit()->add(extern_scope);
                 result = {fmt("std::string(%s)", scope), Side::RHS};
                 break;

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -113,7 +113,7 @@ struct Visitor : hilti::visitor::PreOrder {
         auto id = n->op1()->as<expression::Member>()->id();
         auto elem = n->op0()->type()->type()->as<type::Bitfield>()->bitsIndex(id);
         assert(elem);
-        result = {fmt("(hilti::rt::optional::value(std::get<%u>(%s.value)))", *elem, op0(n)), Side::RHS};
+        result = {fmt("(::hilti::rt::optional::value(std::get<%u>(%s.value)))", *elem, op0(n)), Side::RHS};
     }
 
     void operator()(operator_::bitfield::HasMember* n) final {
@@ -375,27 +375,27 @@ struct Visitor : hilti::visitor::PreOrder {
 
     void operator()(operator_::interval::CtorSignedIntegerSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Interval(%s, hilti::rt::Interval::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Interval(%s, ::hilti::rt::Interval::SecondTag())", args[0]);
     }
 
     void operator()(operator_::interval::CtorSignedIntegerNs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Interval(%s, hilti::rt::Interval::NanosecondTag())", args[0]);
+        result = fmt("::hilti::rt::Interval(%s, ::hilti::rt::Interval::NanosecondTag())", args[0]);
     }
 
     void operator()(operator_::interval::CtorUnsignedIntegerSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Interval(%s, hilti::rt::Interval::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Interval(%s, ::hilti::rt::Interval::SecondTag())", args[0]);
     }
 
     void operator()(operator_::interval::CtorUnsignedIntegerNs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Interval(%s, hilti::rt::Interval::NanosecondTag())", args[0]);
+        result = fmt("::hilti::rt::Interval(%s, ::hilti::rt::Interval::NanosecondTag())", args[0]);
     }
 
     void operator()(operator_::interval::CtorRealSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Interval(%f, hilti::rt::Interval::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Interval(%f, ::hilti::rt::Interval::SecondTag())", args[0]);
     }
 
     // List
@@ -467,10 +467,10 @@ struct Visitor : hilti::visitor::PreOrder {
     /// Real
 
     void operator()(operator_::real::CastToInterval* n) final {
-        result = fmt("::hilti::rt::Interval(%f, hilti::rt::Interval::SecondTag())", op0(n));
+        result = fmt("::hilti::rt::Interval(%f, ::hilti::rt::Interval::SecondTag())", op0(n));
     }
     void operator()(operator_::real::CastToTime* n) final {
-        result = fmt("::hilti::rt::Time(%f, hilti::rt::Time::SecondTag())", op0(n));
+        result = fmt("::hilti::rt::Time(%f, ::hilti::rt::Time::SecondTag())", op0(n));
     }
     void operator()(operator_::real::Difference* n) final { result = binary(n, "-"); }
     void operator()(operator_::real::DifferenceAssign* n) final { result = binary(n, "-="); }
@@ -931,8 +931,8 @@ struct Visitor : hilti::visitor::PreOrder {
 
     void operator()(operator_::signed_integer::CastToBool* n) final { result = fmt("::hilti::rt::Bool(%s)", op0(n)); }
     void operator()(operator_::signed_integer::CastToInterval* n) final {
-        result = fmt("::hilti::rt::Interval(hilti::rt::integer::safe<int64_t>(%" PRId64
-                     ") * 1000000000, hilti::rt::Interval::NanosecondTag())",
+        result = fmt("::hilti::rt::Interval(::hilti::rt::integer::safe<int64_t>(%" PRId64
+                     ") * 1000000000, ::hilti::rt::Interval::NanosecondTag())",
                      op0(n));
     }
     void operator()(operator_::signed_integer::CastToEnum* n) final {
@@ -1034,27 +1034,27 @@ struct Visitor : hilti::visitor::PreOrder {
 
     void operator()(operator_::time::CtorSignedIntegerSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Time(%s, hilti::rt::Time::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Time(%s, ::hilti::rt::Time::SecondTag())", args[0]);
     }
 
     void operator()(operator_::time::CtorSignedIntegerNs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Time(%s, hilti::rt::Time::NanosecondTag())", args[0]);
+        result = fmt("::hilti::rt::Time(%s, ::hilti::rt::Time::NanosecondTag())", args[0]);
     }
 
     void operator()(operator_::time::CtorUnsignedIntegerSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Time(%s, hilti::rt::Time::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Time(%s, ::hilti::rt::Time::SecondTag())", args[0]);
     }
 
     void operator()(operator_::time::CtorUnsignedIntegerNs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Time(%s, hilti::rt::Time::NanosecondTag())", args[0]);
+        result = fmt("::hilti::rt::Time(%s, ::hilti::rt::Time::NanosecondTag())", args[0]);
     }
 
     void operator()(operator_::time::CtorRealSecs* n) final {
         auto args = tupleArguments(n, n->op1());
-        result = fmt("::hilti::rt::Time(%f, hilti::rt::Time::SecondTag())", args[0]);
+        result = fmt("::hilti::rt::Time(%f, ::hilti::rt::Time::SecondTag())", args[0]);
     }
 
     // Tuple
@@ -1091,13 +1091,13 @@ struct Visitor : hilti::visitor::PreOrder {
         result = fmt("::hilti::rt::enum_::from_uint<%s>(%s)", cg->compile(t, codegen::TypeUsage::Storage), op0(n));
     }
     void operator()(operator_::unsigned_integer::CastToInterval* n) final {
-        result = fmt("::hilti::rt::Interval(hilti::rt::integer::safe<uint64_t>(%" PRIu64
-                     ") * 1000000000, hilti::rt::Interval::NanosecondTag())",
+        result = fmt("::hilti::rt::Interval(::hilti::rt::integer::safe<uint64_t>(%" PRIu64
+                     ") * 1000000000, ::hilti::rt::Interval::NanosecondTag())",
                      op0(n));
     }
     void operator()(operator_::unsigned_integer::CastToTime* n) final {
-        result = fmt("::hilti::rt::Time(hilti::rt::integer::safe<uint64_t>(%" PRIu64
-                     ") * 1'000'000'000, hilti::rt::Time::NanosecondTag())",
+        result = fmt("::hilti::rt::Time(::hilti::rt::integer::safe<uint64_t>(%" PRIu64
+                     ") * 1'000'000'000, ::hilti::rt::Time::NanosecondTag())",
                      op0(n));
     }
     void operator()(operator_::unsigned_integer::DecrPostfix* n) final { result = fmt("%s--", op0(n)); }

--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -68,7 +68,7 @@ struct Visitor : hilti::visitor::PreOrder {
                 logger().internalError("not support currently for testing for specific exception in assertion", n);
 
             cxx::Block try_body;
-            try_body.addTmp(cxx::declaration::Local{"_", "::hilti::rt::exception::DisableAbortOnExceptions"});
+            try_body.addTmp(cxx::declaration::Local("_", "::hilti::rt::exception::DisableAbortOnExceptions"));
             try_body.addStatement(fmt("%s", cg->compile(n->expression())));
 
             if ( cg->options().debug_flow )
@@ -142,8 +142,8 @@ struct Visitor : hilti::visitor::PreOrder {
             init = cg->typeDefaultValue(d->type());
         }
 
-        auto l = cxx::declaration::Local{cxx::ID(d->id()), cg->compile(d->type(), codegen::TypeUsage::Storage),
-                                         std::move(args), init};
+        auto l = cxx::declaration::Local(cxx::ID(d->id()), cg->compile(d->type(), codegen::TypeUsage::Storage),
+                                         std::move(args), init);
 
         block->addLocal(l);
     }
@@ -197,7 +197,7 @@ struct Visitor : hilti::visitor::PreOrder {
         else {
             cxx::Block b;
             b.setEnsureBracesforBlock();
-            b.addTmp(cxx::declaration::Local{"__seq", "auto", {}, seq});
+            b.addTmp(cxx::declaration::Local("__seq", "auto", {}, seq));
             b.addForRange(true, id, fmt("::hilti::rt::range(__seq)"), body);
             block->addBlock(std::move(b));
         }

--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -46,7 +46,7 @@ struct Visitor : hilti::visitor::PreOrder {
         std::string throw_;
 
         if ( n->message() )
-            throw_ = fmt("throw ::hilti::rt::AssertionFailure(hilti::rt::to_string_for_print(%s), \"%s\")",
+            throw_ = fmt("throw ::hilti::rt::AssertionFailure(::hilti::rt::to_string_for_print(%s), \"%s\")",
                          cg->compile(n->message()), n->meta().location());
         else {
             auto msg = std::string(*n->expression());
@@ -84,8 +84,8 @@ struct Visitor : hilti::visitor::PreOrder {
             catch_cont.addStatement(""); // dummy to  make it non-empty;
 
             block->addTry(std::move(try_body), {
-                                                   {{{}, "const hilti::rt::AssertionFailure&"}, catch_rethrow},
-                                                   {{{}, "const hilti::rt::Exception&"}, catch_cont},
+                                                   {{{}, "const ::hilti::rt::AssertionFailure&"}, catch_rethrow},
+                                                   {{{}, "const ::hilti::rt::Exception&"}, catch_cont},
                                                });
         }
     }
@@ -261,7 +261,7 @@ struct Visitor : hilti::visitor::PreOrder {
             default_ = cg->compile(d->body());
         else
             default_.addStatement(
-                fmt("throw hilti::rt::UnhandledSwitchCase(hilti::rt::to_string_for_print(%s), \"%s\")",
+                fmt("throw ::hilti::rt::UnhandledSwitchCase(::hilti::rt::to_string_for_print(%s), \"%s\")",
                     (first ? cxx_init : cxx_id), n->meta().location()));
 
         if ( first )

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -396,7 +396,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
             return cg->compile(b->itemType(), codegen::TypeUsage::Storage);
         });
 
-        auto t = fmt("hilti::rt::Bitfield<%s>", util::join(x, ", "));
+        auto t = fmt("::hilti::rt::Bitfield<%s>", util::join(x, ", "));
         result = CxxTypes{.base_type = t};
     }
 
@@ -431,7 +431,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
         });
 
         auto default_ = cxx::Block();
-        default_.addReturn(fmt(R"(hilti::rt::fmt("%s::<unknown-%%" PRIu64 ">", x.value()))", id.local()));
+        default_.addReturn(fmt(R"(::hilti::rt::fmt("%s::<unknown-%%" PRIu64 ">", x.value()))", id.local()));
 
         auto body = cxx::Block();
         body.addSwitch("x.value()", cases, std::move(default_));
@@ -524,7 +524,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
 
         std::string allocator;
         if ( auto def = cg->typeDefaultValue(n->dereferencedType()) )
-            allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+            allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", x, *def);
 
         auto t = fmt("::hilti::rt::Vector<%s%s>::%s", x, allocator, i);
         result = CxxTypes{.base_type = fmt("%s", t)};
@@ -653,7 +653,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
 
             std::string allocator;
             if ( auto def = cg->typeDefaultValue(n->elementType()) )
-                allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+                allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", x, *def);
 
             t = fmt("::hilti::rt::Vector<%s%s>", x, allocator);
         }
@@ -857,7 +857,7 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder {
         auto i = 0;
         for ( const auto&& b : n->bits() )
             elems.push_back(fmt(
-                "::hilti::rt::type_info::bitfield::Bits{ \"%s\", %s, hilti::rt::bitfield::elementOffset<%s, %d>() }",
+                "::hilti::rt::type_info::bitfield::Bits{ \"%s\", %s, ::hilti::rt::bitfield::elementOffset<%s, %d>() }",
                 b->id(), cg->typeInfo(b->itemType()), ttype, i++));
 
         result = fmt("::hilti::rt::type_info::Bitfield(std::vector<::hilti::rt::type_info::bitfield::Bits>({%s}))",
@@ -956,7 +956,7 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder {
         int i = 0;
         for ( const auto& e : n->elements() ) {
             elems.push_back(
-                fmt("::hilti::rt::type_info::tuple::Element{ \"%s\", %s, hilti::rt::tuple::elementOffset<%s, %d>() }",
+                fmt("::hilti::rt::type_info::tuple::Element{ \"%s\", %s, ::hilti::rt::tuple::elementOffset<%s, %d>() }",
                     e->id() ? e->id() : ID(), cg->typeInfo(e->type()), ttype, i));
             ++i;
         }
@@ -1000,7 +1000,7 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder {
 
         std::string allocator;
         if ( auto def = cg->typeDefaultValue(n->elementType()) )
-            allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+            allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", x, *def);
 
         result = fmt("::hilti::rt::type_info::Vector(%s, ::hilti::rt::type_info::Vector::accessor<%s%s>())",
                      cg->typeInfo(n->elementType()), x, allocator);
@@ -1011,7 +1011,7 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder {
 
         std::string allocator;
         if ( auto def = cg->typeDefaultValue(n->dereferencedType()) )
-            allocator = fmt(", hilti::rt::vector::Allocator<%s, %s>", x, *def);
+            allocator = fmt(", ::hilti::rt::vector::Allocator<%s, %s>", x, *def);
 
         result =
             fmt("::hilti::rt::type_info::VectorIterator(%s, ::hilti::rt::type_info::VectorIterator::accessor<%s%s>())",

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -701,7 +701,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
             sid, [&]() { return CxxTypes{.base_type = std::string(sid)}; },
             [&](auto& cxx_types) {
                 auto render_body = cxx::Block();
-                render_body.addStatement("o << ::hilti::rt::to_string(x); return o");
+                render_body.addStatement("return o << ::hilti::rt::to_string(x);");
 
                 auto render = cxx::declaration::Function(cxx::declaration::Function::Free, "std::ostream&",
                                                          cxx::ID{fmt("%s::operator<<", ns)},

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -44,7 +44,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
     }
 
     void operator()(type::Struct* n) final {
-        auto scope = cxx::ID{cg->unit()->cxxNamespace()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace()};
         auto sid = cxx::ID{n->typeID()};
 
         if ( sid.namespace_() )
@@ -273,7 +273,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
     void operator()(type::Union* n) final {
         assert(n->typeID());
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace()};
         auto sid = cxx::ID{n->typeID()};
 
         if ( sid.namespace_() )
@@ -300,7 +300,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
     void operator()(type::Enum* n) final {
         assert(n->typeID());
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace()};
         auto sid = cxx::ID{n->typeID()};
 
         if ( sid.namespace_() )
@@ -317,7 +317,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
     void operator()(type::Exception* n) final {
         assert(n->typeID());
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace()};
         auto sid = cxx::ID{n->typeID()};
 
         if ( sid.namespace_() )
@@ -388,7 +388,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
         auto tid = n->typeID();
         assert(tid);
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace()};
         auto sid = cxx::ID{tid};
 
         if ( sid.namespace_() )
@@ -576,7 +576,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
             return;
         }
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace().namespace_()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace().namespace_()};
         auto sid = cxx::ID{scope, n->typeID()};
         auto ns = sid.namespace_();
 
@@ -693,7 +693,7 @@ struct VisitorStorage : hilti::visitor::PreOrder {
             return;
         }
 
-        auto scope = cxx::ID{cg->unit()->cxxNamespace().namespace_()};
+        auto scope = cxx::ID{cg->unit()->cxxInternalNamespace().namespace_()};
         auto sid = cxx::ID{scope, type_id};
         auto ns = sid.namespace_();
 

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -264,7 +264,7 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
 
                 // Only emit full inline code if we are generating the unit declaring this type.
                 if ( n->typeID().namespace_() == cg->unit()->module()->id() )
-                    return cxx::declaration::Type{id, t, t.inlineCode()};
+                    return cxx::declaration::Type{id, t, t.code()};
                 else
                     return cxx::declaration::Type{id, t, {}};
             });

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -261,7 +261,12 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
                                            .type_name = cxx::ID(id.local()),
                                            .ctor = std::move(ctor),
                                            .add_ctors = true};
-                return cxx::declaration::Type(id, t, t.inlineCode());
+
+                // Only emit full inline code if we are generating the unit declaring this type.
+                if ( n->typeID().namespace_() == cg->unit()->module()->id() )
+                    return cxx::declaration::Type{id, t, t.inlineCode()};
+                else
+                    return cxx::declaration::Type{id, t, {}};
             });
     }
 

--- a/hilti/toolchain/src/compiler/codegen/unpack.cc
+++ b/hilti/toolchain/src/compiler/codegen/unpack.cc
@@ -54,19 +54,20 @@ struct Visitor : hilti::visitor::PreOrder {
     void operator()(type::Bitfield* n) final {
         assert(kind == Kind::Unpack); // packing not supported (yet?)
 
-        auto bitorder = cxx::Expression("hilti::rt::integer::BitOrder::LSB0");
+        auto bitorder = cxx::Expression("::hilti::rt::integer::BitOrder::LSB0");
         if ( args.size() > 1 )
             bitorder = args[1];
 
         auto unpacked =
-            cg->addTmp("x", cxx::Type(util::fmt("hilti::rt::Result<std::tuple<hilti::rt::integer::safe<uint%d_t>, %s>>",
-                                                n->width(), cg->compile(data_type, codegen::TypeUsage::Storage))));
+            cg->addTmp("x",
+                       cxx::Type(util::fmt("::hilti::rt::Result<std::tuple<::hilti::rt::integer::safe<uint%d_t>, %s>>",
+                                           n->width(), cg->compile(data_type, codegen::TypeUsage::Storage))));
         auto unpack_uint =
             fmt("%s = ::hilti::rt::integer::unpack<uint%d_t>(%s, %s)", unpacked, n->width(), data, args[0]);
 
         auto bf_value = cg->unsignedIntegerToBitfield(n, fmt("std::get<0>(*%s)", unpacked), bitorder);
-        result =
-            fmt("(%s, hilti::rt::make_result(std::make_tuple(%s, std::get<1>(*%s))))", unpack_uint, bf_value, unpacked);
+        result = fmt("(%s, ::hilti::rt::make_result(std::make_tuple(%s, std::get<1>(*%s))))", unpack_uint, bf_value,
+                     unpacked);
     }
 
     void operator()(type::UnsignedInteger* n) final {

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -469,7 +469,7 @@ std::string cxx::type::Struct::str() const {
                has_params, type_name, struct_fields_as_str);
 }
 
-std::string cxx::type::Struct::inlineCode() const {
+std::string cxx::type::Struct::code() const {
     if ( ! add_ctors )
         return "";
 
@@ -516,7 +516,7 @@ std::string cxx::type::Struct::inlineCode() const {
                           "");
     };
 
-    std::string inline_code;
+    std::string code;
 
     // Create default constructor. This initializes user-controlled members
     // only if there are no struct parameters. If there are, we wouldn't have
@@ -525,10 +525,10 @@ std::string cxx::type::Struct::inlineCode() const {
     // parameter-based constructors normally anyways, so don't need this
     // here.
     if ( args.size() )
-        inline_code += fmt("%s::%s() {\n%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_non_user());
+        code += fmt("%s::%s() {\n%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_non_user());
     else
-        inline_code += fmt("%s::%s() {\n%s%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_user(),
-                           init_locals_non_user());
+        code += fmt("%s::%s() {\n%s%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_user(),
+                    init_locals_non_user());
 
     if ( args.size() ) {
         // Create constructor taking the struct's parameters.
@@ -539,8 +539,8 @@ std::string cxx::type::Struct::inlineCode() const {
             util::join(util::transform(args, [&](const auto& x) { return fmt("%s(std::move(%s))", x.id, x.id); }),
                        ", ");
 
-        inline_code += fmt("%s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits,
-                           init_locals_user(), init_locals_non_user());
+        code += fmt("%s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits, init_locals_user(),
+                    init_locals_non_user());
     }
 
     if ( locals_user.size() ) {
@@ -560,10 +560,10 @@ std::string cxx::type::Struct::inlineCode() const {
                                        }),
                        "");
 
-        inline_code += fmt("%s::%s(%s) : %s() {\n%s}\n\n", type_name, type_name, ctor_args, type_name, ctor_inits);
+        code += fmt("%s::%s(%s) : %s() {\n%s}\n\n", type_name, type_name, ctor_args, type_name, ctor_inits);
     }
 
-    return inline_code;
+    return code;
 }
 
 std::string cxx::type::Union::str() const {

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -422,7 +422,7 @@ std::string cxx::type::Struct::str() const {
     util::append(struct_fields, util::transform(args, fmt_argument));
 
     if ( add_ctors ) {
-        auto dctor = fmt("inline %s();", type_name);
+        auto dctor = fmt("%s();", type_name);
         auto cctor = fmt("%s(const %s&) = default;", type_name, type_name);
         auto mctor = fmt("%s(%s&&) = default;", type_name, type_name);
         auto cassign = fmt("%s& operator=(const %s&) = default;", type_name, type_name);
@@ -443,7 +443,7 @@ std::string cxx::type::Struct::str() const {
                                                                    return fmt("std::optional<%s> %s", l.type, l.id);
                                                                }),
                                                ", ");
-            auto locals_ctor = fmt("inline %s(%s);", type_name, locals_ctor_args);
+            auto locals_ctor = fmt("%s(%s);", type_name, locals_ctor_args);
             struct_fields.emplace_back(std::move(locals_ctor));
         }
 
@@ -451,7 +451,7 @@ std::string cxx::type::Struct::str() const {
             // Add dedicated constructor to initialize the struct's arguments.
             auto params_ctor_args =
                 util::join(util::transform(args, [&](const auto& x) { return fmt("%s %s", x.type, x.id); }), ", ");
-            auto params_ctor = fmt("inline %s(%s);", type_name, params_ctor_args);
+            auto params_ctor = fmt("%s(%s);", type_name, params_ctor_args);
             struct_fields.emplace_back(params_ctor);
         }
     }
@@ -525,11 +525,10 @@ std::string cxx::type::Struct::inlineCode() const {
     // parameter-based constructors normally anyways, so don't need this
     // here.
     if ( args.size() )
-        inline_code +=
-            fmt("inline %s::%s() {\n%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_non_user());
+        inline_code += fmt("%s::%s() {\n%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_non_user());
     else
-        inline_code += fmt("inline %s::%s() {\n%s%s%s}\n\n", type_name, type_name, init_parameters(),
-                           init_locals_user(), init_locals_non_user());
+        inline_code += fmt("%s::%s() {\n%s%s%s}\n\n", type_name, type_name, init_parameters(), init_locals_user(),
+                           init_locals_non_user());
 
     if ( args.size() ) {
         // Create constructor taking the struct's parameters.
@@ -540,7 +539,7 @@ std::string cxx::type::Struct::inlineCode() const {
             util::join(util::transform(args, [&](const auto& x) { return fmt("%s(std::move(%s))", x.id, x.id); }),
                        ", ");
 
-        inline_code += fmt("inline %s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits,
+        inline_code += fmt("%s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits,
                            init_locals_user(), init_locals_non_user());
     }
 
@@ -561,8 +560,7 @@ std::string cxx::type::Struct::inlineCode() const {
                                        }),
                        "");
 
-        inline_code +=
-            fmt("inline %s::%s(%s) : %s() {\n%s}\n\n", type_name, type_name, ctor_args, type_name, ctor_inits);
+        inline_code += fmt("%s::%s(%s) : %s() {\n%s}\n\n", type_name, type_name, ctor_args, type_name, ctor_inits);
     }
 
     return inline_code;

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -342,9 +342,6 @@ size_t cxx::Block::size(bool ignore_comments) const {
 std::string cxx::declaration::Function::prototype(bool qualify) const {
     std::string qualifier;
 
-    if ( const_ )
-        qualifier = " const";
-
     if ( result == "void" || result == "auto" )
         return fmt("%s %s(%s)%s", result, (qualify ? id : id.local()), util::join(args, ", "), qualifier);
 
@@ -710,112 +707,93 @@ cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::Type& x) {
     return f << util::replace(x, fmt("%s::", f.namespace_(0)), "");
 }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::Type& x) {
-    auto id = x.id.local();
+void cxx::declaration::Type::emit(cxx::Formatter& f) const {
+    auto id_ = id.local();
 
-    if ( x.id.namespace_() )
-        id = cxx::ID(x.id.namespace_(), id);
+    if ( id_.namespace_() )
+        id_ = cxx::ID(id.namespace_(), id);
 
     f.enterNamespace(id.namespace_());
 
-    if ( ! x.no_using && id.local() && ! util::startsWith(x.type, "struct") )
-        f << fmt("using %s = ", id.local()) << x.type << eos();
+    if ( ! no_using && id.local() && ! util::startsWith(type, "struct") )
+        f << fmt("using %s = ", id.local()) << type << eos();
     else
-        f << x.type << eos();
+        f << type << eos();
 
-    if ( x.type.isMultiLine() )
+    if ( type.isMultiLine() )
         f << eol();
-
-    return f;
 }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::IncludeFile& x) {
-    return f << fmt("#include <%s>", x.file) << eol();
-}
+void cxx::declaration::IncludeFile::emit(cxx::Formatter& f) const { f << fmt("#include <%s>", file) << eol(); }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::Local& x) {
-    f << x.type << ' ' << x.id.local();
+void cxx::declaration::Local::emit(cxx::Formatter& f) const {
+    f << type << ' ' << id.local();
 
-    if ( x.init )
-        f << " = " << *x.init;
+    if ( init )
+        f << " = " << *init;
 
     f << eos();
-
-    return f;
 }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::Global& x) {
-    f.enterNamespace(x.id.namespace_());
+void cxx::declaration::Global::emit(cxx::Formatter& f) const {
+    f.enterNamespace(id.namespace_());
 
-    if ( x.linkage )
-        f << x.linkage << ' ';
+    if ( linkage )
+        f << linkage << ' ';
 
-    f << x.type << ' ' << x.id.local();
+    f << type << ' ' << id.local();
 
-    if ( x.init )
-        f << " = " << *x.init;
+    if ( init )
+        f << " = " << *init;
 
     f << eos();
-
-    return f;
 }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::Function& x) {
-    f.enterNamespace(x.id.namespace_());
+void cxx::declaration::Argument::emit(cxx::Formatter& f) const { f << std::string(*this); }
 
-    if ( x.attribute )
-        f << x.attribute << ' ';
+void cxx::declaration::Function::emit(cxx::Formatter& f) const {
+    const auto needs_separator = (inline_body && inline_body->size() > 1);
 
-    if ( x.linkage )
-        f << x.linkage << ' ';
+    if ( needs_separator )
+        f << separator();
 
-    if ( x.inline_body )
+    if ( ! body )
+        f.enterNamespace(id.namespace_());
+
+    if ( linkage )
+        f << linkage << ' ';
+
+    if ( inline_body )
         f << "inline ";
 
-    f << x.prototype(false);
+    f << prototype(body.has_value());
 
-    if ( x.inline_body ) {
+    if ( inline_body ) {
         f.ensure_braces_for_block = true;
-        f << ' ' << *x.inline_body;
+        f << ' ' << *inline_body;
+    }
+    else if ( body ) {
+        f.ensure_braces_for_block = true;
+        f.compact_block = (body->size() <= 1);
+        f << ' ' << *body;
     }
     else
         f << eos();
 
-    return f;
+    if ( needs_separator )
+        f << separator();
 }
 
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::Function& x) {
-    if ( x.declaration.attribute )
-        f << x.declaration.attribute << ' ';
+void cxx::declaration::Constant::emit(cxx::Formatter& f) const {
+    f.enterNamespace(id.namespace_());
 
-    if ( x.declaration.linkage )
-        f << x.declaration.linkage << ' ';
+    if ( linkage )
+        f << linkage << ' ';
 
-    f << x.declaration.prototype(true);
+    f << "const " << type << ' ' << id.local();
 
-    if ( x.default_ )
-        f << " = default;" << eol();
-    else {
-        f.ensure_braces_for_block = true;
-        f.compact_block = (x.body.size() <= 1);
-        f << ' ' << x.body;
-    }
-
-    return f;
-}
-
-cxx::Formatter& cxx::operator<<(cxx::Formatter& f, const cxx::declaration::Constant& x) {
-    f.enterNamespace(x.id.namespace_());
-
-    if ( x.linkage )
-        f << x.linkage << ' ';
-
-    f << "const " << x.type << ' ' << x.id.local();
-
-    if ( x.init )
-        f << " = " << *x.init;
+    if ( init )
+        f << " = " << *init;
 
     f << eos();
-
-    return f;
 }

--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -121,7 +121,7 @@ void cxx::Linker::finalize() {
         unit->add(g);
     }
 
-    unit->finalize();
+    unit->finalize(true);
     _linker_unit = std::move(unit);
 }
 

--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -49,7 +49,7 @@ void cxx::Linker::finalize() {
 
     for ( const auto& p : plugin::registry().plugins() )
         for ( const auto& i : p.cxx_includes )
-            unit->add(cxx::declaration::IncludeFile{i});
+            unit->add(cxx::declaration::IncludeFile(i));
 
     // Note we don't qualify the two subsequent globals with
     // `cxx_namespace_intern` because we need these exact names; that's what

--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -80,40 +80,38 @@ void cxx::Linker::finalize() {
     }
 
     for ( const auto& j : _joins ) {
-        auto impl = cxx::Function();
-        auto body = cxx::Block();
+        std::optional<cxx::declaration::Function> impl;
 
         auto sorted_joins = j.second;
         std::sort(sorted_joins.begin(), sorted_joins.end(),
                   [](const auto& x, const auto& y) { return x.priority > y.priority; });
 
-        bool first = true;
         for ( const auto& c : sorted_joins ) {
-            if ( first ) {
-                impl.declaration = c.callee;
-                impl.declaration.id = c.id;
-                first = false;
+            if ( ! impl ) {
+                impl = c.callee;
+                impl->id = c.id;
+                impl->body = cxx::Block();
+                impl->ftype = cxx::declaration::Function::Free;
             }
 
             if ( c.declare_only )
                 continue;
 
-            auto args = util::transform(impl.declaration.args, [](auto& a) { return a.id; });
+            auto args = util::transform(impl->args, [](auto& a) { return a.id; });
 
             if ( std::string(c.callee.result) != "void" ) {
                 cxx::Block done_body;
                 done_body.addStatement("return x;");
-                impl.body.addIf(fmt("auto x = %s(%s)", c.callee.id, util::join(args, ", ")), std::move(done_body));
+                impl->body->addIf(fmt("auto x = %s(%s)", c.callee.id, util::join(args, ", ")), std::move(done_body));
             }
             else
-                impl.body.addStatement(fmt("%s(%s)", c.callee.id, util::join(args, ", ")));
+                impl->body->addStatement(fmt("%s(%s)", c.callee.id, util::join(args, ", ")));
         }
 
-        if ( std::string(impl.declaration.result) != "void" )
-            impl.body.addStatement("return {}");
+        if ( std::string(impl->result) != "void" )
+            impl->body->addStatement("return {}");
 
-        unit->add(impl.declaration);
-        unit->add(impl);
+        unit->add(*impl);
     }
 
     unsigned int cnt = 0;

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -152,8 +152,8 @@ void Unit::_emitDeclarations(const cxxDeclaration& decl, Formatter& f, Phase pha
                 f << d;
 
             else if ( phase == Phase::Functions ) {
-                if ( d.inline_code.size() && ! prototypes_only ) {
-                    f << d.inline_code << eol();
+                if ( d.code.size() && ! prototypes_only ) {
+                    f << d.code << eol();
                 }
             }
         }

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -144,14 +144,14 @@ void Unit::_addHeader(Formatter& f) {
 
     f << separator() << comment(fmt("Begin %s", c))
       << comment(fmt("Compiled by HILTI version %s", hilti::configuration().version_string)) << separator()
-      << declaration::IncludeFile{.file = "hilti/rt/compiler-setup.h"} << separator();
+      << declaration::IncludeFile("hilti/rt/compiler-setup.h") << separator();
 }
 
 void Unit::_addModuleInitFunction() {
     auto addInitFunction = [&](Context* ctx, auto f, const std::string& id_) {
         auto id = cxx::ID{cxxNamespace(), id_};
 
-        auto body_decl = cxx::declaration::Function{.result = "void", .id = id, .args = {}, .linkage = "extern"};
+        auto body_decl = cxx::declaration::Function("void", id, {}, {}, "extern");
 
         cxx::Block body;
         body.appendFromBlock(std::move(f));
@@ -174,7 +174,7 @@ void Unit::_addModuleInitFunction() {
 
     if ( moduleID() != cxx::ID("__linker__") ) {
         auto scope = fmt("%s_hlto_scope", context()->options().cxx_namespace_intern);
-        auto extern_scope = cxx::declaration::Global{.id = cxx::ID(scope), .type = "const char*", .linkage = "extern"};
+        auto extern_scope = cxx::declaration::Global(cxx::ID(scope), "const char*", {}, {}, "extern");
         add(extern_scope);
 
         cxx::Block register_;

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -128,7 +128,7 @@ inline const DebugStream Driver("driver");
 CxxCode::CxxCode(const detail::cxx::Unit& u) {
     std::stringstream buffer;
     u.print(buffer);
-    load(u.moduleID(), buffer);
+    load(u.cxxModuleID(), buffer);
 }
 
 bool CxxCode::load(const hilti::rt::filesystem::path& path) {

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -103,10 +103,6 @@ Result<Nothing> Unit::codegen() {
     return Nothing();
 }
 
-std::set<declaration::module::UID> Unit::dependencies(bool recursive) const {
-    return context()->astContext()->dependencies(_uid, recursive);
-}
-
 Result<CxxCode> Unit::cxxCode() const {
     if ( ! _cxx_unit )
         return result::Error("no C++ code available for unit");

--- a/hilti/toolchain/src/compiler/unit.cc
+++ b/hilti/toolchain/src/compiler/unit.cc
@@ -1,6 +1,5 @@
 // Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
-#include <fstream>
 #include <utility>
 
 #include <hilti/ast/ast-context.h>
@@ -96,22 +95,6 @@ Result<Nothing> Unit::codegen() {
     if ( ! cxx )
         return cxx.error();
 
-    // Import declarations from our dependencies. They will have been compiled
-    // at this point.
-    //
-    // TODO(robin): Would be nice if we had a "cheap" compilation mode that
-    // only generated declarations.
-    for ( const auto& d : dependencies(true) ) {
-        HILTI_DEBUG(logging::debug::Compiler,
-                    fmt("importing declarations from module %s (%s)", d, d.process_extension));
-        logging::DebugPushIndent _(logging::debug::Compiler);
-
-        if ( auto other_cxx = _codegenModule(d) )
-            (*cxx)->importDeclarations(**other_cxx);
-        else
-            return other_cxx.error();
-    }
-
     HILTI_DEBUG(logging::debug::Compiler, fmt("finalizing module %s", _uid));
     if ( auto x = (*cxx)->finalize(); ! x )
         return x.error();
@@ -134,7 +117,7 @@ Result<CxxCode> Unit::cxxCode() const {
     if ( logger().errors() )
         return result::Error("errors during prototype creation");
 
-    return CxxCode{_cxx_unit->moduleID(), cxx};
+    return CxxCode{_cxx_unit->cxxModuleID(), cxx};
 }
 
 bool Unit::requiresCompilation() {

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -2083,6 +2083,7 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, type::Unit* t, bool
     auto sf_ext_overload1 =
         builder()->declarationField(f_ext_overload1->id().local(), hilti::function::CallingConvention::Extern,
                                     f_ext_overload1->function()->ftype(), f_ext_overload1->function()->attributes());
+
     auto sf_ext_overload2 =
         builder()->declarationField(f_ext_overload2->id().local(), hilti::function::CallingConvention::Extern,
                                     f_ext_overload2->function()->ftype(), f_ext_overload2->function()->attributes());

--- a/tests/Baseline/hilti.ast.basic-module/debug.log
+++ b/tests/Baseline/hilti.ast.basic-module/debug.log
@@ -997,6 +997,7 @@
 [debug/compiler] [HILTI] validating (post)
 [debug/compiler] performing global transformations
 [debug/compiler] [HILTI] validating (post)
+[debug/compiler] computing AST dependencies
 [debug/compiler] codegen module Foo to C++
 [debug/compiler]   generating C++ for module Foo
 [debug/compiler]   finalizing module Foo

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -1377,8 +1377,6 @@
 [debug/driver] codegen for input unit Foo
 [debug/compiler] codegen module Foo to C++
 [debug/compiler]   generating C++ for module Foo
-[debug/compiler]   importing declarations from module Bar (".hlt")
-[debug/compiler]     generating C++ for module Bar
 [debug/compiler]   finalizing module Foo
 [debug/driver] saving C++ code for module Foo to /dev/stdout
 // Begin of Foo (from "foo.hlt")

--- a/tests/Baseline/hilti.ast.imported-id/output
+++ b/tests/Baseline/hilti.ast.imported-id/output
@@ -1373,6 +1373,7 @@
 [debug/compiler] [HILTI] validating (post)
 [debug/compiler] performing global transformations
 [debug/compiler] [HILTI] validating (post)
+[debug/compiler] computing AST dependencies
 [debug/driver] codegen for input unit Foo
 [debug/compiler] codegen module Foo to C++
 [debug/compiler]   generating C++ for module Foo

--- a/tests/Baseline/hilti.ast.types/output
+++ b/tests/Baseline/hilti.ast.types/output
@@ -992,6 +992,7 @@
 [debug/compiler] [HILTI] validating (post)
 [debug/compiler] performing global transformations
 [debug/compiler] [HILTI] validating (post)
+[debug/compiler] computing AST dependencies
 module Foo {
 
 global bytes x1 = b"abc";

--- a/tests/Baseline/hilti.hiltic.print.globals/output
+++ b/tests/Baseline/hilti.hiltic.print.globals/output
@@ -6,19 +6,23 @@
 
 #include <hilti/rt/libhilti.h>
 
-extern const char* __hlt_hlto_scope;
-
 namespace __hlt::Foo {
+    struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string X{};
         template<typename F> void __visit(F _) const { _("X", X); }
     };
 
+}
+
+extern const char* __hlt_hlto_scope;
+
+namespace __hlt::Foo {
+    inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
-    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.globals/output2
+++ b/tests/Baseline/hilti.hiltic.print.globals/output2
@@ -9,11 +9,11 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
+    static std::optional<std::string> X = {};
     extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
-    static std::optional<std::string> X = {};
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.import/output
+++ b/tests/Baseline/hilti.hiltic.print.import/output
@@ -6,33 +6,23 @@
 
 #include <hilti/rt/libhilti.h>
 
-extern const char* __hlt_hlto_scope;
-
 namespace __hlt::Bar {
+    struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string bar{};
         template<typename F> void __visit(F _) const { _("bar", bar); }
     };
 
+}
+
+extern const char* __hlt_hlto_scope;
+
+namespace __hlt::Bar {
+    inline unsigned int __globals_index;
     static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
-    inline unsigned int __globals_index;
-}
-
-namespace __hlt::Foo {
-    struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
-        std::string foo{};
-        template<typename F> void __visit(F _) const { _("foo", foo); }
-    };
-
-    static inline auto __globals() {
-        return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index);
-    }
-
-    extern void __init_globals(::hilti::rt::Context* ctx);
-    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Bar::__register_module)
@@ -59,35 +49,23 @@ extern void __hlt::Bar::__register_module() { ::hilti::rt::detail::registerModul
 
 #include <hilti/rt/libhilti.h>
 
-extern const char* __hlt_hlto_scope;
-
-namespace __hlt::Bar {
-    struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
-        std::string bar{};
-        template<typename F> void __visit(F _) const { _("bar", bar); }
-    };
-
-    static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
-    extern void __init_globals(::hilti::rt::Context* ctx);
-    extern void __init_module();
-    extern void __register_module();
-    inline unsigned int __globals_index;
-}
-
 namespace __hlt::Foo {
+    struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string foo{};
         template<typename F> void __visit(F _) const { _("foo", foo); }
     };
 
-    static inline auto __globals() {
-        return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index);
-    }
+}
 
+extern const char* __hlt_hlto_scope;
+
+namespace __hlt::Foo {
+    inline unsigned int __globals_index;
+    static inline auto __globals() { return ::hilti::rt::detail::moduleGlobals<__globals_t>(__globals_index); }
     extern void __init_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
-    inline unsigned int __globals_index;
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.import/output2
+++ b/tests/Baseline/hilti.hiltic.print.import/output2
@@ -9,17 +9,18 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Bar {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
-    extern void __init_globals(::hilti::rt::Context* ctx);
-    extern void __init_module();
-    extern void __register_module();
     std::optional<std::string> bar = {};
 }
 
 namespace __hlt::Foo {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
-    extern void __init_globals(::hilti::rt::Context* ctx);
     extern std::optional<std::string> foo;
+}
+
+namespace __hlt::Bar {
+    extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __destroy_globals(::hilti::rt::Context* ctx);
+    extern void __init_module();
+    extern void __register_module();
 }
 
 HILTI_PRE_INIT(__hlt::Bar::__register_module)
@@ -48,19 +49,15 @@ extern void __hlt::Bar::__register_module() { ::hilti::rt::detail::registerModul
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Bar {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
-    extern void __init_globals(::hilti::rt::Context* ctx);
-    extern void __init_module();
-    extern void __register_module();
     extern std::optional<std::string> bar;
 }
 
 namespace __hlt::Foo {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
+    std::optional<std::string> foo = {};
     extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __destroy_globals(::hilti::rt::Context* ctx);
     extern void __init_module();
     extern void __register_module();
-    std::optional<std::string> foo = {};
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.hiltic.print.yield/output
+++ b/tests/Baseline/hilti.hiltic.print.yield/output
@@ -46,11 +46,11 @@ extern auto __hlt::Foo::test(const std::string& x) -> std::string {
 extern auto hlt::Foo::test(const std::string& x) -> ::hilti::rt::Resumable {
     auto args = std::make_tuple(::hilti::rt::resumable::detail::copyArg(x));
     auto args_on_heap = std::make_shared<decltype(args)>(std::move(args));
-    auto cb = [args_on_heap](hilti::rt::resumable::Handle* r) -> hilti::rt::any {
+    auto cb = [args_on_heap](::hilti::rt::resumable::Handle* r) -> ::hilti::rt::any {
         return __hlt::Foo::test(std::get<0>(*args_on_heap));
     };
 
-    auto r = std::make_unique<hilti::rt::Resumable>(std::move(cb));
+    auto r = std::make_unique<::hilti::rt::Resumable>(std::move(cb));
     r->run();
     return std::move(*r);
 }

--- a/tests/Baseline/hilti.hiltic.print.yield/output
+++ b/tests/Baseline/hilti.hiltic.print.yield/output
@@ -9,8 +9,8 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    extern void __register_module();
     extern auto test(const std::string& x) -> std::string;
+    extern void __register_module();
 }
 
 namespace hlt::Foo {

--- a/tests/Baseline/hilti.hiltic.print.yield/prototypes
+++ b/tests/Baseline/hilti.hiltic.print.yield/prototypes
@@ -8,8 +8,8 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    extern void __register_module();
     extern auto test(const std::string& x) -> std::string;
+    extern void __register_module();
 }
 
 namespace hlt::Foo {

--- a/tests/Baseline/hilti.types.real.nops/output
+++ b/tests/Baseline/hilti.types.real.nops/output
@@ -17,12 +17,12 @@ assert 0x1.999999999999ap-4 == 0x1.999999999999ap-4;
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
-    extern void __destroy_globals(::hilti::rt::Context* ctx);
-    extern void __init_globals(::hilti::rt::Context* ctx);
-    extern void __init_module();
-    extern void __register_module();
     static std::optional<double> d = {};
     static std::optional<double> r = {};
+    extern void __init_globals(::hilti::rt::Context* ctx);
+    extern void __destroy_globals(::hilti::rt::Context* ctx);
+    extern void __init_module();
+    extern void __register_module();
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/hilti.types.struct.canonical-ids/output
+++ b/tests/Baseline/hilti.types.struct.canonical-ids/output
@@ -105,3 +105,18 @@
 [debug/ast-declarations]             - Parameter "excpt" (hilti::excpt_3)
 [debug/ast-declarations]     - Function "exception_where" (hilti::exception_where_2)
 [debug/ast-declarations]             - Parameter "excpt" (hilti::excpt_4)
+[debug/ast-declarations] Declaration dependencies:
+[debug/ast-declarations] - [function] hilti::exception_what -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_what_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::exception_where -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_where_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::profiler_start -> hilti::Profiler
+[debug/ast-declarations] - [function] hilti::profiler_stop -> hilti::Profiler
+[debug/ast-declarations] - [global variable] Foo::s1 -> Foo::S
+[debug/ast-declarations] - [module] Foo -> Foo::S, Foo::S::test, Foo::s1
+[debug/ast-declarations] - [module] hilti -> hilti::AddressFamily, hilti::BitOrder, hilti::ByteOrder, hilti::Captures, hilti::Charset, hilti::DecodeErrorStrategy, hilti::Exception, hilti::MatchState, hilti::MissingData, hilti::Profiler, hilti::Protocol, hilti::RealType, hilti::RecoverableFailure, hilti::RuntimeError, hilti::Side, hilti::StreamStatistics, hilti::SystemException, hilti::abort, hilti::current_time, hilti::debug, hilti::debugDedent, hilti::debugIndent, hilti::exception_what, hilti::exception_what_2, hilti::exception_where, hilti::exception_where_2, hilti::mktime, hilti::print, hilti::printValues, hilti::profiler_start, hilti::profiler_stop
+[debug/ast-declarations] - [type] hilti::MatchState -> hilti::Captures
+[debug/ast-declarations] - [type] hilti::MissingData -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RecoverableFailure -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RuntimeError -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::SystemException -> hilti::Exception

--- a/tests/Baseline/hilti.types.tuple.coercion/output
+++ b/tests/Baseline/hilti.types.tuple.coercion/output
@@ -9,9 +9,9 @@
 extern const char* __hlt_hlto_scope;
 
 namespace __hlt::Foo {
+    static auto f() -> std::tuple<::hilti::rt::integer::safe<uint64_t>, std::string>;
     extern void __init_module();
     extern void __register_module();
-    static auto f() -> std::tuple<::hilti::rt::integer::safe<uint64_t>, std::string>;
 }
 
 HILTI_PRE_INIT(__hlt::Foo::__register_module)

--- a/tests/Baseline/spicy.tools.spicyc-hello-world/test.hlt
+++ b/tests/Baseline/spicy.tools.spicyc-hello-world/test.hlt
@@ -4,8 +4,8 @@
 
 #include <hilti/rt/compiler-setup.h>
 
-#include <hilti/rt/libhilti.h>
 #include <spicy/rt/libspicy.h>
+#include <hilti/rt/libhilti.h>
 
 extern const char* __hlt_hlto_scope;
 

--- a/tests/Baseline/spicy.types.unit.canonical-ids-with-import/output
+++ b/tests/Baseline/spicy.types.unit.canonical-ids-with-import/output
@@ -865,3 +865,47 @@
 [debug/ast-declarations]             - Parameter "reason" (spicy::reason)
 [debug/ast-declarations]     - ImportedModule "hilti" (spicy::hilti)
 [debug/ast-declarations]     - ImportedModule "spicy_rt" (spicy::spicy_rt)
+[debug/ast-declarations] Declaration dependencies:
+[debug/ast-declarations] - [function] a::__register_a_X -> a::X, hilti::Exception, hilti::RecoverableFailure, spicy_rt::MIMEType, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext, spicy_rt::registerParser
+[debug/ast-declarations] - [function] a::a::X::__parse_a__X_stage2 -> hilti::ByteOrder, hilti::Exception, hilti::RecoverableFailure, hilti::debugDedent, spicy_rt::Filters, spicy_rt::waitForInput_2
+[debug/ast-declarations] - [function] a::a::X::__parse_stage1 -> hilti::Exception, hilti::RecoverableFailure, hilti::SystemException, hilti::debugIndent
+[debug/ast-declarations] - [function] a::a::X::parse1 -> a::X, hilti::Exception, hilti::RecoverableFailure, hilti::exception_what_2, hilti::exception_where_2, spicy_rt::MIMEType, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] a::a::X::parse2 -> a::X, hilti::Exception, hilti::RecoverableFailure, hilti::exception_what_2, hilti::exception_where_2, spicy_rt::MIMEType, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] a::a::X::parse3 -> a::X, hilti::Exception, hilti::RecoverableFailure, hilti::exception_what_2, hilti::exception_where_2, spicy_rt::MIMEType, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext, spicy_rt::initializeParsedUnit
+[debug/ast-declarations] - [function] b::a::X::__on_x -> hilti::printValues
+[debug/ast-declarations] - [function] hilti::exception_what -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_what_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::exception_where -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_where_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::profiler_start -> hilti::Profiler
+[debug/ast-declarations] - [function] hilti::profiler_stop -> hilti::Profiler
+[debug/ast-declarations] - [function] spicy::base64_decode -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::base64_encode -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::base64_finish -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::zlib_decompress -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy::zlib_finish -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy::zlib_init -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy_rt::atEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::createContext -> spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] spicy_rt::initializeParsedUnit -> spicy_rt::ParsedUnit, spicy_rt::TypeInfo
+[debug/ast-declarations] - [function] spicy_rt::printParserState -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] spicy_rt::registerParser -> spicy_rt::MIMEType, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo
+[debug/ast-declarations] - [function] spicy_rt::setContext -> spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] spicy_rt::unit_find -> spicy_rt::FindDirection
+[debug/ast-declarations] - [function] spicy_rt::waitForEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInput -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInputOrEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInputOrEod_2 -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInput_2 -> spicy_rt::Filters
+[debug/ast-declarations] - [module] a -> a::X, a::__feat%a@@X%is_filter, a::__feat%a@@X%supports_filters, a::__feat%a@@X%supports_sinks, a::__feat%a@@X%synchronization, a::__feat%a@@X%uses_offset, a::__feat%a@@X%uses_random_access, a::__feat%a@@X%uses_stream, a::__feat%a@@X%uses_sync_advance, a::__register_a_X, a::a::X::__parse_a__X_stage2, a::a::X::__parse_stage1, a::a::X::parse1, a::a::X::parse2, a::a::X::parse3, hilti::ByteOrder, hilti::Exception, hilti::RecoverableFailure, hilti::SystemException, hilti::debugDedent, hilti::debugIndent, hilti::exception_what_2, hilti::exception_where_2, spicy_rt::Filters, spicy_rt::MIMEType, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext, spicy_rt::initializeParsedUnit, spicy_rt::registerParser, spicy_rt::waitForInput_2
+[debug/ast-declarations] - [module] b -> a::X, b::a::X::__on_x, hilti::Exception, hilti::RecoverableFailure, hilti::printValues, spicy_rt::MIMEType, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [module] hilti -> hilti::AddressFamily, hilti::BitOrder, hilti::ByteOrder, hilti::Captures, hilti::Charset, hilti::DecodeErrorStrategy, hilti::Exception, hilti::MatchState, hilti::MissingData, hilti::Profiler, hilti::Protocol, hilti::RealType, hilti::RecoverableFailure, hilti::RuntimeError, hilti::Side, hilti::StreamStatistics, hilti::SystemException, hilti::abort, hilti::current_time, hilti::debug, hilti::debugDedent, hilti::debugIndent, hilti::exception_what, hilti::exception_what_2, hilti::exception_where, hilti::exception_where_2, hilti::mktime, hilti::print, hilti::printValues, hilti::profiler_start, hilti::profiler_stop
+[debug/ast-declarations] - [module] spicy -> spicy::AddressFamily, spicy::Base64Stream, spicy::BitOrder, spicy::ByteOrder, spicy::Charset, spicy::DecodeErrorStrategy, spicy::Direction, spicy::Error, spicy::MatchState, spicy::Protocol, spicy::RealType, spicy::ReassemblerPolicy, spicy::Side, spicy::StreamStatistics, spicy::ZlibStream, spicy::accept_input, spicy::base64_decode, spicy::base64_encode, spicy::base64_finish, spicy::bytes_to_hexstring, spicy::crc32_add, spicy::crc32_init, spicy::current_time, spicy::decline_input, spicy::getenv, spicy::mktime, spicy::parse_address, spicy::parse_address_2, spicy::strftime, spicy::strptime, spicy::zlib_decompress, spicy::zlib_finish, spicy::zlib_init
+[debug/ast-declarations] - [module] spicy_rt -> hilti::Exception, hilti::RecoverableFailure, spicy_rt::Backtrack, spicy_rt::BitOrder, spicy_rt::Direction, spicy_rt::Filters, spicy_rt::FindDirection, spicy_rt::Forward, spicy_rt::HiltiResumable, spicy_rt::MIMEType, spicy_rt::MissingData, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::Sink, spicy_rt::SinkState, spicy_rt::TypeInfo, spicy_rt::UnitAlreadyConnected, spicy_rt::UnitContext, spicy_rt::atEod, spicy_rt::backtrack, spicy_rt::confirm, spicy_rt::createContext, spicy_rt::filter_connect, spicy_rt::filter_disconnect, spicy_rt::filter_forward, spicy_rt::filter_forward_eod, spicy_rt::filter_init, spicy_rt::initializeParsedUnit, spicy_rt::printParserState, spicy_rt::registerParser, spicy_rt::reject, spicy_rt::setContext, spicy_rt::unit_find, spicy_rt::waitForEod, spicy_rt::waitForInput, spicy_rt::waitForInputOrEod, spicy_rt::waitForInputOrEod_2, spicy_rt::waitForInput_2
+[debug/ast-declarations] - [type] a::X -> a::X, hilti::Exception, hilti::RecoverableFailure, spicy_rt::MIMEType, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [type] hilti::MatchState -> hilti::Captures
+[debug/ast-declarations] - [type] hilti::MissingData -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RecoverableFailure -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RuntimeError -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::SystemException -> hilti::Exception
+[debug/ast-declarations] - [type] spicy_rt::Parser -> spicy_rt::MIMEType, spicy_rt::ParserPort, spicy_rt::TypeInfo

--- a/tests/Baseline/spicy.types.unit.canonical-ids/output
+++ b/tests/Baseline/spicy.types.unit.canonical-ids/output
@@ -1007,3 +1007,44 @@
 [debug/ast-declarations]             - Parameter "reason" (spicy::reason)
 [debug/ast-declarations]     - ImportedModule "hilti" (spicy::hilti)
 [debug/ast-declarations]     - ImportedModule "spicy_rt" (spicy::spicy_rt)
+[debug/ast-declarations] Declaration dependencies:
+[debug/ast-declarations] - [function] DNS::DNS::Label::__parse_DNS__Label_stage2 -> DNS::Label, DNS::Pointer, hilti::Exception, hilti::RecoverableFailure, hilti::debugDedent
+[debug/ast-declarations] - [function] DNS::DNS::Label::__parse_stage1 -> hilti::Exception, hilti::RecoverableFailure, hilti::SystemException, hilti::debugIndent
+[debug/ast-declarations] - [function] DNS::DNS::Pointer::__parse_DNS__Pointer_2_stage2 -> DNS::Label, DNS::Pointer, hilti::Exception, hilti::RecoverableFailure, hilti::debugDedent
+[debug/ast-declarations] - [function] DNS::DNS::Pointer::__parse_stage1 -> hilti::Exception, hilti::RecoverableFailure, hilti::SystemException, hilti::debugIndent
+[debug/ast-declarations] - [function] hilti::exception_what -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_what_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::exception_where -> hilti::Exception, hilti::SystemException
+[debug/ast-declarations] - [function] hilti::exception_where_2 -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] hilti::profiler_start -> hilti::Profiler
+[debug/ast-declarations] - [function] hilti::profiler_stop -> hilti::Profiler
+[debug/ast-declarations] - [function] spicy::base64_decode -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::base64_encode -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::base64_finish -> spicy::Base64Stream
+[debug/ast-declarations] - [function] spicy::zlib_decompress -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy::zlib_finish -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy::zlib_init -> spicy::ZlibStream
+[debug/ast-declarations] - [function] spicy_rt::atEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::createContext -> spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] spicy_rt::initializeParsedUnit -> spicy_rt::ParsedUnit, spicy_rt::TypeInfo
+[debug/ast-declarations] - [function] spicy_rt::printParserState -> hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [function] spicy_rt::registerParser -> spicy_rt::MIMEType, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::TypeInfo
+[debug/ast-declarations] - [function] spicy_rt::setContext -> spicy_rt::TypeInfo, spicy_rt::UnitContext
+[debug/ast-declarations] - [function] spicy_rt::unit_find -> spicy_rt::FindDirection
+[debug/ast-declarations] - [function] spicy_rt::waitForEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInput -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInputOrEod -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInputOrEod_2 -> spicy_rt::Filters
+[debug/ast-declarations] - [function] spicy_rt::waitForInput_2 -> spicy_rt::Filters
+[debug/ast-declarations] - [module] DNS -> DNS::DNS::Label::__parse_DNS__Label_stage2, DNS::DNS::Label::__parse_stage1, DNS::DNS::Pointer::__parse_DNS__Pointer_2_stage2, DNS::DNS::Pointer::__parse_stage1, DNS::Label, DNS::Pointer, DNS::__feat%DNS@@Label%is_filter, DNS::__feat%DNS@@Label%supports_filters, DNS::__feat%DNS@@Label%supports_sinks, DNS::__feat%DNS@@Label%synchronization, DNS::__feat%DNS@@Label%uses_offset, DNS::__feat%DNS@@Label%uses_random_access, DNS::__feat%DNS@@Label%uses_stream, DNS::__feat%DNS@@Label%uses_sync_advance, DNS::__feat%DNS@@Pointer%is_filter, DNS::__feat%DNS@@Pointer%supports_filters, DNS::__feat%DNS@@Pointer%supports_sinks, DNS::__feat%DNS@@Pointer%synchronization, DNS::__feat%DNS@@Pointer%uses_offset, DNS::__feat%DNS@@Pointer%uses_random_access, DNS::__feat%DNS@@Pointer%uses_stream, DNS::__feat%DNS@@Pointer%uses_sync_advance, DNS::__register_DNS_Label, DNS::__register_DNS_Pointer, hilti::Exception, hilti::RecoverableFailure, hilti::SystemException, hilti::debugDedent, hilti::debugIndent
+[debug/ast-declarations] - [module] hilti -> hilti::AddressFamily, hilti::BitOrder, hilti::ByteOrder, hilti::Captures, hilti::Charset, hilti::DecodeErrorStrategy, hilti::Exception, hilti::MatchState, hilti::MissingData, hilti::Profiler, hilti::Protocol, hilti::RealType, hilti::RecoverableFailure, hilti::RuntimeError, hilti::Side, hilti::StreamStatistics, hilti::SystemException, hilti::abort, hilti::current_time, hilti::debug, hilti::debugDedent, hilti::debugIndent, hilti::exception_what, hilti::exception_what_2, hilti::exception_where, hilti::exception_where_2, hilti::mktime, hilti::print, hilti::printValues, hilti::profiler_start, hilti::profiler_stop
+[debug/ast-declarations] - [module] spicy -> spicy::AddressFamily, spicy::Base64Stream, spicy::BitOrder, spicy::ByteOrder, spicy::Charset, spicy::DecodeErrorStrategy, spicy::Direction, spicy::Error, spicy::MatchState, spicy::Protocol, spicy::RealType, spicy::ReassemblerPolicy, spicy::Side, spicy::StreamStatistics, spicy::ZlibStream, spicy::accept_input, spicy::base64_decode, spicy::base64_encode, spicy::base64_finish, spicy::bytes_to_hexstring, spicy::crc32_add, spicy::crc32_init, spicy::current_time, spicy::decline_input, spicy::getenv, spicy::mktime, spicy::parse_address, spicy::parse_address_2, spicy::strftime, spicy::strptime, spicy::zlib_decompress, spicy::zlib_finish, spicy::zlib_init
+[debug/ast-declarations] - [module] spicy_rt -> hilti::Exception, hilti::RecoverableFailure, spicy_rt::Backtrack, spicy_rt::BitOrder, spicy_rt::Direction, spicy_rt::Filters, spicy_rt::FindDirection, spicy_rt::Forward, spicy_rt::HiltiResumable, spicy_rt::MIMEType, spicy_rt::MissingData, spicy_rt::ParseError, spicy_rt::ParsedUnit, spicy_rt::Parser, spicy_rt::ParserPort, spicy_rt::Sink, spicy_rt::SinkState, spicy_rt::TypeInfo, spicy_rt::UnitAlreadyConnected, spicy_rt::UnitContext, spicy_rt::atEod, spicy_rt::backtrack, spicy_rt::confirm, spicy_rt::createContext, spicy_rt::filter_connect, spicy_rt::filter_disconnect, spicy_rt::filter_forward, spicy_rt::filter_forward_eod, spicy_rt::filter_init, spicy_rt::initializeParsedUnit, spicy_rt::printParserState, spicy_rt::registerParser, spicy_rt::reject, spicy_rt::setContext, spicy_rt::unit_find, spicy_rt::waitForEod, spicy_rt::waitForInput, spicy_rt::waitForInputOrEod, spicy_rt::waitForInputOrEod_2, spicy_rt::waitForInput_2
+[debug/ast-declarations] - [type] DNS::Label -> DNS::Label, DNS::Pointer, hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [type] DNS::Pointer -> DNS::Label, DNS::Pointer, hilti::Exception, hilti::RecoverableFailure
+[debug/ast-declarations] - [type] hilti::MatchState -> hilti::Captures
+[debug/ast-declarations] - [type] hilti::MissingData -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RecoverableFailure -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::RuntimeError -> hilti::Exception
+[debug/ast-declarations] - [type] hilti::SystemException -> hilti::Exception
+[debug/ast-declarations] - [type] spicy_rt::Parser -> spicy_rt::MIMEType, spicy_rt::ParserPort, spicy_rt::TypeInfo

--- a/tests/Baseline/spicy.types.unit.hooks-across-imports/.stderr
+++ b/tests/Baseline/spicy.types.unit.hooks-across-imports/.stderr
@@ -66,5 +66,5 @@
 [debug/ast-stats]     - type::stream::Iterator: 1023
 [debug/ast-stats]     - type::stream::View: 557
 [debug/ast-stats]     - type::tuple::Element: 675
-[debug/ast-stats] garbage collected 32486 nodes in 18 rounds, 0 left retained
+[debug/ast-stats] garbage collected 31248 nodes in 18 rounds, 0 left retained
 [debug/ast-stats] garbage collected 0 nodes in 1 round, 0 left retained

--- a/tests/Baseline/spicy.types.unit.sub-unit/.stderr
+++ b/tests/Baseline/spicy.types.unit.sub-unit/.stderr
@@ -66,5 +66,5 @@
 [debug/ast-stats]     - type::stream::Iterator: 755
 [debug/ast-stats]     - type::stream::View: 409
 [debug/ast-stats]     - type::tuple::Element: 598
-[debug/ast-stats] garbage collected 23357 nodes in 18 rounds, 0 left retained
+[debug/ast-stats] garbage collected 23354 nodes in 18 rounds, 0 left retained
 [debug/ast-stats] garbage collected 0 nodes in 1 round, 0 left retained

--- a/tests/spicy/codegen/inline-bodies.spicy
+++ b/tests/spicy/codegen/inline-bodies.spicy
@@ -5,6 +5,9 @@
 #
 # We do not emit any `operator<<` for non-local types.
 # @TEST-EXEC-FAIL: grep -q 'operator<<.*X1.*{' foo_x2.cc
+#
+# We do not emit any ctors for non-local types.
+# @TEST-EXEC-FAIL: grep -q 'X1::X1(.*) {' foo_x2.cc
 
 # @TEST-START-FILE x1.spicy
 module x1;

--- a/tests/spicy/codegen/inline-bodies.spicy
+++ b/tests/spicy/codegen/inline-bodies.spicy
@@ -1,0 +1,25 @@
+# @TEST-DOC: Validates that we do not emit too many function bodies, regression test for #1800.
+#
+# @TEST-EXEC: spicyc x?.spicy -x foo
+# @TEST-EXEC: test -e foo_x2.cc
+#
+# We do not emit any `operator<<` for non-local types.
+# @TEST-EXEC-FAIL: grep -q 'operator<<.*X1.*{' foo_x2.cc
+
+# @TEST-START-FILE x1.spicy
+module x1;
+
+public type X1 = unit {
+    x1: uint8;
+};
+# @TEST-END-FILE
+
+# @TEST-START-FILE x2.spicy
+module x2;
+
+import x1;
+
+public type X2 = unit {
+    x1: x1::X1;
+};
+# @TEST-END-FILE

--- a/tests/spicy/types/unit/imported-declarations.spicy
+++ b/tests/spicy/types/unit/imported-declarations.spicy
@@ -1,0 +1,28 @@
+# @TEST-EXEC: spicyc -c -o output.cc %INPUT
+# @TEST-EXEC: grep -q Used output.cc
+# @TEST-EXEC-FAIL: grep NotUsed output.cc
+#
+# @TEST-DOC: Check that for imported modules we only declare types we need inside the C++ code.
+
+module Test;
+
+import Bar;
+
+public type Message = unit {
+    x: Bar::Used;
+
+    on %done { print self; }
+};
+
+# @TEST-START-FILE bar.spicy
+
+module Bar;
+
+public type Used = unit {
+    data: bytes &eod;
+};
+
+# This isn't used, so the type shouldn't show up in the generated C++ code.
+public type NotUsed = unit {
+    data: bytes &eod;
+};


### PR DESCRIPTION
This reworks how we emit C++ code, in particular declarations. We now
determine what to emit (and when) through dependencies: at the AST
level, we compute how global declarations depend on each other. Then,
at the C++ level, we emit dependencies as needed, and no longer simply
bulk copy *everything* imported over into a unit. In some cases, this
cuts down emitted code by a lot (though not necessarily compile time
it turns out).

The main commits in this PR are `Add an AST pass collecting
dependencies between declarations.` and `Rework emission of C++
code.`. The latter is unfortunately a bit messy, mostly because our
C++ code emission is messy to begin with. However, overall, the change
simplifies things quite a bit, and gets rid of a number of low-level
pieces no longer needed. It might still be challenging to review
unfortunately.

This PR does also ports #1801 over. Some commits needed a bit of
tweaking to match the new code.

I checked analyzer compile time performance with these changes and
didn't see much of a difference either way. In fact, I saw no change
at all without the #1801 port. With #1801 included, I did see a small
increase in compile time for a large internal analyzer; but nothing to
worry about.

- **Fully qualify runtime identifiers in generated code.**
- **Fix `Node::tryAs_()`.**
- **Add an AST pass collecting dependencies between declarations.**
- **Remove usage of designated initializers for all `cxx::declaration::*` classes.**
- **Rework emission of C++ code.**
- **Remove unused methods to retrieve module dependencies.**
- **Simplify body of generated `operator<<`.**
- **Only emit full C++ body of functions in module of matching namespace.**
- **Tweak when we emit struct inline code.**
- **Rename `cxx::type::Struct`'s `inlineCode` to `code`.**
- **Properly set parse extension when importing by path.**
