### PR TITLE
Bring back the internal `__visit` method for generated structs.

### DIFF
--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -367,6 +367,7 @@ std::string cxx::declaration::Global::str() const { return fmtDeclaration(id, ty
 
 std::string cxx::type::Struct::str() const {
     std::vector<std::string> to_string_fields;
+    std::vector<std::string> visitor_calls;
 
     auto fmt_member = [&](const auto& f) {
         if ( auto x = std::get_if<declaration::Local>(&f) ) {
@@ -376,6 +377,11 @@ std::string cxx::type::Struct::str() const {
                     to_string_fields.emplace_back(fmt(R"("$%s=" + hilti::rt::to_string(%s))", id, x->id));
                 }
             }
+
+            if ( x->isAnonymous() )
+                visitor_calls.emplace_back(fmt("_(\"<anon>\", %s); ", x->id));
+            else if ( ! (x->isInternal() || x->linkage == "inline static") ) // Don't visit internal or static fields.
+                visitor_calls.emplace_back(fmt("_(\"%s\", %s); ", x->id, x->id));
 
             // We default initialize any members here that don't have an
             // explicit "init" expression. Those that do will be initialized
@@ -458,6 +464,9 @@ std::string cxx::type::Struct::str() const {
             struct_fields.emplace_back(params_ctor);
         }
     }
+
+    struct_fields.emplace_back(
+        fmt("template<typename F> void __visit(F _) const { %s}", util::join(visitor_calls, "")));
 
     auto struct_fields_as_str =
         util::join(util::transform(struct_fields, [&](const auto& x) { return fmt("    %s", x); }), "\n");

--- a/tests/Baseline/hilti.hiltic.print.globals/output
+++ b/tests/Baseline/hilti.hiltic.print.globals/output
@@ -12,6 +12,7 @@ namespace __hlt::Foo {
     struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string X{};
+        template<typename F> void __visit(F _) const { _("X", X); }
 
         std::string __to_string() const {
             return "["s + "$X=" + hilti::rt::to_string(X) + "]";

--- a/tests/Baseline/hilti.hiltic.print.import/output
+++ b/tests/Baseline/hilti.hiltic.print.import/output
@@ -12,6 +12,7 @@ namespace __hlt::Bar {
     struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string bar{};
+        template<typename F> void __visit(F _) const { _("bar", bar); }
 
         std::string __to_string() const {
             return "["s + "$bar=" + hilti::rt::to_string(bar) + "]";
@@ -55,6 +56,7 @@ namespace __hlt::Foo {
     struct __globals_t;
     struct __globals_t : ::hilti::rt::trait::isStruct, ::hilti::rt::Controllable<__globals_t> {
         std::string foo{};
+        template<typename F> void __visit(F _) const { _("foo", foo); }
 
         std::string __to_string() const {
             return "["s + "$foo=" + hilti::rt::to_string(foo) + "]";


### PR DESCRIPTION
This reverts part of https://github.com/zeek/spicy/commit/cb7336ff8d02a32fc82ec4f1c74f4606e13b8ff0: as it turns out, the Zeek
integration still needs `__visit`. I'd like to solve this differently
on the Zeek side, but have't quite gotten that to work yet. So
reverting this for now so that we don't block.
