### PR TITLE
Various documentation updates

### DIFF
--- a/doc/programming/language/statements.rst
+++ b/doc/programming/language/statements.rst
@@ -25,14 +25,33 @@ type, see the type's documentation.
 Ensures at runtime that ``EXPR`` evaluates to a ``True`` value. If it
 doesn't, an exception gets thrown that will typically abort execution.
 ``EXPR`` must either be of boolean type to begin with, or support
-coercion into it. If ``MSG`` is specified, it must be a string and
-will be carried along with the exception.
+coercion into it. If ``MSG`` is specified, it must be a string or
+:ref:`error <type_error>`, and will be carried along with the
+exception.
 
 .. note::
 
     Technically, the version providing a ``MSG`` isn't a separate
     syntax but just leveraging the :ref:`condition test
     <operator_condition_test>` operator.
+
+.. _statement_assert_exception:
+
+``assert-exception``
+--------------------
+
+::
+
+    assert-exception EXPR;
+
+    assert-exception EXPR : MSG;
+
+Ensures at runtime that evaluating ``EXPR`` triggers an exception. If
+it indeed does, the exception is silently caught and execution
+proceeds normally. If it doesn't, an ``AssertionFailure`` exception is
+triggered by the statement, which will typically abort execution. If
+``MSG`` is specified, it must be a string or :ref:`error
+<type_error>`, and will be carried along with the exception.
 
 .. _operator_begin:
 

--- a/doc/programming/language/types.rst
+++ b/doc/programming/language/types.rst
@@ -225,8 +225,19 @@ Map
 ---
 
 Maps are containers holding key/value pairs of elements, with fast
-lookup for keys to retrieve the corresponding value. They provide
-iterators to traverse their content, with no particular ordering.
+lookup for keys to retrieve the corresponding value.
+
+Maps provide iterators to traverse their content, with no particular
+ordering. A map iterator yields the corresponding key/value pair as a
+2-tuple. The following is an example iterating over a map's elements
+using the :ref:`'for' statement <statement_for>`:
+
+.. spicy-code::
+
+  global m: map("a": 1, "b": 2, "c": 3);
+
+  for ( i in m )
+    print i[0], i[1]; # key, value
 
 .. rubric:: Types
 
@@ -513,8 +524,18 @@ Patterns support the following optional flags:
 Set
 ---
 
-Sets are containers for unique elements with fast lookup. They provide
-iterators to traverse their content, with no particular ordering.
+Sets are containers for unique elements with fast lookup.
+
+Sets provide iterators to traverse their content, with no particular
+ordering. The following is an example iterating over a set's elements
+using the :ref:`statement_for` statement:
+
+.. spicy-code::
+
+  global s = set("a", "b", "c");
+
+  for ( i in s )
+      print i;
 
 .. rubric:: Types
 
@@ -759,8 +780,18 @@ Vector
 ------
 
 Vectors are homogeneous containers, holding a set of elements of a
-given element type. They provide iterators to traverse their content.
-Indexes begin at 0.
+given element type. Indexes begin at 0.
+
+Vectors provide iterators to traverse their content in order. The
+following is an example iterating over a vector's elements using the
+:ref:`statement_for` statement:
+
+.. spicy-code::
+
+  global v = vector("a", "b", "c");
+
+  for ( i in v )
+      print i;
 
 .. rubric:: Types
 

--- a/doc/programming/parsing.rst
+++ b/doc/programming/parsing.rst
@@ -1399,15 +1399,18 @@ loop. To that end, vectors support the following attributes:
     as a boolean expression after each parsed element, and before
     adding the element to the vector. Once ``EXPR`` evaluates to true,
     parsing stops *without* adding the element that was just
+    parsed. Inside ``EXPR``, ``$$`` refers to the element most recently
     parsed.
 
 ``&until-including=EXPR``
     Similar to ``&until``, but does include the final element ``EXPR``
-    into the field's vector when stopping parsing.
+    into the field's vector when stopping parsing. Inside ``EXPR``,
+    ``$$`` refers to the element most recently parsed.
 
 ``&while=EXPR``
     Continues parsing as long as the boolean expression ``EXPR``
-    evaluates to true.
+    evaluates to true. Inside ``EXPR``, ``$$`` refers to the element
+    most recently parsed.
 
 If neither a size nor an attribute is given, Spicy will attempt to use
 :ref:`look-ahead parsing <parse_lookahead>` to determine the end of


### PR DESCRIPTION
- **Document iteration over maps/set/vectors.**
- **Document `assert-exception`.**
- **Document use of `$$` inside `&{while,until,until-including}`.**
- **Add documentation on how to interpret stack traces involving fibers.**
