### PR TITLE
Simple parser (micro-)benchmarking

### DIFF
--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -99,3 +99,7 @@ target_link_libraries(spicy-rt-tests
                       PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug-objects,spicy-rt-objects>)
 target_link_libraries(spicy-rt-tests PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug,spicy-rt> doctest)
 add_test(NAME spicy-rt-tests COMMAND ${PROJECT_BINARY_DIR}/bin/spicy-rt-tests)
+
+if (${USE_BENCHMARK})
+    add_subdirectory(tests/benchmarks/)
+endif ()

--- a/spicy/runtime/tests/benchmarks/CMakeLists.txt
+++ b/spicy/runtime/tests/benchmarks/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
+
+set(BENCH_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/parsers.spicy")
+set(BENCH_MODULE Benchmark)
+
+list(TRANSFORM BENCH_MODULE PREPEND Benchmark_ OUTPUT_VARIABLE _generated_sources)
+list(TRANSFORM _generated_sources APPEND ".cc" OUTPUT_VARIABLE _generated_sources)
+list(APPEND _generated_sources "Benchmark___linker__.cc")
+
+add_custom_command(
+    OUTPUT ${_generated_sources}
+    COMMAND ${CMAKE_BINARY_DIR}/bin/spicyc -x ${CMAKE_CURRENT_BINARY_DIR}/Benchmark
+            "${BENCH_SOURCES}"
+    DEPENDS spicyc ${BENCH_SOURCES}
+    COMMENT "Generating C++ code for Benchmark")
+
+add_executable(spicy-rt-parsing-benchmark parsing.cc ${_generated_sources})
+target_compile_options(spicy-rt-parsing-benchmark PRIVATE "-Wall")
+target_link_libraries(spicy-rt-parsing-benchmark
+                      PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug,spicy-rt>)
+target_link_libraries(spicy-rt-parsing-benchmark
+                      PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug,hilti-rt>)
+target_link_libraries(spicy-rt-parsing-benchmark PRIVATE benchmark)

--- a/spicy/runtime/tests/benchmarks/parsers.spicy
+++ b/spicy/runtime/tests/benchmarks/parsers.spicy
@@ -1,0 +1,25 @@
+# Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
+
+module Benchmark;
+
+type Inner = unit {
+    b: b"A";
+};
+
+public type UnitVectorSize = unit {
+    length: uint64;
+    inner: Inner[] &size=self.length;
+    end_: b"END";
+};
+
+public type UnitVectorLookahead = unit {
+    length: uint64;
+    inner: Inner[];
+    end_: b"END";
+};
+
+public type Regex = unit {
+    length: uint64;
+    data: /A*/;
+    end_: b"END";
+};

--- a/spicy/runtime/tests/benchmarks/parsing.cc
+++ b/spicy/runtime/tests/benchmarks/parsing.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
+
+#include <benchmark/benchmark.h>
+
+#include <hilti/rt/init.h>
+#include <hilti/rt/logging.h>
+#include <hilti/rt/types/reference.h>
+#include <hilti/rt/types/stream.h>
+#include <hilti/rt/util.h>
+
+#include <spicy/rt/init.h>
+#include <spicy/rt/parsed-unit.h>
+#include <spicy/rt/parser.h>
+
+static std::string bigEndian(std::uint64_t number) {
+    char buffer[8];
+    for ( int i = 0; i < 8; ++i ) {
+        buffer[i] = static_cast<char>((number >> (56 - 8 * i)) & 0xFF);
+    }
+    return std::string(buffer, sizeof(buffer));
+}
+
+static std::string makeInput(std::uint64_t input_size) {
+    return hilti::rt::fmt("%s%sEND", bigEndian(input_size), std::string(input_size, 'A'));
+}
+
+template<class... Args>
+static void benchmarkParser(benchmark::State& state, Args&&... args) {
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    auto parser_name = std::get<0>(args_tuple);
+
+    hilti::rt::init();
+    spicy::rt::init();
+
+    const spicy::rt::Parser* parser = nullptr;
+    for ( auto* p : spicy::rt::parsers() ) {
+        if ( p->name == parser_name ) {
+            parser = p;
+            break;
+        }
+    }
+
+    if ( ! parser )
+        hilti::rt::fatalError(hilti::rt::fmt("parser %s not found", parser_name));
+
+    for ( auto _ : state ) {
+        (void)_;
+        state.PauseTiming();
+        auto in = makeInput(state.range(0));
+        auto stream = hilti::rt::reference::make_value<hilti::rt::Stream>(in);
+        stream->freeze();
+        state.ResumeTiming();
+        parser->parse1(stream, {}, {});
+    }
+
+    hilti::rt::done();
+}
+
+static const int64_t min_input = 100;
+static const int64_t max_input = 100000;
+static const int64_t mult = 10;
+
+BENCHMARK_CAPTURE(benchmarkParser, Benchmark::UnitVectorSize, std::string("Benchmark::UnitVectorSize"))
+    ->RangeMultiplier(mult)
+    ->Range(min_input, max_input);
+
+BENCHMARK_CAPTURE(benchmarkParser, Benchmark::UnitVectorLookahead, std::string("Benchmark::UnitVectorLookahead"))
+    ->RangeMultiplier(mult)
+    ->Range(min_input, max_input);
+
+BENCHMARK_CAPTURE(benchmarkParser, Benchmark::Regex, std::string("Benchmark::Regex"))
+    ->RangeMultiplier(mult)
+    ->Range(min_input, max_input);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Draft PR as I work on it, but thought it might be useful/interesting.

Initial run with the two cases I ran:

```
--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
benchmark_parser/Benchmark::WithUnit/100         12910 ns        12849 ns        55722
benchmark_parser/Benchmark::WithUnit/1000       120478 ns       120480 ns         5742
benchmark_parser/Benchmark::WithUnit/10000     1140806 ns      1140793 ns          588
benchmark_parser/Benchmark::WithUnit/100000   11261903 ns     11261919 ns           62
benchmark_parser/Benchmark::Regex/100             5099 ns         5102 ns       136973
benchmark_parser/Benchmark::Regex/1000           39491 ns        39493 ns        17754
benchmark_parser/Benchmark::Regex/10000         379056 ns       378989 ns         1840
benchmark_parser/Benchmark::Regex/100000       3784368 ns      3784473 ns          184
```

I still want to get some details from previous releases (if possible) and maybe get a way to modify the C++ code generated from Spicy (maybe just from adding the files to SOURCES or something)

this just piggybacks on the `--enable-benchmark` configure flag. It generates a binary `spicy-rt-parsing-benchmark`