### PR TITLE
Fix usage of `&convert` with unit's requiring parameters.

### DIFF
--- a/hilti/toolchain/include/compiler/validator.h
+++ b/hilti/toolchain/include/compiler/validator.h
@@ -38,6 +38,10 @@ public:
     /** Returns the number of errors reported so far. */
     auto errors() const { return _errors; }
 
+    /** Validates if provided type arguments match a type's expectation. */
+    void checkTypeArguments(const node::Range<Expression>& have, const node::Set<type::function::Parameter>& want,
+                            Node* n, bool allow_no_arguments = false, bool do_not_check_types = false);
+
 private:
     Builder* _builder;
     int _errors = 0;

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -56,7 +56,9 @@ struct Visitor : hilti::visitor::PreOrder {
     void operator()(ctor::Default* n) final {
         std::string args;
 
-        if ( ! n->type()->type()->parameters().empty() ) {
+        // If type arguments are provided, call the corresponding constructor.
+        // If they aren't, we'll use the default constructor instead.
+        if ( ! n->typeArguments().empty() ) {
             auto exprs = cg->compileCallArguments(n->typeArguments(), n->type()->type()->parameters());
             args = util::join(exprs, ", ");
         }

--- a/hilti/toolchain/src/compiler/validator.cc
+++ b/hilti/toolchain/src/compiler/validator.cc
@@ -322,7 +322,7 @@ struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
         }
 
         if ( ! t->parameters().empty() )
-            checkTypeArguments(n->typeArguments(), t->parameters(), n);
+            checkTypeArguments(n->typeArguments(), t->parameters(), n, true);
     }
 
     void operator()(hilti::ctor::Exception* n) final {

--- a/spicy/toolchain/src/compiler/validator.cc
+++ b/spicy/toolchain/src/compiler/validator.cc
@@ -867,6 +867,15 @@ struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
 
         if ( auto rc = checkFieldAttributes(n); ! rc )
             error(rc.error(), n);
+
+        if ( auto t = n->type() ) {
+            if ( auto unit = t->type()->tryAs<type::Unit>() )
+                // We disable the actual type checking here because arguments
+                // won't have been coerced yet. We are only interested in in
+                // the number of arguments being correct, type checking will
+                // happen later on the HILTI side.
+                checkTypeArguments(n->arguments(), unit->parameters(), n, false, true);
+        }
     }
 
     void operator()(spicy::type::unit::item::UnresolvedField* n) final {

--- a/tests/spicy/types/unit/convert-with-type-param.spicy
+++ b/tests/spicy/types/unit/convert-with-type-param.spicy
@@ -1,0 +1,18 @@
+# @TEST-EXEC: spicyc -j -d %INPUT
+#
+# @TEST-DOC: Use `&convert` on a unit that has a type parameter; regression test for #1790.
+
+module Test;
+
+type Ctx = bool;
+
+public type XXX = unit {
+    %context = Ctx;
+    xxx: YYY(self.context());
+};
+
+type YYY = unit(ctx1: Ctx&) {
+    message: ZZZ(ctx1);
+} &convert=self.message;
+
+type ZZZ = unit(ctx2: Ctx&) {};


### PR DESCRIPTION
Fix usage of `&convert` with unit's requiring parameters.

The generated code needs to create a temporary instance of the type,
but doesn't have any arguments to provide to it. But that's ok, and we
now let the validation pass and just instantiate a default-constructed
instance.

This is a bit hackish due to needing to shift things around to the
right places, but couldn't think of a better fix.

- **Factor out logic to validate arguments given to a type.**
- **Fix usage of `&convert` with unit's requiring parameters.**
