### PR TITLE
Fix minor typos in comments and docs

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -59,7 +59,7 @@ an executable.
     often far easier to comprehend than the final C++ code, in
     particular once we do some actual parsing.  To see that
     intermediary HILTI code, execute ``spicy -p hello.spicy``. The
-    ``.hlto`` extension comes from HILTI as well: It's an
+    ``.hlto`` extension comes from HILTI as well: It's a
     HILTI-generated object file.
 
 A Simple Parser

--- a/doc/host-applications.rst
+++ b/doc/host-applications.rst
@@ -289,7 +289,7 @@ taking the file to load from the command line:
 .. literalinclude:: examples/my_http-host-driver-hlto.cc
     :caption: my-driver.cc
     :lines: 9-70
-    :emphasize-lines: 5-8
+    :emphasize-lines: 27-31
     :language: c++
 
 ::

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -568,7 +568,7 @@ public:
      * current node. If  the node already has a parent, it will be deep-copied
      * first, and the new instance will be added instead of the once passed in.
      * If there's an existing child at that index, it'll be removed first and
-     * it's parent cleared.
+     * its parent cleared.
      *
      * @param ctx current context in use
      * @param idx index of child to set

--- a/spicy/runtime/include/sink.h
+++ b/spicy/runtime/include/sink.h
@@ -117,7 +117,7 @@ public:
 
     /**
      * Connects a filter unit to the sink. Any input will then pass through the
-     * filter before being forwarded tp parsing. Must not be called when data
+     * filter before being forwarded to parsing. Must not be called when data
      * has been processed already. Multiple filters can be connected and will be
      * chained.
      *


### PR DESCRIPTION
Also, I have a question:

Is it "an HILTI" or "a HILTI"? I picked "a HILTI"

also these are the lines highlighted by the highlight change:

![Screenshot 2025-04-01 at 4 33 52 PM](https://github.com/user-attachments/assets/516251d6-b354-461e-ba0e-69959ab3fdfb)
