### PR TITLE
Do not by default skip CI in update-changes cfg. [skip CI]

### DIFF
--- a/.update-changes.cfg
+++ b/.update-changes.cfg
@@ -1,6 +1,6 @@
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
-new_commit_msg="Update CHANGES. [skip ci]"
+new_commit_msg="Update CHANGES."
 show_authors=1
 
 # Add heuristic for pulling GitHub issue number out of the commit message.


### PR DESCRIPTION
We rely on CI to create releases, so having `[skip CI]` in our update-changes config was always a hassle which needed to be edited out when creating a release (just tagging would autocommit with the message template without a way to change the commit message before tagging).

Drop this part to make releases easier and less error prone.