### PR TITLE
Don't qualify magic linker symbols with C++ namespace.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -51,12 +51,11 @@ void cxx::Linker::finalize() {
         for ( const auto& i : p.cxx_includes )
             unit->add(cxx::declaration::IncludeFile{i});
 
-    auto cxx_namespace = _codegen->context()->options().cxx_namespace_intern;
-
-    unit->add(fmt("const char HILTI_EXPORT HILTI_WEAK * %s_hlto_library_version = R\"(%s)\";", cxx_namespace,
-                  version.toJSON()));
-    unit->add(fmt("const char HILTI_EXPORT HILTI_WEAK * %s_hlto_bind_to_version = " HILTI_VERSION_FUNCTION_STRING "();",
-                  cxx_namespace));
+    // Note we don't qualify the two subsequent globals with
+    // `cxx_namespace_intern` because we need these exact names; that's what
+    // the runtime lbirary is likewise hard-coded to expect.
+    unit->add(fmt("const char HILTI_EXPORT HILTI_WEAK * __hlt_hlto_library_version = R\"(%s)\";", version.toJSON()));
+    unit->add("const char HILTI_EXPORT HILTI_WEAK * __hlt_hlto_bind_to_version = " HILTI_VERSION_FUNCTION_STRING "();");
 
     // Create a scope string that's likely to be unique to this linker module.
     std::size_t hash = 0;
@@ -66,6 +65,7 @@ void cxx::Linker::finalize() {
         hash = rt::hashCombine(hash, std::hash<std::string>()(content));
     }
 
+    auto cxx_namespace = _codegen->context()->options().cxx_namespace_intern;
     auto scope = hilti::rt::fmt("%" PRIx64, hash);
     unit->add(fmt("const char HILTI_WEAK * %s_hlto_scope = \"%s\";", cxx_namespace, scope));
 

--- a/tests/hilti/codegen/library-version.hlt
+++ b/tests/hilti/codegen/library-version.hlt
@@ -1,0 +1,11 @@
+# @TEST-EXEC: hiltic -x foo %INPUT
+# @TEST-EXEC: grep -q _hlt_hlto_library_version foo___linker__.cc
+# @TEST-EXEC: grep -q _hlt_hlto_bind_to_version foo___linker__.cc
+#
+# A hand-built HLTO file has all symbols needed to load correctly.
+# @TEST-EXEC: $(spicy-config --cxx --cxxflags-hlto --ldflags-hlto --debug) -o foo.hlto foo*cc
+# @TEST-EXEC: hiltic -j foo.hlto
+#
+# @TEST-DOC: Ensure that our magic linker symbols are created with their hardcoded names, and not using the `cxx_namespace_intern` prefix; regression test for #1823.
+
+module Foo {}


### PR DESCRIPTION
We need them at their original values because that's what the runtime
lbirary is hard-coded to expect.

Closes #1823.
