### PR TITLE
Associate source code locations with current fiber instead of current thread.

### DIFF
--- a/hilti/runtime/include/context.h
+++ b/hilti/runtime/include/context.h
@@ -44,7 +44,7 @@ struct Context {
      */
     resumable::Handle* resumable = nullptr;
 
-    /**  Context-specific state for fiber management. */
+    /** Context-specific state for fiber management. */
     detail::FiberContext fiber;
 
     /**
@@ -59,6 +59,13 @@ struct Context {
 
     /** Current indent level for debug messages. */
     uint64_t debug_indent{};
+
+    /**
+     * Current location for user-visible diagnostic messages if we're running
+     * outside of a fiber; null if not set. Considered valid only if
+     * `resumable` is not set.
+     */
+    const char* location = nullptr;
 };
 
 namespace context {

--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -208,6 +208,15 @@ public:
     auto&& result() { return std::move(_result); }
     std::exception_ptr exception() const { return _exception; }
 
+    /** Returns the current source code location if set, or null if not. */
+    const char* location() const { return _location; }
+
+    /**
+     * Sets the current source code location or unsets it if argument is null.
+     * @param l pointer to a statically allocated string that won't go out of scope.
+     */
+    void setLocation(const char* location = nullptr) { _location = location; }
+
     std::string tag() const;
 
     static std::unique_ptr<Fiber> create();
@@ -259,6 +268,9 @@ private:
 
     /** Buffer for the fiber's stack when swapped out. */
     StackBuffer _stack_buffer;
+
+    /** Current location for user-visible diagnostic messages; null if not set. */
+    const char* _location = nullptr;
 
 #ifdef HILTI_HAVE_ASAN
     /** Additional tracking state that ASAN needs. */

--- a/hilti/runtime/src/logging.cc
+++ b/hilti/runtime/src/logging.cc
@@ -13,8 +13,6 @@ using namespace hilti::rt::detail;
 
 using namespace hilti::rt;
 
-HILTI_THREAD_LOCAL const char* debug::detail::tls_location = nullptr;
-
 void hilti::rt::internalError(std::string_view msg) {
     std::cerr << fmt("[libhilti] Internal error: %s", msg) << '\n';
     abort_with_backtrace();


### PR DESCRIPTION
This fixes potential location mix-ups when switching between fibers.
Note that we still need a context-wide fallback location as well
because we're not always running inside a fiber.

I ran a performance comparison before/after and couldn't measure a
difference. Looks like using TLS storage was a case of premature
optimization.

Closes #1868.
