### PR TITLE
Only disable clang-tidy if CMake version supports it.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.2
+  rev: v0.11.5
   hooks:
   - id: ruff
     args: [ --fix ]

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -12,8 +12,10 @@ flex_target(scanner_hilti src/compiler/parser/scanner.ll ${AUTOGEN_CC}/__scanner
 bison_target_pp(parser_hilti src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc DEFINES_FILE
                 ${AUTOGEN_CC}/__parser.h)
 
-set_source_files_properties(${FLEX_scanner_hilti_OUTPUTS} PROPERTIES SKIP_LINTING ON)
-set_source_files_properties(${BISON_parser_hilti_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+    set_source_files_properties(${FLEX_scanner_hilti_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+    set_source_files_properties(${BISON_parser_hilti_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+endif ()
 
 bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
 bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})

--- a/spicy/runtime/tests/benchmarks/CMakeLists.txt
+++ b/spicy/runtime/tests/benchmarks/CMakeLists.txt
@@ -6,7 +6,10 @@ set(BENCH_MODULE Benchmark)
 list(TRANSFORM BENCH_MODULE PREPEND Benchmark_ OUTPUT_VARIABLE _generated_sources)
 list(TRANSFORM _generated_sources APPEND ".cc" OUTPUT_VARIABLE _generated_sources)
 list(APPEND _generated_sources "Benchmark___linker__.cc")
-set_source_files_properties(${_generated_sources} PROPERTIES SKIP_LINTING ON)
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+    set_source_files_properties(${_generated_sources} PROPERTIES SKIP_LINTING ON)
+endif ()
 
 if (BUILD_TOOLCHAIN)
     add_custom_command(

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -14,8 +14,10 @@ flex_target(scanner_spicy src/compiler/parser/scanner.ll ${AUTOGEN_CC}/__scanner
 bison_target_pp(parser_spicy src/compiler/parser/parser.yy ${AUTOGEN_CC}/__parser.cc DEFINES_FILE
                 ${AUTOGEN_CC}/__parser.h)
 
-set_source_files_properties(${FLEX_scanner_spicy_OUTPUTS} PROPERTIES SKIP_LINTING ON)
-set_source_files_properties(${BISON_parser_spicy_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+    set_source_files_properties(${FLEX_scanner_spicy_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+    set_source_files_properties(${BISON_parser_spicy_OUTPUTS} PROPERTIES SKIP_LINTING ON)
+endif ()
 
 bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
 bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})


### PR DESCRIPTION
We use `SKIP_LINTING` to disable running tools like `clang-tidy` via
CMake on generated. This is only supported with >=cmake-3.27 which is
satisfied in our CI infrastructure.

It is not really clear to me how to properly do this with earlier CMake
versions, so we simply only set this up if supported. This means that
users trying to run linters via CMake with an older version might see
diagnostics in generated code. This seems acceptable to me.