### PR TITLE
Add support for case-insensitive matching to regular expressions.

### DIFF
--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -464,7 +464,13 @@ call site.
 Regular Expression
 ------------------
 
-Spicy provides POSIX-style regular expressions.
+Spicy provides POSIX-style regular expressions. Regular expression are
+typically of the form ``/PATTERN/[FLAGS]``, where ``PATTERN`` is a
+regular expression to match, and ``FLAGS`` contains optional flags
+modifying the matching behavior. In addition, regular expression
+constants can also consist of multiple patterns, separated by ``|``.
+This creates a single regular expression constant that matches any of
+the patterns.
 
 .. rubric:: Type
 
@@ -473,8 +479,9 @@ Spicy provides POSIX-style regular expressions.
 .. rubric:: Constants
 
 - ``/Foo*bar?/``, ``/X(..)(..)(..)Y/``
+- ``/Foo/$(1) | /Bar/$(2)``
 
-Regular expressions use the extended POSIX syntax, with a few smaller
+Regular expression patterns use the extended POSIX syntax, with a few smaller
 differences and extensions:
 
 - Supported character classes are: ``[:lower:]``, ``[:upper:]``,
@@ -483,8 +490,12 @@ differences and extensions:
   boundary.
 - ``\xXX`` matches a byte with the binary hex value ``XX`` (e.g.,
   ``\xff`` matches a byte of decimal value 255).
-- ``{#<number>}`` associates a numerical ID with a regular expression
-  (useful for set matching).
+
+Patterns support the following optional flags:
+
+``$(ID)`` Associates a numeric ``ID`` with the pattern. When a regular
+  expression consists of multiple patterns, such IDs allow to identify
+  the one that matched.
 
 Regular expression constants support the following optional attribute:
 

--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -478,14 +478,16 @@ the patterns.
 
 .. rubric:: Constants
 
-- ``/Foo*bar?/``, ``/X(..)(..)(..)Y/``
+- ``/Foo*bar?/``, ``/X(..)(..)(..)Y/``, ``/foo/i``
 - ``/Foo/$(1) | /Bar/$(2)``
 
 Regular expression patterns use the extended POSIX syntax, with a few smaller
 differences and extensions:
 
 - Supported character classes are: ``[:lower:]``, ``[:upper:]``,
-  ``[:digit:]``, ``[:blank:]``.
+  ``[:digit:]``, ``[:blank:]``. Note that ``[:lower:]`` and
+  ``[:upper:]`` do not take locales into account, they only match
+  standard ASCII characters.
 - ``\b`` asserts a word-boundary, ``\B`` matches asserts no word
   boundary.
 - ``\xXX`` matches a byte with the binary hex value ``XX`` (e.g.,
@@ -493,9 +495,15 @@ differences and extensions:
 
 Patterns support the following optional flags:
 
-``$(ID)`` Associates a numeric ``ID`` with the pattern. When a regular
-  expression consists of multiple patterns, such IDs allow to identify
-  the one that matched.
+``i``
+  Matches the pattern case-insensitively. Just like ``[:lower:]`` and
+  ``[:upper:]``, this flag only affects standard ASCII characters; it
+  does not consider any locale.
+
+``$(ID)``
+  Associates a numeric ID with the pattern. When a regular expression
+  constant consists of multiple patterns, their IDs identify the one
+  that matched.
 
 Regular expression constants support the following optional attribute:
 

--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -505,12 +505,6 @@ Patterns support the following optional flags:
   constant consists of multiple patterns, their IDs identify the one
   that matched.
 
-Regular expression constants support the following optional attribute:
-
-``&nosub``
-    Compile without support for capturing subexpressions, which makes
-    matching more efficient.
-
 
 .. include:: /autogen/types/regexp.rst
 

--- a/hilti/runtime/include/types/regexp.h
+++ b/hilti/runtime/include/types/regexp.h
@@ -43,22 +43,27 @@ struct Flags {
  */
 class Pattern {
 public:
-    Pattern(std::string value = "", uint64_t id = 0) : _value(std::move(value)), _id(id) {}
+    Pattern(std::string value = "", bool case_insensitive = false, uint64_t id = 0)
+        : _value(std::move(value)), _case_insensitive(case_insensitive), _id(id) {}
 
     const auto& value() const { return _value; }
+    auto isCaseInsensitive() const { return _case_insensitive; }
     auto matchID() const { return _id; }
 
     void setValue(std::string value) { _value = std::move(value); }
+    void setCaseInsensitive(bool case_insensitive) { _case_insensitive = case_insensitive; }
     void setMatchID(uint64_t id) { _id = id; }
 
 private:
     std::string _value;
+    bool _case_insensitive;
     uint64_t _id;
 };
 
 inline std::string to_string(const Pattern& pattern) {
+    auto ci = (pattern.isCaseInsensitive() ? "i" : "");
     auto id = (pattern.matchID() ? fmt("$(%" PRIu64 ")", pattern.matchID()) : "");
-    return fmt("/%s/%s", pattern.value(), id);
+    return fmt("/%s/%s%s", pattern.value(), ci, id);
 }
 
 inline std::ostream& operator<<(std::ostream& out, const Pattern& pattern) { return out << to_string(pattern); }

--- a/hilti/runtime/include/types/regexp.h
+++ b/hilti/runtime/include/types/regexp.h
@@ -43,15 +43,23 @@ struct Flags {
  */
 class Pattern {
 public:
-    Pattern(std::string value = "") : _value(std::move(value)) {}
+    Pattern(std::string value = "", uint64_t id = 0) : _value(std::move(value)), _id(id) {}
 
     const auto& value() const { return _value; }
+    auto matchID() const { return _id; }
+
+    void setValue(std::string value) { _value = std::move(value); }
+    void setMatchID(uint64_t id) { _id = id; }
 
 private:
     std::string _value;
+    uint64_t _id;
 };
 
-inline std::string to_string(const Pattern& pattern) { return fmt("/%s/", pattern.value()); }
+inline std::string to_string(const Pattern& pattern) {
+    auto id = (pattern.matchID() ? fmt("$(%" PRIu64 ")", pattern.matchID()) : "");
+    return fmt("/%s/%s", pattern.value(), id);
+}
 
 inline std::ostream& operator<<(std::ostream& out, const Pattern& pattern) { return out << to_string(pattern); }
 

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -231,10 +231,10 @@ TEST_CASE("lower") {
 
 TEST_CASE("match") {
     const auto b = "123"_b;
-    CHECK_EQ(b.match(RegExp(".*2"), 0), Result("12"_b));
-    CHECK_EQ(b.match(RegExp(".*(2)"), 1), Result("2"_b));
-    CHECK_EQ(b.match(RegExp(".*a"), 0), Result<Bytes>(result::Error("no matches found")));
-    CHECK_EQ(b.match(RegExp(".*2"), 1), Result<Bytes>(result::Error("no matches found")));
+    CHECK_EQ(b.match(RegExp({".*2"}), 0), Result("12"_b));
+    CHECK_EQ(b.match(RegExp({".*(2)"}), 1), Result("2"_b));
+    CHECK_EQ(b.match(RegExp({".*a"}), 0), Result<Bytes>(result::Error("no matches found")));
+    CHECK_EQ(b.match(RegExp({".*2"}), 1), Result<Bytes>(result::Error("no matches found")));
 }
 
 TEST_CASE("iteration") {

--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -16,7 +16,7 @@ using namespace hilti::rt::bytes::literals;
 
 TEST_SUITE_BEGIN("RegExp");
 
-inline auto operator ""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
+inline auto operator""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
 
 TEST_CASE("match") {
     SUBCASE("min-matcher") {
@@ -160,16 +160,16 @@ TEST_CASE("find") {
 
 TEST_CASE("matchGroups") {
     SUBCASE("min-matcher") {
-        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b), "cannot capture groups during set matching",
-                             const NotSupported&);
+        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b),
+                             "cannot capture groups during set matching", const NotSupported&);
     }
 
     SUBCASE("std-matcher") {
         CHECK_EQ(RegExp(".*abc"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>({" abc"_b}));
         CHECK_EQ(RegExp("123"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>());
 
-        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b), "cannot capture groups during set matching",
-                             const NotSupported&);
+        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b),
+                             "cannot capture groups during set matching", const NotSupported&);
 
         CHECK_EQ(RegExp(".*(a)bc"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b),
                  Vector<Bytes>({" abc"_b, "a"_b}));
@@ -270,7 +270,7 @@ TEST_CASE("advance") {
     }
 
     SUBCASE("on set") {
-        const auto patterns = regexp::Patterns({{"a(b+cx){#10}"}, {"a(b+cy){#20}"}});
+        const auto patterns = regexp::Patterns({{"a(b+cx)", 10}, {"a(b+cy)", 20}});
         const auto re_std = RegExp(patterns, regexp::Flags{.use_std = true});
         const auto re_no_sub = RegExp(patterns, regexp::Flags{.no_sub = true});
 

--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -16,192 +16,186 @@ using namespace hilti::rt::bytes::literals;
 
 TEST_SUITE_BEGIN("RegExp");
 
+inline auto operator ""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
+
 TEST_CASE("match") {
     SUBCASE("min-matcher") {
-        CHECK_GT(RegExp("abc", regexp::Flags{.no_sub = 1}).match("abc"_b), 0);
-        CHECK_GT(RegExp(".*abc", regexp::Flags{.no_sub = 1}).match(" abc"_b), 0);
-        CHECK_GT(RegExp("abc", regexp::Flags{.no_sub = 1}).match("abc "_b), 0);
-        CHECK_GT(RegExp(".*abc", regexp::Flags{.no_sub = 1}).match(" abc "_b), 0);
+        CHECK_GT(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).match("abc"_b), 0);
+        CHECK_GT(RegExp(".*abc"_p, regexp::Flags{.no_sub = 1}).match(" abc"_b), 0);
+        CHECK_GT(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).match("abc "_b), 0);
+        CHECK_GT(RegExp(".*abc"_p, regexp::Flags{.no_sub = 1}).match(" abc "_b), 0);
 
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.no_sub = 1}).match("abc"_b), 1);
-        CHECK_EQ(RegExp("abc$", regexp::Flags{.no_sub = 1}).match("123"_b), 0);
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.no_sub = 1}).match("123"_b), 0);
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.no_sub = 1}).match("abc"_b), 1);
+        CHECK_EQ(RegExp("abc$"_p, regexp::Flags{.no_sub = 1}).match("123"_b), 0);
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.no_sub = 1}).match("123"_b), 0);
 
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*123"}), regexp::Flags{.no_sub = 1}).match(" abc "_b), 1);
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*123"}), regexp::Flags{.no_sub = 1}).match(" 123 "_b), 2);
+        CHECK_EQ(RegExp({".*abc"_p, ".*123"_p}, regexp::Flags{.no_sub = 1}).match(" abc "_b), 1);
+        CHECK_EQ(RegExp({".*abc"_p, ".*123"_p}, regexp::Flags{.no_sub = 1}).match(" 123 "_b), 2);
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.no_sub = 1}).match(""_b), -1);
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.no_sub = 1}).match(""_b), -1);
 
         // Ambiguous case, captured here to ensure consistency.
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*abc"}), regexp::Flags{.no_sub = 1}).match(" abc "_b), 1);
+        CHECK_EQ(RegExp({".*abc"_p, ".*abc"_p}, regexp::Flags{.no_sub = 1}).match(" abc "_b), 1);
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("xyz"_b), 0);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("abbbcdef"_b), 1);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("012abbbc345"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("xyz"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("abbbcdef"_b), 1);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("012abbbc345"_b), 0);
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("xyz"_b), 0);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("abbbcdef"_b), 1);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).match("012abbbc345"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("xyz"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("abbbcdef"_b), 1);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).match("012abbbc345"_b), 0);
     }
 
     SUBCASE("std-matcher") {
-        CHECK_GT(RegExp("abc", regexp::Flags{.use_std = 1}).match("abc"_b), 0);
-        CHECK_GT(RegExp(".*abc", regexp::Flags{.use_std = 1}).match(" abc"_b), 0);
-        CHECK_GT(RegExp("abc", regexp::Flags{.use_std = 1}).match("abc "_b), 0);
-        CHECK_GT(RegExp(".*abc", regexp::Flags{.use_std = 1}).match(" abc "_b), 0);
+        CHECK_GT(RegExp("abc"_p, regexp::Flags{.use_std = 1}).match("abc"_b), 0);
+        CHECK_GT(RegExp(".*abc"_p, regexp::Flags{.use_std = 1}).match(" abc"_b), 0);
+        CHECK_GT(RegExp("abc"_p, regexp::Flags{.use_std = 1}).match("abc "_b), 0);
+        CHECK_GT(RegExp(".*abc"_p, regexp::Flags{.use_std = 1}).match(" abc "_b), 0);
 
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.use_std = 1}).match("abc"_b), 1);
-        CHECK_EQ(RegExp("abc$", regexp::Flags{.use_std = 1}).match("123"_b), 0);
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.use_std = 1}).match("123"_b), 0);
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.use_std = 1}).match("abc"_b), 1);
+        CHECK_EQ(RegExp("abc$"_p, regexp::Flags{.use_std = 1}).match("123"_b), 0);
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.use_std = 1}).match("123"_b), 0);
 
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*123"}), regexp::Flags{.use_std = 1}).match(" abc "_b), 1);
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*123"}), regexp::Flags{.use_std = 1}).match(" 123 "_b), 2);
+        CHECK_EQ(RegExp({".*abc"_p, ".*123"_p}, regexp::Flags{.use_std = 1}).match(" abc "_b), 1);
+        CHECK_EQ(RegExp({".*abc"_p, ".*123"_p}, regexp::Flags{.use_std = 1}).match(" 123 "_b), 2);
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.use_std = 1}).match(""_b), -1);
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.use_std = 1}).match(""_b), -1);
 
         // Ambiguous case, captured here to ensure consistency.
