### PR TITLE
Fix optimizer regression.

### DIFF
--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -583,6 +583,26 @@ struct TypeVisitor : OptimizerVisitor {
         }
     }
 
+    void operator()(type::Name* n) final {
+        auto t = n->resolvedType();
+        assert(t);
+
+        switch ( _stage ) {
+            case Stage::COLLECT: {
+                if ( const auto& type_id = t->typeID() )
+                    // Record this type as used.
+                    _used[type_id] = true;
+
+                break;
+            }
+
+            case Stage::PRUNE_USES:
+            case Stage::PRUNE_DECLS:
+                // Nothing.
+                break;
+        }
+    }
+
     void operator()(UnqualifiedType* n) final {
         if ( n->parent(2)->isA<declaration::Type>() )
             return;

--- a/tests/Baseline/spicy.optimization.unused-types/log
+++ b/tests/Baseline/spicy.optimization.unused-types/log
@@ -1038,7 +1038,6 @@
 [debug/optimizer] [unused-types.spicy:43:22-46:1] operator_::struct_::MemberCall "(*self).__on_0x25_finally()" -> expression::Ctor "default<void>()" (replacing call to unimplemented method with default value)
 [debug/optimizer] [unused-types.spicy:43:22-46:1] operator_::struct_::MemberCall "(*self).__on_0x25_finally()" -> expression::Ctor "default<void>()" (replacing call to unimplemented method with default value)
 [debug/optimizer] [unused-types.spicy:43:22-46:1] operator_::struct_::MemberCall "(*self).__on_0x25_init()" -> expression::Ctor "default<void>()" (replacing call to unimplemented method with default value)
-[debug/optimizer] [unused-types.spicy:49:1-49:31] declaration::Type "type Priv11 = enum { A = 0, B = 1, C = 2 };" -> null (removing unused type)
 [debug/optimizer] removing field for unused method foo::Priv10::__on_0x25_confirmed
 [debug/optimizer] removing field for unused method foo::Priv10::__on_0x25_done
 [debug/optimizer] removing field for unused method foo::Priv10::__on_0x25_error

--- a/tests/Baseline/spicy.optimization.unused-types/opt.hlt
+++ b/tests/Baseline/spicy.optimization.unused-types/opt.hlt
@@ -48,6 +48,7 @@ public type Priv10 = struct {
     method view<stream> parse3(inout value_ref<spicy_rt::ParsedUnit> __gunit, inout value_ref<stream> __data, optional<view<stream>> __cur = Null, optional<spicy_rt::UnitContext> __context) &needed-by-feature="is_filter" &needed-by-feature="supports_sinks" &static;
     method tuple<const view<stream>, int<64>, const iterator<stream>, optional<hilti::RecoverableFailure>> __parse_foo__Priv10_stage2(inout value_ref<stream> __data, iterator<stream> __begin, copy view<stream> __cur, copy bool __trim, copy int<64> __lah, copy iterator<stream> __lahe, copy optional<hilti::RecoverableFailure> __error);
 } &on-heap;
+type Priv11 = enum { A = 0, B = 1, C = 2 };
 type Priv12 = enum { A = 0, B = 1, C = 2 };
 
 const bool __feat%foo@@Priv1%uses_offset = False;


### PR DESCRIPTION
We were no longer marking types as used that are referenced through a
type name.

Closes #1831.
