### PR TITLE
Fix possibly-incorrect custom host compile command

### DIFF
--- a/doc/host-applications.rst
+++ b/doc/host-applications.rst
@@ -142,7 +142,7 @@ expected.
     one through its ``--cxx`` option. You can even put that directly
     into the build command line::
 
-        # $(spicy-config --cxx --cxxflags --ldflags) -o my_http my_http-host.cc my_http___linker__.cc my_http_MyHTTP.cc
+        # $(spicy-config --cxx) -o my_http my_http-host.cc my_http___linker__.cc my_http_MyHTTP.cc $(spicy-config --cxxflags --ldflags)
 
 When using ``parse1()`` we don't get access to the parsed information.
 If we want that, we can use ``parse2()`` instead and provide it with a


### PR DESCRIPTION
The order of `ldflags` compared to the `-o` output/source file matters - linking flags should be after (I think). This took me a while to debug because I haven't seen it before and it worked on my Mac so I was confused. As-is, the documentation fails to compile for me, but with this change, the command succeeds.

Compiler is `c++ (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)`