### PR TITLE
Fix doc code snippet that won't compile.

### DIFF
--- a/doc/programming/examples/_parse-websocket-bitfield.spicy
+++ b/doc/programming/examples/_parse-websocket-bitfield.spicy
@@ -1,11 +1,14 @@
 # Automatically generated; edit in Sphinx source code, not here.
 module WebSocket;
 
+import spicy;
+
 public type Header= unit {
-  : bitfield(32) {
-    fin: 0;
-    rsv: 1..3;
-    opcode: 4..7;
-    mask: 8;
-    payload_len: 9..15;
-} &bit-order=spicy::BitOrder::MSB0
+    : bitfield(32) {
+        fin: 0;
+        rsv: 1..3;
+        opcode: 4..7;
+        mask: 8;
+        payload_len: 9..15;
+    } &bit-order=spicy::BitOrder::MSB0;
+};

--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -1107,14 +1107,17 @@ on the whole bitfield:
 
     module WebSocket;
 
+    import spicy;
+
     public type Header= unit {
-      : bitfield(32) {
-        fin: 0;
-        rsv: 1..3;
-        opcode: 4..7;
-        mask: 8;
-        payload_len: 9..15;
-    } &bit-order=spicy::BitOrder::MSB0
+        : bitfield(32) {
+            fin: 0;
+            rsv: 1..3;
+            opcode: 4..7;
+            mask: 8;
+            payload_len: 9..15;
+        } &bit-order=spicy::BitOrder::MSB0;
+    };
 
 The way to think about this is that the most significant bit of an integer in
 network byte order is always the most left bit and the least significant bit


### PR DESCRIPTION
Going through docs to make sure attributes line up for validation and I noticed that this snippet won't compile (missing semicolons, closing brace, and import).

Also changed it to 4 space indents because that's what code around it is