### PR TITLE
Fix `skip` with units.

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -616,7 +616,7 @@ struct ProductionVisitor : public production::Visitor {
                 type_args = meta.field()->arguments();
             }
 
-            if ( meta.field() && ! meta.field()->isSkip() ) {
+            if ( meta.field() ) {
                 Expression* default_ =
                     builder()->default_(builder()->typeName(unit->unitType()->typeID()), type_args, location);
                 builder()->addAssign(destination(), default_);

--- a/tests/spicy/types/unit/skip-unit.spicy
+++ b/tests/spicy/types/unit/skip-unit.spicy
@@ -1,0 +1,13 @@
+# @TEST-EXEC: printf 'x' | spicy-driver -d %INPUT
+#
+# @TEST-DOC: Check that even with skip, a unit instance gets properly initialized for paresing; regression test for #1852
+
+module Test;
+
+public type Testing = unit {
+    padding: skip Pad(42);
+};
+
+type Pad = unit(x: uint8) {
+    on %init { assert(x == 42); } # before fix, x ended up being zero here
+};


### PR DESCRIPTION
For unit parsing with `skip`, we would create a temporary instance
but wouldn't properly initialize it, meaning for example that
parameters weren't available. We now generally fully initialize any
destination, even if temporary.

Closes #1852.
