### PR TITLE
Proposal: Allow optional semicolon after unit hooks.

### DIFF
--- a/spicy/toolchain/src/compiler/parser/parser.yy
+++ b/spicy/toolchain/src/compiler/parser/parser.yy
@@ -875,6 +875,8 @@ opt_skip_     :
                 SKIP                             { $$ = true; }
               | /* empty */                      { $$ = false; }
 
+opt_semi      : ';' | /* empty */
+
 opt_unit_field_args
               : '(' opt_exprs ')'                { $$ = std::move($2); }
               | /* empty */                      { $$ = hilti::Expressions(); }
@@ -896,7 +898,7 @@ opt_unit_field_sinks
               | /* empty */                      { $$ = hilti::Expressions(); }
 
 opt_unit_item_hooks
-              : unit_hooks                       { $$ = std::move($1); }
+              : unit_hooks opt_semi              { $$ = std::move($1); }
               | ';'                              { $$ = spicy::declaration::Hooks(); }
 
 unit_hooks    : unit_hooks unit_hook             { $$ = std::move($1); $$.push_back(std::move($2)); }

--- a/tests/spicy/types/unit/semi-after-hooks.spicy
+++ b/tests/spicy/types/unit/semi-after-hooks.spicy
@@ -1,0 +1,11 @@
+# @TEST-EXEC: spicyc -c %INPUT
+#
+# @TEST-DOC: Ensures that semicolons can follow unit hooks
+
+module Test;
+
+public type Data = unit {
+    # Test both with and without semicolons
+    : uint8 { print $$; }
+    : uint8 { print $$; };
+};


### PR DESCRIPTION
This is a proposal, but it's easy to do so I'm proposing through a PR

It has become a frustration for me, even as I get better writing Spicy parsers, that semicolons can't come after hooks. The main reason is I may have some unit:

```
public type Data = unit {
    x: uint8;
};
```

Then I want to print that unit or add something for debugging, so I naturally just insert the hook before the semicolon (since the hook is tied to the field it makes sense the semicolon terminates the field to me):

```
public type Data = unit {
    x: uint8 { print $$; };
};
```

But that errors! This happens basically every time I try to do this but it's really not necessary.

I originally had this for unit hooks not attached to fields but I dropped it because there's no reason for that one, and it's uglier.