### PR TITLE
Document `continue` statements

### DIFF
--- a/doc/programming/language/statements.rst
+++ b/doc/programming/language/statements.rst
@@ -65,6 +65,18 @@ See :ref:`statement_reject` to reject the synchronization instead.
 
 ``confirm`` can only be invoked from hooks.
 
+.. _statement_continue:
+
+``continue``
+------------
+
+::
+
+    continue;
+
+Inside a :ref:`statement_for` or :ref:`statement_while` loop, ``continue``
+causes the remaining portion of the enclosing loop body to be skipped.
+
 .. _operator_end:
 
 ``end``


### PR DESCRIPTION
Not too sure if it was left off for a reason, but seems like a lot changed since this was added. I think if `break` is documented, `continue` should be.