### PR TITLE
Compile generated C++ with `-O0` in debug mode.

### DIFF
--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -140,7 +140,7 @@ void Configuration::init(bool use_build_directory) {
     //
     // (3) it helps the optimizer to know that symbols won't be accessed
     // externally.
-    runtime_cxx_flags_debug = flatten({"-fPIC", "-std=c++17", "-g", "-fvisibility=hidden", "-Wno-invalid-offsetof",
+    runtime_cxx_flags_debug = flatten({"-fPIC", "-std=c++17", "-g", "-O0", "-fvisibility=hidden", "-Wno-invalid-offsetof",
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
                                        prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});
 


### PR DESCRIPTION
This speeds things up a bit.
