### PR TITLE
Fix use of move'd from variable.

### DIFF
--- a/hilti/toolchain/include/ast/declarations/module-uid.h
+++ b/hilti/toolchain/include/ast/declarations/module-uid.h
@@ -61,7 +61,7 @@ struct UID {
           parse_extension(std::move(parse_extension)),
           process_extension(std::move(process_extension)),
           in_memory(true) {
-        assert(this->id && ! parse_extension.empty() && ! process_extension.empty());
+        assert(this->id && ! this->parse_extension.empty() && ! this->process_extension.empty());
         //  just make up a path
         path = util::fmt("/tmp/hilti/%s.%" PRIu64 ".%s.%s", unique, ++_no_file_counter, process_extension,
                          parse_extension);


### PR DESCRIPTION
Function parameters still shadown members in C++. This is a fixup of c3abbbe8eb28d1e2cee5b58b19e1a30710b38853.