### PR TITLE
Fix computation of declaration dependencies.

### DIFF
--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -191,11 +191,11 @@ set_config_val(HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS
 # LD flags
 set_config_val(
     HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG
-    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT} -Wno-unused-command-line-argument"
+    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}"
 )
 set_config_val(
     HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE
-    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT} -Wno-unused-command-line-argument"
+    "${EXTRA_CXX_FLAGS} ${CMAKE_CXX_FLAGS} ${addl_ld_flags} ${EXTRA_LD_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_INIT}"
 )
 
 configure_file(include/config.h.in ${AUTOGEN_H}/config.h)

--- a/hilti/toolchain/include/ast/type.h
+++ b/hilti/toolchain/include/ast/type.h
@@ -365,6 +365,12 @@ public:
     /** Returns true if the qualified type is constant. */
     bool isConstant() const { return _constness == Constness::Const; }
 
+    /**
+     * Returns true if the type was created through `createExternal()`. If so,
+     * `type()` will retrieve the external type.
+     */
+    auto isExternal() const { return static_cast<bool>(_external); }
+
     /** Returns the type's constness. */
     auto constness() const { return _constness; }
 

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -122,6 +122,11 @@ private:
 
     void operator()(declaration::Type* n) final { insert(n); }
 
+    void operator()(QualifiedType* n) final {
+        if ( n->isExternal() )
+            follow(n->type());
+    }
+
     void operator()(expression::Name* n) final {
         auto d = n->resolvedDeclaration();
         assert(d);

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -140,13 +140,14 @@ void Configuration::init(bool use_build_directory) {
     //
     // (3) it helps the optimizer to know that symbols won't be accessed
     // externally.
-    runtime_cxx_flags_debug = flatten({"-fPIC", "-std=c++17", "-g", "-fvisibility=hidden",
+    runtime_cxx_flags_debug = flatten({"-fPIC", "-std=c++17", "-g", "-fvisibility=hidden", "-Wno-invalid-offsetof",
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});
 
-    runtime_cxx_flags_release = flatten({"-fPIC", "-std=c++17", "-g", "-O3", "-DNDEBUG", "-fvisibility=hidden",
-                                         prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
-                                         prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag)});
+    runtime_cxx_flags_release =
+        flatten({"-fPIC", "-std=c++17", "-g", "-O3", "-DNDEBUG", "-fvisibility=hidden", "-Wno-invalid-offsetof",
+                 prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag)});
 
 
     if ( auto libhilti_pch = precompiled_libhilti(*this, true) )
@@ -155,29 +156,29 @@ void Configuration::init(bool use_build_directory) {
     if ( auto libhilti_pch = precompiled_libhilti(*this, false) )
         runtime_cxx_flags_release.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
 
-    runtime_ld_flags_debug = flatten(
-        {prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag),
-         prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
+    runtime_ld_flags_debug =
+        flatten({prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_DEBUG}", "-l", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag),
+                 prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag),
+                 "-Wno-unused-command-line-argument"});
 
-    runtime_ld_flags_release = flatten(
-        {prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
-         prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag),
-         prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag)});
+    runtime_ld_flags_release =
+        flatten({prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-L", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "-Wl,-rpath,", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_LIBRARIES_RELEASE}", "-l", installation_tag),
+                 prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag),
+                 prefix(CMAKE_THREAD_LIBS_INIT, "-l", installation_tag), prefix(CMAKE_DL_LIBS, "-l", installation_tag),
+                 "-Wno-unused-command-line-argument"});
 
     hlto_cxx_flags_debug = runtime_cxx_flags_debug;
     hlto_cxx_flags_release = runtime_cxx_flags_release;
 
     hlto_ld_flags_debug = flatten({"-shared", "-Wl,-undefined", "-Wl,dynamic_lookup",
-                                   prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag),
-                                   "-Wno-unused-command-line-argument"});
+                                   prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG}", "", installation_tag)});
     hlto_ld_flags_release = flatten({"-shared", "-Wl,-undefined", "-Wl,dynamic_lookup",
-                                     prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag),
-                                     "-Wno-unused-command-line-argument"});
+                                     prefix("${HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE}", "", installation_tag)});
 
 #ifdef __APPLE__
     // Recent macOS versions have started to report `ld: warning: -undefined


### PR DESCRIPTION
One more branch we had to follow to track down all dependencies
between global declarations: external qualified types.

Closes #1835.
