### PR TITLE
Remove copyright years [skip CI].

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023 by the Zeek Project through the International
+Copyright (c) 2020-now by the Zeek Project through the International
 Computer Science Institute. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath("scripts"))
 # -- Project information -----------------------------------------------------
 
 project = "Spicy"
-copyright = "2024 by the Zeek Project"
+copyright = "by the Zeek Project"
 author = "Zeek Project"
 
 version = open("../VERSION").readline()


### PR DESCRIPTION
It may be worth going through the files to change it to something similar as well, but for now I'll just put this in as a minimal amount. This covers the most forward-facing parts, at least :)

what docs copyright looks like now:

![Screenshot 2025-01-09 at 11 25 18 AM](https://github.com/user-attachments/assets/0ef7da4b-c170-4116-bab4-4432be1f195a)