-        CHECK_EQ(RegExp(std::vector<std::string>({".*abc", ".*abc"}), regexp::Flags{.use_std = 1}).match(" abc "_b), 1);
+        CHECK_EQ(RegExp({".*abc"_p, ".*abc"_p}, regexp::Flags{.use_std = 1}).match(" abc "_b), 1);
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("xyz"_b), 0);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("abbbcdef"_b), 1);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("012abbbc345"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("xyz"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("abbbcdef"_b), 1);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("012abbbc345"_b), 0);
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("xyz"_b), 0);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("abbbcdef"_b), 1);
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).match("012abbbc345"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("xyz"_b), 0);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("abbbcdef"_b), 1);
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).match("012abbbc345"_b), 0);
     }
 }
 
 TEST_CASE("find") {
     SUBCASE("empty needle") {
-        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find(""_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).find(""_b), std::make_tuple(-1, ""_b));
     }
 
     SUBCASE("min-matcher") {
-        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find(" abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find("abc "_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.no_sub = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).find(" abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).find("abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.no_sub = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
 
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.no_sub = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc$", regexp::Flags{.no_sub = 1}).find("123"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.no_sub = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc$"_p, regexp::Flags{.no_sub = 1}).find("123"_b), std::make_tuple(-1, ""_b));
         // TODO(bbannier): This should never match and return `0`.
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.no_sub = 1}).find("123"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.no_sub = 1}).find("123"_b), std::make_tuple(-1, ""_b));
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.no_sub = 1}).find(" abc "_b),
-                 std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.no_sub = 1}).find(" 123 "_b),
-                 std::make_tuple(2, "123"_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.no_sub = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.no_sub = 1}).find(" 123 "_b), std::make_tuple(2, "123"_b));
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.no_sub = 1}).find(""_b),
-                 std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.no_sub = 1}).find(""_b), std::make_tuple(-1, ""_b));
 
         // Ambiguous case, captured here to ensure consistency.
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "abc"}), regexp::Flags{.no_sub = 1}).find(" abc "_b),
-                 std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp({"abc"_p, "abc"_p}, regexp::Flags{.no_sub = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.no_sub = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.no_sub = 1}).find("xxA1234X5678Y0912Bxx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.no_sub = 1}).find("xxA1234X5678Y0912Bxx"_b),
                  std::make_tuple(1, "234X5678Y09"_b));
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.no_sub = 1}).find("xxA123X0912Bxx23YY09xx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.no_sub = 1}).find("xxA123X0912Bxx23YY09xx"_b),
                  std::make_tuple(1, "23X0912Bxx23YY09"_b));
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.no_sub = 1}).find("xxA123X2309YY09xx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.no_sub = 1}).find("xxA123X2309YY09xx"_b),
                  std::make_tuple(1, "23X2309YY09"_b));
     }
 
     SUBCASE("std-matcher") {
-        CHECK_EQ(RegExp("abc", regexp::Flags{.use_std = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.use_std = 1}).find(" abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.use_std = 1}).find("abc "_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc", regexp::Flags{.use_std = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.use_std = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.use_std = 1}).find(" abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.use_std = 1}).find("abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc"_p, regexp::Flags{.use_std = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
 
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.use_std = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp("abc$", regexp::Flags{.use_std = 1}).find("123"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.use_std = 1}).find("abc"_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp("abc$"_p, regexp::Flags{.use_std = 1}).find("123"_b), std::make_tuple(-1, ""_b));
         // TODO(bbannier): This should never match and return `0`.
-        CHECK_EQ(RegExp("^abc$", regexp::Flags{.use_std = 1}).find("123"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("^abc$"_p, regexp::Flags{.use_std = 1}).find("123"_b), std::make_tuple(-1, ""_b));
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.use_std = 1}).find(" abc "_b),
-                 std::make_tuple(1, "abc"_b));
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.use_std = 1}).find(" 123 "_b),
-                 std::make_tuple(2, "123"_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.use_std = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.use_std = 1}).find(" 123 "_b), std::make_tuple(2, "123"_b));
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"}), regexp::Flags{.use_std = 1}).find(""_b),
-                 std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}, regexp::Flags{.use_std = 1}).find(""_b), std::make_tuple(-1, ""_b));
 
         // Ambiguous case, captured here to ensure consistency.
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "abc"}), regexp::Flags{.use_std = 1}).find(" abc "_b),
-                 std::make_tuple(1, "abc"_b));
+        CHECK_EQ(RegExp({"abc"_p, "abc"_p}, regexp::Flags{.use_std = 1}).find(" abc "_b), std::make_tuple(1, "abc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
-        CHECK_EQ(RegExp("ab+c", regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("xyz"_b), std::make_tuple(-1, ""_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("abbbcdef"_b), std::make_tuple(1, "abbbc"_b));
+        CHECK_EQ(RegExp("ab+c"_p, regexp::Flags{.use_std = 1}).find("012abbbc345"_b), std::make_tuple(1, "abbbc"_b));
 
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.use_std = 1}).find("xxA1234X5678Y0912Bxx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.use_std = 1}).find("xxA1234X5678Y0912Bxx"_b),
                  std::make_tuple(1, "234X5678Y09"_b));
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.use_std = 1}).find("xxA123X0912Bxx23YY09xx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.use_std = 1}).find("xxA123X0912Bxx23YY09xx"_b),
                  std::make_tuple(1, "23X0912Bxx23YY09"_b));
