### PR TITLE
Keep test `spicy.rt.time` working for the next 200 years.

### DIFF
--- a/tests/spicy/rt/time.spicy
+++ b/tests/spicy/rt/time.spicy
@@ -6,4 +6,4 @@ module Test;
 import spicy;
 
 global t = spicy::current_time();
-assert t > time(1564617600) && t < time(1735689600);
+assert t > time(1000000000) && t < time(8000000000);


### PR DESCRIPTION
This test still compares the current time against hardcoded times to check ordering. Extend the upper value so this test passes for the next ~200 years.