### PR TITLE
Fix using `&try` with `&max-size`, and potentially other cases.

### DIFF
--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -137,17 +137,17 @@ private:
     }
 
     void operator()(expression::Name* n) final {
-        auto d = n->resolvedDeclaration();
-        assert(d);
-        dispatch(d);
-        follow(d);
+        if ( auto d = n->resolvedDeclaration() ) {
+            dispatch(d);
+            follow(d);
+        }
     }
 
     void operator()(type::Name* n) final {
-        auto d = n->resolvedDeclaration();
-        assert(d);
-        dispatch(d);
-        follow(d);
+        if ( auto d = n->resolvedDeclaration() ) {
+            dispatch(d);
+            follow(d);
+        }
     }
 };
 

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -444,6 +444,9 @@ struct FunctionVisitor : OptimizerVisitor {
             return;
 
         auto decl = n->op0()->as<expression::Name>()->resolvedDeclaration();
+        if ( ! decl )
+            return;
+
         const auto& function_id = decl->fullyQualifiedID();
         assert(function_id);
 
@@ -754,6 +757,9 @@ struct ConstantFoldingVisitor : OptimizerVisitor {
             case Stage::PRUNE_DECLS: return;
             case Stage::PRUNE_USES: {
                 auto decl = n->resolvedDeclaration();
+                if ( ! decl )
+                    return;
+
                 const auto& id = decl->fullyQualifiedID();
                 assert(id);
 
@@ -1102,6 +1108,9 @@ public:
                     return;
 
                 auto decl = rid->resolvedDeclaration();
+                if ( ! decl )
+                    return;
+
                 const auto& fn = decl->tryAs<declaration::Function>();
                 if ( ! fn )
                     return;
@@ -1507,7 +1516,7 @@ struct MemberVisitor : OptimizerVisitor {
         switch ( _stage ) {
             case Stage::COLLECT: {
                 auto decl = n->resolvedDeclaration();
-                if ( ! decl->isA<declaration::Field>() )
+                if ( ! decl || ! decl->isA<declaration::Field>() )
                     return;
 
                 // Record the member as used.

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -761,6 +761,9 @@ struct ProductionVisitor : public production::Visitor {
 
         pb->enableDefaultNewValueForField(true);
 
+        if ( field->attributes()->find(hilti::attribute::Kind::Try) )
+            pb->initBacktracking();
+
         if ( auto c = field->condition() )
             pushBuilder(builder()->addIf(c));
 
@@ -802,9 +805,6 @@ struct ProductionVisitor : public production::Visitor {
                                       builder()->optional(builder()->qualifiedType(builder()->typeUnsignedInteger(64),
                                                                                    hilti::Constness::Const))}));
         }
-
-        if ( field->attributes()->find(hilti::attribute::Kind::Try) )
-            pb->initBacktracking();
 
         return pre_container_offset;
     }
@@ -912,9 +912,6 @@ struct ProductionVisitor : public production::Visitor {
 
         HILTI_DEBUG(spicy::logging::debug::ParserBuilder, fmt("- post-parse field: %s", field->id()));
 
-        if ( field->attributes()->find(hilti::attribute::Kind::Try) )
-            pb->finishBacktracking();
-
         if ( pb->options().getAuxOption<bool>("spicy.track_offsets", false) ) {
             assert(field->index());
             auto __offsets = builder()->member(state().self, "__offsets");
@@ -960,6 +957,9 @@ struct ProductionVisitor : public production::Visitor {
 
         if ( field->condition() )
             popBuilder();
+
+        if ( field->attributes()->find(hilti::attribute::Kind::Try) )
+            pb->finishBacktracking();
     }
 
     // top_level: true if we're called directly for the grammar's root unit, and

--- a/tests/Baseline/spicy.types.unit.backtrack-lah/output
+++ b/tests/Baseline/spicy.types.unit.backtrack-lah/output
@@ -2,5 +2,4 @@
 [$a=[$payload=b"AAA"], $b=(not set), $c=(not set)]
 [$a=(not set), $b=[$payload=b"BBB"], $c=(not set)]
 [$a=(not set), $b=(not set), $c=[$payload=b"CCC"]]
-[$a=(not set), $b=(not set), $c=(not set)]
 could not parse: 'ddd DDD'

--- a/tests/spicy/types/unit/synchronize-try-with-size.spicy
+++ b/tests/spicy/types/unit/synchronize-try-with-size.spicy
@@ -1,0 +1,9 @@
+# @TEST-EXEC: spicyc -j %INPUT
+#
+# @TEST-DOC: Regression test for #2007, just ensuring that it builds.
+
+module Test;
+
+public type Data = unit {
+    : bytes &eod &max-size=5 &try;
+};


### PR DESCRIPTION
- **Let optimizer and dependency tracker ignore unresolved declarations.**
- **Fix using `&try` with `&max-size`, and potentially other cases.**