-        CHECK_EQ(RegExp("23.*09", regexp::Flags{.use_std = 1}).find("xxA123X2309YY09xx"_b),
+        CHECK_EQ(RegExp("23.*09"_p, regexp::Flags{.use_std = 1}).find("xxA123X2309YY09xx"_b),
                  std::make_tuple(1, "23X2309YY09"_b));
     }
 }
 
 TEST_CASE("matchGroups") {
     SUBCASE("min-matcher") {
-        CHECK_THROWS_WITH_AS(RegExp(std::vector<std::string>({"abc", "123"})).matchGroups("abc"_b),
-                             "cannot capture groups during set matching", const NotSupported&);
+        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b), "cannot capture groups during set matching",
+                             const NotSupported&);
     }
 
     SUBCASE("std-matcher") {
-        CHECK_EQ(RegExp(".*abc", regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>({" abc"_b}));
-        CHECK_EQ(RegExp("123", regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>());
+        CHECK_EQ(RegExp(".*abc"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>({" abc"_b}));
+        CHECK_EQ(RegExp("123"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b), Vector<Bytes>());
 
-        CHECK_THROWS_WITH_AS(RegExp(std::vector<std::string>({"abc", "123"})).matchGroups("abc"_b),
-                             "cannot capture groups during set matching", const NotSupported&);
+        CHECK_THROWS_WITH_AS(RegExp({"abc"_p, "123"_p}).matchGroups("abc"_b), "cannot capture groups during set matching",
+                             const NotSupported&);
 
-        CHECK_EQ(RegExp(".*(a)bc", regexp::Flags{.use_std = 1}).matchGroups(" abc "_b),
+        CHECK_EQ(RegExp(".*(a)bc"_p, regexp::Flags{.use_std = 1}).matchGroups(" abc "_b),
                  Vector<Bytes>({" abc"_b, "a"_b}));
 
-        CHECK_EQ(RegExp("a(b*)c(d.f)g", regexp::Flags{.use_std = 1}).matchGroups("xyz"_b), Vector<Bytes>());
-        CHECK_EQ(RegExp("a(b*)c(d.f)g", regexp::Flags{.use_std = 1}).matchGroups("abbbcdefg"_b),
+        CHECK_EQ(RegExp("a(b*)c(d.f)g"_p, regexp::Flags{.use_std = 1}).matchGroups("xyz"_b), Vector<Bytes>());
+        CHECK_EQ(RegExp("a(b*)c(d.f)g"_p, regexp::Flags{.use_std = 1}).matchGroups("abbbcdefg"_b),
                  Vector<Bytes>({"abbbcdefg"_b, "bbb"_b, "def"_b}));
-        CHECK_EQ(RegExp(".*a(b*)c(d.f)g", regexp::Flags{.use_std = 1}).matchGroups("012abbbcdefg345"_b),
+        CHECK_EQ(RegExp(".*a(b*)c(d.f)g"_p, regexp::Flags{.use_std = 1}).matchGroups("012abbbcdefg345"_b),
                  Vector<Bytes>({"012abbbcdefg"_b, "bbb"_b, "def"_b}));
     }
 }
 
 TEST_CASE("binary data") {
-    CHECK_GT(RegExp("\xf0\xfe\xff").match("\xf0\xfe\xff"_b), 0);    // Pass in raw data directly.
-    CHECK_GT(RegExp("\\xF0\\xFe\\xff").match("\xf0\xfe\xff"_b), 0); // Let the ctor unescape
+    CHECK_GT(RegExp("\xf0\xfe\xff"_p).match("\xf0\xfe\xff"_b), 0);    // Pass in raw data directly.
+    CHECK_GT(RegExp("\\xF0\\xFe\\xff"_p).match("\xf0\xfe\xff"_b), 0); // Let the ctor unescape
 
-    auto x = RegExp("[\\x7F\\x80]*").find("\x7f\x80\x7f\x80$$$"_b);
+    auto x = RegExp("[\\x7F\\x80]*"_p).find("\x7f\x80\x7f\x80$$$"_b);
     CHECK_GT(std::get<0>(x), 0);
     CHECK_EQ(std::get<1>(x).size(), 4); // check for expected length of match
 
-    x = RegExp("abc\\x00def").find("$$abc\000def%%"_b);
+    x = RegExp("abc\\x00def"_p).find("$$abc\000def%%"_b);
     CHECK_GT(std::get<0>(x), 0);
     CHECK_EQ(std::get<1>(x).size(), 7); // check for expected length of match
 
     // Try escaped data & pattern, which will be matched literally as ASCII characters.
-    CHECK_GT(RegExp("\\\\xFF\\\\xFF").match("\\xFF\\xFF"_b), 0);
+    CHECK_GT(RegExp("\\\\xFF\\\\xFF"_p).match("\\xFF\\xFF"_b), 0);
 }
 
 TEST_SUITE_END();
@@ -214,15 +208,14 @@ TEST_CASE("construct") {
 
 TEST_CASE("advance") {
     SUBCASE("matching semantics") {
-        CHECK_EQ(RegExp("123").tokenMatcher().advance("123"_b, false), std::make_tuple(1, 3));
-        CHECK_EQ(RegExp("123").tokenMatcher().advance("123"_b, true), std::make_tuple(1, 3));
+        CHECK_EQ(RegExp("123"_p).tokenMatcher().advance("123"_b, false), std::make_tuple(1, 3));
+        CHECK_EQ(RegExp("123"_p).tokenMatcher().advance("123"_b, true), std::make_tuple(1, 3));
 
-        CHECK_EQ(RegExp(std::vector<std::string>({"abc", "123"})).tokenMatcher().advance("123"_b, true),
-                 std::make_tuple(2, 3));
+        CHECK_EQ(RegExp({"abc"_p, "123"_p}).tokenMatcher().advance("123"_b, true), std::make_tuple(2, 3));
 
-        CHECK_EQ(RegExp("").tokenMatcher().advance("123"_b, false), std::make_tuple(1, 0));
+        CHECK_EQ(RegExp(""_p).tokenMatcher().advance("123"_b, false), std::make_tuple(1, 0));
 
-        auto re = RegExp("123").tokenMatcher();
+        auto re = RegExp("123"_p).tokenMatcher();
         REQUIRE_EQ(re.advance(""_b, true), std::make_tuple(0, 0));
         CHECK_THROWS_WITH_AS(re.advance("123"_b, true), "matching already complete", const MatchStateReuse&);
 
@@ -231,8 +224,8 @@ TEST_CASE("advance") {
         CHECK_THROWS_WITH_AS(regexp::MatchState().advance(Stream("123"_b).view()),
                              "no regular expression associated with match state", const PatternError&);
 
-        const auto re_std = RegExp("a(b+)c(d.f)g", regexp::Flags{.use_std = true});
-        const auto re_no_sub = RegExp("a(b+)c(d.f)g", regexp::Flags{.no_sub = true});
+        const auto re_std = RegExp("a(b+)c(d.f)g"_p, regexp::Flags{.use_std = true});
+        const auto re_no_sub = RegExp("a(b+)c(d.f)g"_p, regexp::Flags{.no_sub = true});
 
         {
             auto ms_std_1 = re_std.tokenMatcher();
@@ -267,17 +260,17 @@ TEST_CASE("advance") {
         }
 
         // Check that patterns stop when current match cannot be possible expanded anymore.
-        auto http_re_std = RegExp("[ \\t]+", regexp::Flags{.use_std = true});
+        auto http_re_std = RegExp("[ \\t]+"_p, regexp::Flags{.use_std = true});
         auto http_ms_std = http_re_std.tokenMatcher();
         CHECK_EQ(http_ms_std.advance(" /post HTTP/1.1"_b, false), std::make_tuple(1, 1));
 
-        auto http_re_std_sub = RegExp("[ \\t]+", regexp::Flags{.no_sub = true});
+        auto http_re_std_sub = RegExp("[ \\t]+"_p, regexp::Flags{.no_sub = true});
         auto http_ms_std_sub = http_re_std_sub.tokenMatcher();
         CHECK_EQ(http_ms_std_sub.advance(" /post HTTP/1.1"_b, false), std::make_tuple(1, 1));
     }
 
     SUBCASE("on set") {
-        const auto patterns = std::vector<std::string>({"a(b+cx){#10}", "a(b+cy){#20}"});
+        const auto patterns = regexp::Patterns({{"a(b+cx){#10}"}, {"a(b+cy){#20}"}});
         const auto re_std = RegExp(patterns, regexp::Flags{.use_std = true});
         const auto re_no_sub = RegExp(patterns, regexp::Flags{.no_sub = true});
 
@@ -320,7 +313,7 @@ TEST_CASE("advance") {
 
         SUBCASE("match until limit") {
             // Match a regexp ending in a wildcard so it could match the entire input.
-            const auto x = RegExp("123.*").tokenMatcher().advance(limited);
+            const auto x = RegExp("123.*"_p).tokenMatcher().advance(limited);
             const auto& rc = std::get<0>(x);
             const auto& unconsumed = std::get<1>(x);
 
@@ -331,7 +324,7 @@ TEST_CASE("advance") {
 
         SUBCASE("no match in limit") {
             // Match a regexp matching the input, but not the passed, limited view.
-            const auto x = RegExp(input.data()).tokenMatcher().advance(limited);
+            const auto x = RegExp({input.data()}).tokenMatcher().advance(limited);
             const auto& rc = std::get<0>(x);
 
             CHECK_EQ(rc, -1); // No match found yet in available, limited data.
@@ -349,11 +342,11 @@ TEST_CASE("advance") {
         s.freeze();
         REQUIRE_EQ(s.numberOfChunks(), 2);
 
-        CHECK_EQ(RegExp("[ \\n]*", {}).tokenMatcher().advance(s.view()), std::make_tuple(1, stream::View()));
+        CHECK_EQ(RegExp("[ \\n]*"_p, {}).tokenMatcher().advance(s.view()), std::make_tuple(1, stream::View()));
     }
 
     SUBCASE("advance with backtracking across chunks of input") {
-        const auto re_std = RegExp("abc(123)?", regexp::Flags{.use_std = true});
+        const auto re_std = RegExp("abc(123)?"_p, regexp::Flags{.use_std = true});
         auto ms_std_1 = re_std.tokenMatcher();
         CHECK_EQ(ms_std_1.advance("a"_b, false), std::make_tuple(-1, 1));
         CHECK_EQ(ms_std_1.advance("b"_b, false), std::make_tuple(-1, 1));
@@ -371,7 +364,7 @@ TEST_CASE("advance") {
         s.append("BC");
         s.freeze();
 
-        const auto re = RegExp("(A|B|C)");
+        const auto re = RegExp("(A|B|C)"_p);
 
         auto cur = s.view();
 
@@ -403,7 +396,7 @@ TEST_CASE("advance") {
 
 TEST_CASE("reassign") {
     SUBCASE("inherits state") {
-        const auto re = RegExp("123");
+        const auto re = RegExp("123"_p);
 
         // Create and complete a matcher.
         auto ms1 = re.tokenMatcher();
@@ -426,7 +419,7 @@ TEST_CASE("reassign") {
     }
 
     SUBCASE("no copy from REG_STD_MATCHER regexp") {
-        const auto re = RegExp("123", regexp::Flags({.no_sub = false}));
+        const auto re = RegExp("123"_p, regexp::Flags({.no_sub = false}));
         const auto ms1 = re.tokenMatcher();
 
         CHECK_THROWS_WITH_AS(regexp::MatchState{ms1}, "cannot copy match state of regexp with sub-expressions support",
@@ -438,7 +431,7 @@ TEST_CASE("reassign") {
     }
 
     SUBCASE("copy from non-REG_STD_MATCHER regexp") {
-        const auto re = RegExp("123", regexp::Flags({.no_sub = true}));
+        const auto re = RegExp("123"_p, regexp::Flags({.no_sub = true}));
         const auto ms1 = re.tokenMatcher();
 
         CHECK_NOTHROW(regexp::MatchState{ms1});
@@ -451,12 +444,12 @@ TEST_CASE("reassign") {
 TEST_CASE("caching") {
     const auto emptya = RegExp();
     const auto emptyb = RegExp();
-    const auto re1a = RegExp("123");
-    const auto re1b = RegExp("123");
-    const auto re2a = RegExp(std::vector<std::string>{"123", "456"}, {.no_sub = true});
-    const auto re2b = RegExp(std::vector<std::string>{"123", "456"}, {.no_sub = true});
-    const auto re3 = RegExp("123", {.no_sub = true});
-    const auto re4 = RegExp(std::vector<std::string>{"123", "456"}, {.no_sub = false});
+    const auto re1a = RegExp("123"_p);
+    const auto re1b = RegExp("123"_p);
+    const auto re2a = RegExp({"123"_p, "456"_p}, {.no_sub = true});
+    const auto re2b = RegExp({"123"_p, "456"_p}, {.no_sub = true});
+    const auto re3 = RegExp("123"_p, {.no_sub = true});
+    const auto re4 = RegExp({"123"_p, "456"_p}, {.no_sub = false});
 
     CHECK_EQ(emptya.jrx(), emptyb.jrx());
     CHECK_EQ(re1a.jrx(), re1b.jrx());

--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -270,7 +270,7 @@ TEST_CASE("advance") {
     }
 
     SUBCASE("on set") {
-        const auto patterns = regexp::Patterns({{"a(b+cx)", 10}, {"a(b+cy)", 20}});
+        const auto patterns = regexp::Patterns({{"a(b+cx)", false, 10}, {"a(b+cy)", false, 20}});
         const auto re_std = RegExp(patterns, regexp::Flags{.use_std = true});
         const auto re_no_sub = RegExp(patterns, regexp::Flags{.no_sub = true});
 

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -27,6 +27,8 @@
 
 using namespace hilti::rt;
 
+inline auto operator ""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
+
 TEST_SUITE_BEGIN("to_string");
 
 TEST_CASE("any") { CHECK_EQ(to_string(hilti::rt::any()), "<any value>"); }
@@ -245,17 +247,17 @@ TEST_CASE("real::Type") {
 
 TEST_CASE("RegExp") {
     CHECK_EQ(to_string(RegExp()), "<regexp w/o pattern>");
-    CHECK_EQ(to_string(RegExp("a", regexp::Flags())), "/a/");
-    CHECK_EQ(to_string(RegExp("a", regexp::Flags({.no_sub = 1}))), "/a/ &nosub");
-    CHECK_EQ(to_string(RegExp(std::vector<std::string>({"a"}), regexp::Flags())), "/a/");
-    CHECK_EQ(to_string(RegExp(std::vector<std::string>({"a", "b"}), regexp::Flags())), "/a/ | /b/");
+    CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags())), "/a/");
+    CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags({.no_sub = 1}))), "/a/ &nosub");
+    CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags())), "/a/");
+    CHECK_EQ(to_string(RegExp({{"a"}, {"b"}}, regexp::Flags())), "/a/ | /b/");
 
-    CHECK_EQ(to_string(RegExp("/", regexp::Flags())), "///");
+    CHECK_EQ(to_string(RegExp({"/"}, regexp::Flags())), "///");
 
-    CHECK_EQ(to_string(RegExp("", regexp::Flags()).tokenMatcher()), "<regexp-match-state>");
+    CHECK_EQ(to_string(RegExp({""}, regexp::Flags()).tokenMatcher()), "<regexp-match-state>");
 
     std::stringstream x;
-    x << RegExp("X");
+    x << RegExp({"X"});
     CHECK_EQ(x.str(), "/X/");
 }
 

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -27,7 +27,7 @@
 
 using namespace hilti::rt;
 
-inline auto operator ""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
+inline auto operator""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
 
 TEST_SUITE_BEGIN("to_string");
 
@@ -250,7 +250,7 @@ TEST_CASE("RegExp") {
     CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags())), "/a/");
     CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags({.no_sub = 1}))), "/a/ &nosub");
     CHECK_EQ(to_string(RegExp({"a"}, regexp::Flags())), "/a/");
-    CHECK_EQ(to_string(RegExp({{"a"}, {"b"}}, regexp::Flags())), "/a/ | /b/");
+    CHECK_EQ(to_string(RegExp({regexp::Pattern{"a"}, regexp::Pattern{"b"}}, regexp::Flags())), "/a/ | /b/");
 
     CHECK_EQ(to_string(RegExp({"/"}, regexp::Flags())), "///");
 

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -257,9 +257,10 @@ void regexp::detail::CompiledRegExp::_newJrx() {
 void regexp::detail::CompiledRegExp::_compileOne(regexp::Pattern pattern, int idx) {
     auto regexp = pattern.value();
 
+    int cflags = (pattern.isCaseInsensitive() ? REG_ICASE : 0);
     auto id = static_cast<jrx_accept_id>(pattern.matchID());
 
-    if ( auto rc = jrx_regset_add2(_jrx.get(), regexp.c_str(), regexp.size(), 0, id); rc != REG_OK ) {
+    if ( auto rc = jrx_regset_add2(_jrx.get(), regexp.c_str(), regexp.size(), cflags, id); rc != REG_OK ) {
         static char err[256];
         jrx_regerror(rc, _jrx.get(), err, sizeof(err));
         throw PatternError(fmt("error compiling pattern '%s': %s", pattern, err));

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -255,7 +255,11 @@ void regexp::detail::CompiledRegExp::_newJrx() {
 }
 
 void regexp::detail::CompiledRegExp::_compileOne(regexp::Pattern pattern, int idx) {
-    if ( auto rc = jrx_regset_add(_jrx.get(), pattern.value().c_str(), pattern.value().size()); rc != REG_OK ) {
+    auto regexp = pattern.value();
+
+    auto id = static_cast<jrx_accept_id>(pattern.matchID());
+
+    if ( auto rc = jrx_regset_add2(_jrx.get(), regexp.c_str(), regexp.size(), 0, id); rc != REG_OK ) {
         static char err[256];
         jrx_regerror(rc, _jrx.get(), err, sizeof(err));
         throw PatternError(fmt("error compiling pattern '%s': %s", pattern, err));

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -225,7 +225,7 @@ void regexp::detail::CompiledRegExp::RegFree::operator()(jrx_regex_t* j) {
     delete j;
 }
 
-regexp::detail::CompiledRegExp::CompiledRegExp(const std::vector<std::string>& patterns, regexp::Flags flags)
+regexp::detail::CompiledRegExp::CompiledRegExp(const regexp::Patterns& patterns, regexp::Flags flags)
     : _flags(flags), _patterns(patterns) {
     _newJrx();
 
@@ -254,8 +254,8 @@ void regexp::detail::CompiledRegExp::_newJrx() {
     jrx_regset_init(_jrx.get(), -1, cflags);
 }
 
-void regexp::detail::CompiledRegExp::_compileOne(std::string pattern, int idx) {
-    if ( auto rc = jrx_regset_add(_jrx.get(), pattern.c_str(), pattern.size()); rc != REG_OK ) {
+void regexp::detail::CompiledRegExp::_compileOne(regexp::Pattern pattern, int idx) {
+    if ( auto rc = jrx_regset_add(_jrx.get(), pattern.value().c_str(), pattern.value().size()); rc != REG_OK ) {
         static char err[256];
         jrx_regerror(rc, _jrx.get(), err, sizeof(err));
         throw PatternError(fmt("error compiling pattern '%s': %s", pattern, err));
@@ -264,8 +264,10 @@ void regexp::detail::CompiledRegExp::_compileOne(std::string pattern, int idx) {
     _patterns.push_back(std::move(pattern));
 }
 
-RegExp::RegExp(const std::vector<std::string>& patterns, regexp::Flags flags) {
-    const auto& key = (patterns.empty() ? std::string() : join(patterns, "|") + "|" + flags.cacheKey());
+RegExp::RegExp(const regexp::Patterns& patterns, regexp::Flags flags) {
+    const auto& key = (patterns.empty() ? std::string() :
+                                          join(transform(patterns, [](const auto& p) { return to_string(p); }), "|") +
+                                              "|" + flags.cacheKey());
     auto& ptr = detail::globalState()->regexp_cache[key];
 
     if ( ! ptr )
@@ -274,10 +276,9 @@ RegExp::RegExp(const std::vector<std::string>& patterns, regexp::Flags flags) {
     _re = ptr;
 }
 
-RegExp::RegExp(std::string pattern, regexp::Flags flags)
-    : RegExp(std::vector<std::string>{std::move(pattern)}, flags) {}
+RegExp::RegExp(regexp::Pattern pattern, regexp::Flags flags) : RegExp(regexp::Patterns{{std::move(pattern)}}, flags) {}
 
-RegExp::RegExp() : RegExp(std::vector<std::string>{}, regexp::Flags{}) {}
+RegExp::RegExp() : RegExp(regexp::Patterns{}, regexp::Flags{}) {}
 
 int32_t RegExp::match(const Bytes& data) const {
     jrx_match_state ms;
@@ -435,8 +436,7 @@ std::string hilti::rt::detail::adl::to_string(const RegExp& x, adl::tag /*unused
     if ( x.patterns().empty() )
         return "<regexp w/o pattern>";
 
-    auto p = join(transform(x.patterns(), [&](const auto& s) { return fmt("/%s/", s); }), " | ");
-
+    auto p = join(transform(x.patterns(), [&](const auto& s) { return to_string(s); }), " | ");
     auto f = std::vector<std::string>();
 
     if ( x.flags().no_sub )

--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -246,7 +246,7 @@ public:
         return expressionCtor(ctorRegExp({std::move(p)}, attrs, m), m);
     }
 
-    auto regexp(std::vector<std::string> p, AttributeSet* attrs = {}, const Meta& m = Meta()) {
+    auto regexp(hilti::ctor::regexp::Patterns p, AttributeSet* attrs = {}, const Meta& m = Meta()) {
         return expressionCtor(ctorRegExp(std::move(p), attrs, m), m);
     }
 

--- a/hilti/toolchain/include/ast/builder/node-factory.h
+++ b/hilti/toolchain/include/ast/builder/node-factory.h
@@ -100,7 +100,7 @@ public:
     }
     auto ctorPort(hilti::rt::Port v, const Meta& meta = {}) { return hilti::ctor::Port::create(context(), v, meta); }
     auto ctorReal(double v, const Meta& meta = {}) { return hilti::ctor::Real::create(context(), v, meta); }
-    auto ctorRegExp(std::vector<std::string> v, AttributeSet* attrs = nullptr, const Meta& meta = {}) {
+    auto ctorRegExp(hilti::ctor::regexp::Patterns v, AttributeSet* attrs = nullptr, const Meta& meta = {}) {
         return hilti::ctor::RegExp::create(context(), std::move(v), attrs, meta);
     }
     auto ctorResult(Expression* expr, const Meta& meta = {}) {

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -187,15 +187,17 @@ struct Visitor : hilti::visitor::PreOrder {
         if ( n->isNoSub() )
             flags.emplace_back(".no_sub = true");
 
-        result = fmt("::hilti::rt::RegExp({%s}, {%s})",
-                     util::join(util::transform(n->patterns(),
-                                                [&](const auto& p) {
-                                                    return fmt("hilti::rt::regexp::Pattern{\"%s\"}",
-                                                               util::escapeUTF8(p.value(), hilti::rt::render_style::
-                                                                                               UTF8::EscapeQuotes));
-                                                }),
-                                ", "),
-                     util::join(flags, ", "));
+        result =
+            fmt("::hilti::rt::RegExp({%s}, {%s})",
+                util::join(util::transform(n->patterns(),
+                                           [&](const auto& p) {
+                                               return fmt("hilti::rt::regexp::Pattern{\"%s\", %s}",
+                                                          util::escapeUTF8(p.value(),
+                                                                           hilti::rt::render_style::UTF8::EscapeQuotes),
+                                                          p.matchID());
+                                           }),
+                           ", "),
+                util::join(flags, ", "));
     }
 
     void operator()(ctor::Set* n) final {

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -191,10 +191,10 @@ struct Visitor : hilti::visitor::PreOrder {
             fmt("::hilti::rt::RegExp({%s}, {%s})",
                 util::join(util::transform(n->patterns(),
                                            [&](const auto& p) {
-                                               return fmt("hilti::rt::regexp::Pattern{\"%s\", %s}",
+                                               return fmt("hilti::rt::regexp::Pattern{\"%s\", %s, %s}",
                                                           util::escapeUTF8(p.value(),
                                                                            hilti::rt::render_style::UTF8::EscapeQuotes),
-                                                          p.matchID());
+                                                          (p.isCaseInsensitive() ? "true" : "false"), p.matchID());
                                            }),
                            ", "),
                 util::join(flags, ", "));

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -187,12 +187,12 @@ struct Visitor : hilti::visitor::PreOrder {
         if ( n->isNoSub() )
             flags.emplace_back(".no_sub = true");
 
-        auto t = (n->value().size() == 1 ? "std::string" : "std::vector<std::string>");
-        result = fmt("::hilti::rt::RegExp(%s{%s}, {%s})", t,
-                     util::join(util::transform(n->value(),
-                                                [&](const auto& s) {
-                                                    return fmt("\"%s\"", util::escapeUTF8(s, hilti::rt::render_style::
-                                                                                                 UTF8::EscapeQuotes));
+        result = fmt("::hilti::rt::RegExp({%s}, {%s})",
+                     util::join(util::transform(n->patterns(),
+                                                [&](const auto& p) {
+                                                    return fmt("hilti::rt::regexp::Pattern{\"%s\"}",
+                                                               util::escapeUTF8(p.value(), hilti::rt::render_style::
+                                                                                               UTF8::EscapeQuotes));
                                                 }),
                                 ", "),
                      util::join(flags, ", "));

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -952,7 +952,15 @@ re_pattern_constant
                                                  }
 
 opt_re_pattern_constant_flags
-              : '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
+              : local_id opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $2;
+                                                   if ( $1 == ID("i") )
+                                                       $$.setCaseInsensitive(true);
+                                                   else
+                                                       error(@$, "unknown regular expression flag");
+                                                 }
+              | '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
                                                  {
                                                    $$ = $5;
                                                    $$.setMatchID($3);

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -243,7 +243,7 @@ static int _field_width = 0;
 %token WEAK_REF "weak_ref"
 %token YIELD "yield"
 
-%type <hilti::ID>                               local_id scoped_id dotted_id function_id scoped_function_id
+%type <hilti::ID>                             local_id scoped_id dotted_id function_id scoped_function_id
 %type <hilti::Declaration*>                   local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl struct_field union_field
 %type <hilti::Declarations>                     struct_fields union_fields opt_union_fields
 %type <hilti::UnqualifiedType*>               base_type_no_attrs base_type type function_type tuple_type struct_type enum_type union_type func_param_type bitfield_type
@@ -273,7 +273,7 @@ static int _field_width = 0;
 %type <hilti::type::bitfield::BitRanges>        bitfield_bit_ranges opt_bitfield_bit_ranges
 %type <hilti::type::bitfield::BitRange*>      bitfield_bit_range
 %type <hilti::ctor::regexp::Patterns> re_patterns
-%type <hilti::ctor::regexp::Pattern>        re_pattern_constant
+%type <hilti::ctor::regexp::Pattern>        re_pattern_constant opt_re_pattern_constant_flags
 %type <hilti::statement::switch_::Case*>      switch_case
 %type <hilti::statement::switch_::Cases>        switch_cases opt_switch_cases
 %type <hilti::statement::try_::Catch*>        try_catch
@@ -945,8 +945,19 @@ re_patterns   : re_patterns '|' re_pattern_constant
               | re_pattern_constant              { $$ = hilti::ctor::regexp::Patterns{std::move($1)}; }
 
 re_pattern_constant
-              : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/'
-                                                 { $$ = std::move($3); }
+              : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/' opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $6;
+                                                   $$.setValue($3);
+                                                 }
+
+opt_re_pattern_constant_flags
+              : '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $5;
+                                                   $$.setMatchID($3);
+                                                 }
+              | /* empty */                      { $$ = {}; }
 
 opt_map_elems : map_elems                        { $$ = std::move($1); }
               | /* empty */                      { $$ = hilti::ctor::map::Elements(); }

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -272,8 +272,8 @@ static int _field_width = 0;
 %type <hilti::type::enum_::Labels>              enum_labels
 %type <hilti::type::bitfield::BitRanges>        bitfield_bit_ranges opt_bitfield_bit_ranges
 %type <hilti::type::bitfield::BitRange*>      bitfield_bit_range
-%type <std::vector<std::string>>                re_patterns
-%type <std::string>                             re_pattern_constant
+%type <hilti::ctor::regexp::Patterns> re_patterns
+%type <hilti::ctor::regexp::Pattern>        re_pattern_constant
 %type <hilti::statement::switch_::Case*>      switch_case
 %type <hilti::statement::switch_::Cases>        switch_cases opt_switch_cases
 %type <hilti::statement::try_::Catch*>        try_catch
@@ -938,11 +938,11 @@ struct_elems  : struct_elems ',' struct_elem     { $$ = std::move($1); $$.push_b
 
 struct_elem   : '$' local_id  '=' expr           { $$ = builder->ctorStructField(std::move($2), std::move($4)); }
 
-regexp        : re_patterns opt_attributes      { $$ = builder->ctorRegExp(std::move($1), std::move($2), __loc__); }
+regexp        : re_patterns opt_attributes       { $$ = builder->ctorRegExp(std::move($1), std::move($2), __loc__); }
 
 re_patterns   : re_patterns '|' re_pattern_constant
                                                  { $$ = $1; $$.push_back(std::move($3)); }
-              | re_pattern_constant              { $$ = std::vector<std::string>{std::move($1)}; }
+              | re_pattern_constant              { $$ = hilti::ctor::regexp::Patterns{std::move($1)}; }
 
 re_pattern_constant
               : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/'

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -250,7 +250,7 @@ struct Printer : visitor::PreOrder {
     void operator()(ctor::StrongReference* n) final { _out << "Null"; }
 
     void operator()(ctor::RegExp* n) final {
-        _out << std::make_pair(util::transform(n->value(), [](const auto& p) { return fmt("/%s/", p); }), " |");
+        _out << std::make_pair(util::transform(n->patterns(), [](const auto& p) { return to_string(p); }), " |");
 
         if ( auto* attrs = n->attributes(); *attrs )
             _out << ' ' << std::make_pair(attrs->attributes(), " ");

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -250,7 +250,7 @@ struct Printer : visitor::PreOrder {
     void operator()(ctor::StrongReference* n) final { _out << "Null"; }
 
     void operator()(ctor::RegExp* n) final {
-        _out << std::make_pair(util::transform(n->patterns(), [](const auto& p) { return to_string(p); }), " |");
+        _out << std::make_pair(util::transform(n->patterns(), [](const auto& p) { return to_string(p); }), " | ");
 
         if ( auto* attrs = n->attributes(); *attrs )
             _out << ' ' << std::make_pair(attrs->attributes(), " ");

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -977,7 +977,7 @@ struct ProductionVisitor : public production::Visitor {
 
         // Store the regexp as a global constant to avoid recomputing the
         // regexp on each runtime pass through the calling context.
-        auto re = pb->cg()->addGlobalConstant(builder()->ctorRegExp(c->value()));
+        auto re = pb->cg()->addGlobalConstant(builder()->ctorRegExp(c->patterns()));
 
         auto ncur = builder()->addTmp("ncur", state().cur);
         auto ms = builder()->local("ms", builder()->memberCall(re, "token_matcher"));
@@ -1083,15 +1083,15 @@ struct ProductionVisitor : public production::Visitor {
                     return std::make_pair(c->template as<production::Ctor>()
                                               ->ctor()
                                               ->template as<hilti::ctor::RegExp>()
-                                              ->value(),
+                                              ->patterns(),
                                           c->tokenID());
                 });
 
-                auto flattened = std::vector<std::string>();
+                auto flattened = hilti::ctor::regexp::Patterns();
 
                 for ( const auto& p : patterns ) {
                     for ( const auto& r : p.first )
-                        flattened.push_back(hilti::util::fmt("%s{#%" PRId64 "}", r, p.second));
+                        flattened.emplace_back(hilti::util::fmt("%s{#%" PRId64 "}", r.value(), p.second));
                 }
 
                 auto re = pb->cg()->addGlobalConstant(

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -1091,7 +1091,7 @@ struct ProductionVisitor : public production::Visitor {
 
                 for ( const auto& p : patterns ) {
                     for ( const auto& r : p.first )
-                        flattened.emplace_back(hilti::util::fmt("%s{#%" PRId64 "}", r.value(), p.second));
+                        flattened.emplace_back(r.value(), p.second);
                 }
 
                 auto re = pb->cg()->addGlobalConstant(

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -1091,7 +1091,7 @@ struct ProductionVisitor : public production::Visitor {
 
                 for ( const auto& p : patterns ) {
                     for ( const auto& r : p.first )
-                        flattened.emplace_back(r.value(), p.second);
+                        flattened.emplace_back(r.value(), r.isCaseInsensitive(), p.second);
                 }
 
                 auto re = pb->cg()->addGlobalConstant(

--- a/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
@@ -146,7 +146,7 @@ struct Visitor : public visitor::PreOrder {
         if ( ! state().captures )
             attrs->add(context(), builder()->attribute(hilti::attribute::Kind::Nosub));
 
-        auto re = pb()->cg()->addGlobalConstant(builder()->ctorRegExp(n->value(), attrs));
+        auto re = pb()->cg()->addGlobalConstant(builder()->ctorRegExp(n->patterns(), attrs));
 
         auto parse = [&](Expression* result, bool trim) -> Expression* {
             if ( ! result && state().literal_mode != LiteralMode::Skip )

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -300,7 +300,7 @@ static std::vector<hilti::DocString> _docs;
 %type <hilti::type::bitfield::BitRanges>    bitfield_bit_ranges opt_bitfield_bit_ranges
 %type <hilti::type::bitfield::BitRange*>  bitfield_bit_range
 %type <hilti::ctor::regexp::Patterns> re_patterns
-%type <hilti::ctor::regexp::Pattern>        re_pattern_constant
+%type <hilti::ctor::regexp::Pattern>        re_pattern_constant opt_re_pattern_constant_flags
 %type <hilti::statement::switch_::Case*>  switch_case
 %type <hilti::statement::switch_::Cases>    switch_cases
 
@@ -1183,8 +1183,19 @@ re_patterns   : re_patterns '|' re_pattern_constant
               | re_pattern_constant              { $$ = hilti::ctor::regexp::Patterns{std::move($1)}; }
 
 re_pattern_constant
-              : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/'
-                                                 { $$ = std::move($3); }
+              : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/' opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $6;
+                                                   $$.setValue($3);
+                                                 }
+
+opt_re_pattern_constant_flags
+              : '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $5;
+                                                   $$.setMatchID($3);
+                                                 }
+              | /* empty */                      { $$ = {}; }
 
 opt_map_elems : map_elems                        { $$ = std::move($1); }
               | /* empty */                      { $$ = hilti::ctor::map::Elements(); }

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -299,8 +299,8 @@ static std::vector<hilti::DocString> _docs;
 %type <hilti::type::enum_::Labels>          enum_labels
 %type <hilti::type::bitfield::BitRanges>    bitfield_bit_ranges opt_bitfield_bit_ranges
 %type <hilti::type::bitfield::BitRange*>  bitfield_bit_range
-%type <std::vector<std::string>>            re_patterns
-%type <std::string>                         re_pattern_constant
+%type <hilti::ctor::regexp::Patterns> re_patterns
+%type <hilti::ctor::regexp::Pattern>        re_pattern_constant
 %type <hilti::statement::switch_::Case*>  switch_case
 %type <hilti::statement::switch_::Cases>    switch_cases
 
@@ -1180,7 +1180,7 @@ regexp        : re_patterns                      { $$ = builder->ctorRegExp(std:
 
 re_patterns   : re_patterns '|' re_pattern_constant
                                                  { $$ = $1; $$.push_back(std::move($3)); }
-              | re_pattern_constant              { $$ = std::vector<std::string>{std::move($1)}; }
+              | re_pattern_constant              { $$ = hilti::ctor::regexp::Patterns{std::move($1)}; }
 
 re_pattern_constant
               : '/' { driver->enablePatternMode(); } CREGEXP { driver->disablePatternMode(); } '/'

--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -1190,7 +1190,15 @@ re_pattern_constant
                                                  }
 
 opt_re_pattern_constant_flags
-              : '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
+              : local_id opt_re_pattern_constant_flags
+                                                 {
+                                                   $$ = $2;
+                                                   if ( $1 == ID("i") )
+                                                       $$.setCaseInsensitive(true);
+                                                   else
+                                                       error(@$, "unknown regular expression flag");
+                                                 }
+              | '$' '(' CUINTEGER ')' opt_re_pattern_constant_flags
                                                  {
                                                    $$ = $5;
                                                    $$.setMatchID($3);

--- a/tests/Baseline/spicy.types.unit.switch-lahead-regexp-incremental/output
+++ b/tests/Baseline/spicy.types.unit.switch-lahead-regexp-incremental/output
@@ -3,3 +3,4 @@ A, xaaa, Foo
 B, xaaaX, Bar
 A, xaaa, Foo
 B, xaaaX, Bar
+B, xaaax, Bar

--- a/tests/hilti/codegen/type-info.hlt
+++ b/tests/hilti/codegen/type-info.hlt
@@ -378,7 +378,7 @@ struct VisitorTypesInit {
             }
             case TypeInfo::RegExp: {
                 SEEN();
-                auto x = RegExp("foo");
+                auto x = RegExp({"foo"});
                 CHECK(type.regexp->get(v) == x);
                 break;
             }

--- a/tests/hilti/types/regexp/case-insensitive.hlt
+++ b/tests/hilti/types/regexp/case-insensitive.hlt
@@ -1,0 +1,41 @@
+# @TEST-EXEC: hiltic -j %INPUT
+
+module Foo {
+
+import hilti;
+
+global regexp re1_ci = /ghi/i;
+global regexp re1_cs = /ghi/;
+
+assert re1_ci.match(b"GHI") == 1;
+assert re1_ci.match(b"gHi") == 1;
+assert re1_ci.match(b"ghi") == 1;
+
+assert re1_cs.match(b"GHI") == 0;
+assert re1_cs.match(b"gHi") == 0;
+assert re1_ci.match(b"ghi") == 1;
+
+##
+
+global auto re2 = /Fo*o/ | /Ba*r/i | /Hu*rz/;
+
+assert re2.match(b"foo") == 0;
+assert re2.match(b"Foo") > 0;
+
+assert re2.match(b"bar") > 0;
+assert re2.match(b"Bar") > 0;
+
+assert re2.match(b"hurz") == 0;
+assert re2.match(b"Hurz") > 0;
+
+##
+
+global auto re3 = /Fo*o/$(100) | /Ba*r/i$(200) | /Hu*rz/;
+
+assert re3.match(b"foo") == 0;
+assert re3.match(b"Foo") == 100;
+assert re3.match(b"bar") == 200;
+assert re3.match(b"Bar") == 200;
+assert re3.match(b"Hurz") > 0;
+assert re3.match(b"hurz") == 0;
+}

--- a/tests/hilti/types/regexp/incremental-spicy-style.hlt
+++ b/tests/hilti/types/regexp/incremental-spicy-style.hlt
@@ -5,7 +5,7 @@ module Foo {
 
 import hilti;
 
-global auto re = /NixMatch{#43}/ | /1234ABCDEFGH*{#42}/ &nosub;
+global auto re = /NixMatch/$(43) | /1234ABCDEFGH*/$(42) &nosub;
 global hilti::MatchState m = re.token_matcher();
 
 global stream data = b"12";

--- a/tests/hilti/types/regexp/set-matching.hlt
+++ b/tests/hilti/types/regexp/set-matching.hlt
@@ -6,7 +6,7 @@ module Foo {
 import hilti;
 
 global auto re1 = /.*Fo*o/ | /.*Ba*r/ | /.*Hu*rz/;
-global auto re2 = /.*Fo*o{#41}/ | /.*Ba*r{#42}/ | /.*Hu*rz{#43}/;
+global auto re2 = /.*Fo*o/$(41) | /.*Ba*r/$(42) | /.*Hu*rz/$(43);
 
 hilti::print(re1.match(b"XXXFooooYYY"));
 hilti::print(re1.match(b"XXXBaaarrYYY"));

--- a/tests/spicy/types/unit/switch-lahead-regexp-incremental.spicy
+++ b/tests/spicy/types/unit/switch-lahead-regexp-incremental.spicy
@@ -3,6 +3,7 @@
 # @TEST-EXEC: echo xaaaXBar | spicy-driver -i 1 %INPUT.hlto >>output
 # @TEST-EXEC: echo xaaaFoo | spicy-driver -i 4 %INPUT.hlto >>output
 # @TEST-EXEC: echo xaaaXBar | spicy-driver -i 4 %INPUT.hlto >>output
+# @TEST-EXEC: echo xaaaxBar | spicy-driver -i 4 %INPUT.hlto >>output
 # @TEST-EXEC: btest-diff output
 
 module Mini;
@@ -14,7 +15,7 @@ type A = unit {
 };
 
 type B = unit {
-    x: /xa+X/;
+    x: /XA+X/i;
     y: /Bar/;
     on %done { print "B", self.x, self.y; }
 };


### PR DESCRIPTION
By adding an `i` flag to a regular expression pattern, it will no w be
matched case-insensitively (e.g. `/foobar/i`).

This goes with https://github.com/rsmmr/justrx/pull/11, if anybody feels like reviewing that one as well.

- **Refactor regexp patterns.**
- **Bump justrx to pull in new API group matching.**
- **Switch regular expressions to new justrx API.**
- **Add support for case-insensitive matching to regular expressions.**
