### PR TITLE
Fix path to spicyc in custom command for bundled builds.

### DIFF
--- a/spicy/runtime/tests/benchmarks/CMakeLists.txt
+++ b/spicy/runtime/tests/benchmarks/CMakeLists.txt
@@ -11,8 +11,7 @@ set_source_files_properties(${_generated_sources} PROPERTIES SKIP_LINTING ON)
 if (BUILD_TOOLCHAIN)
     add_custom_command(
         OUTPUT ${_generated_sources}
-        COMMAND ${CMAKE_BINARY_DIR}/bin/spicyc -x ${CMAKE_CURRENT_BINARY_DIR}/Benchmark
-                "${BENCH_SOURCES}"
+        COMMAND $<TARGET_FILE:spicyc> -x ${CMAKE_CURRENT_BINARY_DIR}/Benchmark "${BENCH_SOURCES}"
         DEPENDS spicyc ${BENCH_SOURCES}
         COMMENT "Generating C++ code for Benchmark")
 


### PR DESCRIPTION
If Spicy is built as a subproject binaries might not end up in `${CMAKE_BINARY_DIR}/bin`, so having this path hardcoded might not work there.

This patch changes the command to instead query CMake for the path to spicyc.