### PR TITLE
Remove stray removal of directory in /tmp in test.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,14 +37,14 @@ repos:
     stages: ["pre-commit"]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v18.1.8'
+  rev: 'v19.1.2'
   hooks:
   - id: clang-format
     types_or: ["c", "c++"]
     stages: ["pre-commit"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     exclude: '^tests/Baseline'
@@ -86,21 +86,21 @@ repos:
     stages: ["pre-commit"]
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.19.0
+  rev: v1.26.0
   hooks:
   - id: typos
     exclude: 'tests/.*/regexp/.*|.clang-tidy'
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.1
+  rev: v0.7.0
   hooks:
   - id: ruff
     args: [ --fix ]
   - id: ruff-format
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.16.0
+  rev: v3.19.0
   hooks:
   - id: pyupgrade
     args: ["--py37-plus"]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,11 @@
 # Copyright (c) 2020-2023 by the Zeek Project. See LICENSE for details.
 
+[files]
+extend-exclude = [
+  # This is a file generated from a template not controlled by us.
+  "doc/Doxyfile",
+]
+
 [default.extend-words]
 inout = "inout"
 ocur = "ocur"

--- a/CHANGES
+++ b/CHANGES
@@ -2436,7 +2436,7 @@
 
   * Use unchecked operations for `View::unsafeEnd`. (Benjamin Bannier, Corelight)
 
-    We previously would call `end()` to compute `unsafeEnd` which incurrs
+    We previously would call `end()` to compute `unsafeEnd` which incurs
     overheads this function is explicitly designed to avoid. We now switch
     this implementation of this function to completely unsafe code avoiding
     these overheads.

--- a/hilti/runtime/src/tests/reference.cc
+++ b/hilti/runtime/src/tests/reference.cc
@@ -699,7 +699,9 @@ TEST_CASE("fmt") {
     CHECK_EQ(fmt("%s", WeakReference<int>(StrongReference<int>(42))), "42");
 
     auto wref = WeakReference<int>();
-    { wref = StrongReference<int>(42); }
+    {
+        wref = StrongReference<int>(42);
+    }
     REQUIRE(wref.isExpired());
     CHECK_EQ(fmt("%s", wref), "<expired ref>");
 }
@@ -710,7 +712,9 @@ TEST_CASE("to_string") {
     CHECK_EQ(to_string(WeakReference<int>(StrongReference<int>(42))), "42");
 
     auto wref = WeakReference<int>();
-    { wref = StrongReference<int>(42); }
+    {
+        wref = StrongReference<int>(42);
+    }
     REQUIRE(wref.isExpired());
     CHECK_EQ(to_string(wref), "<expired ref>");
 }
@@ -722,7 +726,9 @@ TEST_CASE("to_string_for_print") {
         CHECK_EQ(to_string_for_print(WeakReference<std::string>(StrongReference<std::string>("🤷\r\n"))), "🤷\r\n");
 
         auto wref = WeakReference<std::string>();
-        { wref = StrongReference<std::string>("abc"); }
+        {
+            wref = StrongReference<std::string>("abc");
+        }
         REQUIRE(wref.isExpired());
         CHECK_EQ(to_string_for_print(wref), "<expired ref>");
     }
@@ -734,7 +740,9 @@ TEST_CASE("to_string_for_print") {
                  "\\x00\\x01\\x02\\x03");
 
         auto wref = WeakReference<Bytes>();
-        { wref = StrongReference<Bytes>("abc"_b); }
+        {
+            wref = StrongReference<Bytes>("abc"_b);
+        }
         REQUIRE(wref.isExpired());
         CHECK_EQ(to_string_for_print(wref), "<expired ref>");
     }

--- a/hilti/runtime/src/types/address.cc
+++ b/hilti/runtime/src/types/address.cc
@@ -13,7 +13,7 @@ void Address::_parse(const std::string& addr) {
     // We need to guess whether it's a struct in_addr or IPv6 address. If
     // there's a colon in there, it's the latter.
     if ( addr.find(':') == std::string::npos ) {
-        struct in_addr v4 {};
+        struct in_addr v4{};
         if ( inet_pton(AF_INET, addr.c_str(), &v4) > 0 )
             _init(v4);
         else
@@ -21,7 +21,7 @@ void Address::_parse(const std::string& addr) {
     }
 
     else {
-        struct in6_addr v6 {};
+        struct in6_addr v6{};
         if ( inet_pton(AF_INET6, addr.c_str(), &v6) > 0 )
             _init(v6);
         else
@@ -77,7 +77,7 @@ std::variant<struct in_addr, struct in6_addr> Address::asInAddr() const {
         case AddressFamily::IPv4: return in_addr{integer::hton32(_a2)};
 
         case AddressFamily::IPv6: {
-            struct in6_addr v6 {};
+            struct in6_addr v6{};
             uint64_t a1 = integer::hton64(_a1);
             memcpy(&v6, &a1, 8);
 

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -173,7 +173,7 @@ std::pair<int32_t, int64_t> regexp::MatchState::_advance(const stream::View& dat
                 jrx_regexec_partial_min(_pimpl->_re->jrx(), reinterpret_cast<const char*>(block->start), block->size,
                                         first, last, &_pimpl->_ms, final_block));
 
-            // Note: The JRX match_state initializes offsets with 1.
+        // Note: The JRX match_state initializes offsets with 1.
 
 #ifdef _DEBUG_MATCHING
         std::cerr << fmt("-> state=%p rc=%d ms->offset=%d\n", this, rc, _pimpl->_ms.offset);

--- a/hilti/runtime/src/types/time.cc
+++ b/hilti/runtime/src/types/time.cc
@@ -10,7 +10,7 @@
 using namespace hilti::rt;
 
 Time time::current_time() {
-    struct timeval tv {};
+    struct timeval tv{};
     if ( gettimeofday(&tv, nullptr) < 0 )
         throw RuntimeError("gettimeofday failed in current_time()");
 
@@ -49,7 +49,7 @@ Time::operator std::string() const {
     time_t secs = _nsecs.Ref() / 1000000000;
 
     char buffer[60];
-    struct tm tm {};
+    struct tm tm{};
     strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S", gmtime_r(&secs, &tm));
     auto sfrac = fmt("%.9fZ", frac);
     return fmt("%s.%s", buffer, sfrac.substr(2));

--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -187,7 +187,7 @@ void util::abortWithBacktrace() {
 }
 
 double util::currentTime() {
-    struct timeval tv {};
+    struct timeval tv{};
     gettimeofday(&tv, nullptr);
     return static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) / 1e6;
 }

--- a/tests/spicy/tools/spicyc-ccache-data-race.spicy
+++ b/tests/spicy/tools/spicyc-ccache-data-race.spicy
@@ -1,6 +1,5 @@
 # @TEST-DOC: This test validates that if the same module is included in multiple other modules, we create unique filenames. This avoids that concurrent JIT jobs work on the same file.
 #
-# @TEST-EXEC: rm -f /tmp/log
 # @TEST-EXEC: chmod +x wrapper.sh
 #
 # We expect exactly three files for this compilation (modules `a` and `foo` and linker script).


### PR DESCRIPTION
I am unsure why we included this in the first place. I suspect it was a
leftover from development.