### PR TITLE
[WIP] Introduce global `option` declarations.

### DIFF
--- a/hilti/toolchain/include/ast/builder/node-factory.h
+++ b/hilti/toolchain/include/ast/builder/node-factory.h
@@ -251,6 +251,12 @@ public:
                            Meta meta = {}) {
         return hilti::declaration::Module::create(context(), uid, scope, decls, std::move(meta));
     }
+    auto declarationOption(ID id, Expression* value, Meta meta = {}) {
+        return hilti::declaration::Option::create(context(), std::move(id), value, std::move(meta));
+    }
+    auto declarationOption(ID id, QualifiedType* type, Expression* value, Meta meta = {}) {
+        return hilti::declaration::Option::create(context(), std::move(id), type, value, std::move(meta));
+    }
     auto declarationParameter(ID id, UnqualifiedType* type, parameter::Kind kind, hilti::Expression* default_,
                               AttributeSet* attrs, Meta meta = {}) {
         return hilti::declaration::Parameter::create(context(), std::move(id), type, kind, default_, attrs,

--- a/hilti/toolchain/include/ast/declarations/all.h
+++ b/hilti/toolchain/include/ast/declarations/all.h
@@ -10,6 +10,7 @@
 #include <hilti/ast/declarations/imported-module.h>
 #include <hilti/ast/declarations/local-variable.h>
 #include <hilti/ast/declarations/module.h>
+#include <hilti/ast/declarations/option.h>
 #include <hilti/ast/declarations/parameter.h>
 #include <hilti/ast/declarations/property.h>
 #include <hilti/ast/declarations/type.h>

--- a/hilti/toolchain/include/ast/declarations/option.h
+++ b/hilti/toolchain/include/ast/declarations/option.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
+
+#pragma once
+
+#include <sys/types.h>
+
+#include <utility>
+
+#include <hilti/ast/declaration.h>
+#include <hilti/ast/expression.h>
+#include <hilti/ast/type.h>
+
+namespace hilti::declaration {
+
+/** AST node for a constant declaration. */
+class Option : public Declaration {
+public:
+    auto init() const { return child<hilti::Expression>(1); }
+
+    QualifiedType* type() const {
+        if ( auto t = child<QualifiedType>(0) )
+            return t;
+        else
+            return init()->type();
+    }
+
+    std::string_view displayName() const final { return "option"; }
+
+    void setInit(ASTContext* ctx, hilti::Expression* e) { setChild(ctx, 1, e); }
+    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t->recreateAsLhs(ctx)); }
+
+    static auto create(ASTContext* ctx, ID id, QualifiedType* type, hilti::Expression* value, Meta meta = {}) {
+        return ctx->make<Option>(ctx, {type->recreateAsLhs(ctx), value}, std::move(id), declaration::Linkage::Public,
+                                 std::move(meta));
+    }
+
+    static auto create(ASTContext* ctx, ID id, hilti::Expression* value, const Meta& meta = {}) {
+        return create(ctx, std::move(id), QualifiedType::createAuto(ctx, meta), value, meta);
+    }
+
+protected:
+    Option(ASTContext* ctx, Nodes children, ID id, declaration::Linkage linkage, Meta meta)
+        : Declaration(ctx, NodeTags, std::move(children), std::move(id), linkage, std::move(meta)) {}
+
+    HILTI_NODE_1(declaration::Option, Declaration, final);
+};
+
+} // namespace hilti::declaration

--- a/hilti/toolchain/include/ast/forward.h
+++ b/hilti/toolchain/include/ast/forward.h
@@ -82,6 +82,7 @@ class GlobalVariable;
 class ImportedModule;
 class LocalVariable;
 class Module;
+class Option;
 class Parameter;
 class Property;
 class Type;

--- a/hilti/toolchain/include/ast/node-tag.h
+++ b/hilti/toolchain/include/ast/node-tag.h
@@ -115,9 +115,10 @@ constexpr Tag GlobalVariable = 304;
 constexpr Tag ImportedModule = 305;
 constexpr Tag LocalVariable = 306;
 constexpr Tag Module = 307;
-constexpr Tag Parameter = 308;
-constexpr Tag Property = 309;
-constexpr Tag Type = 310;
+constexpr Tag Option = 308;
+constexpr Tag Parameter = 309;
+constexpr Tag Property = 310;
+constexpr Tag Type = 311;
 } // namespace declaration
 
 namespace expression {

--- a/hilti/toolchain/include/ast/visitor-dispatcher.h
+++ b/hilti/toolchain/include/ast/visitor-dispatcher.h
@@ -84,6 +84,7 @@ public:
     virtual void operator()(hilti::declaration::ImportedModule*) {}
     virtual void operator()(hilti::declaration::LocalVariable*) {}
     virtual void operator()(hilti::declaration::Module*) {}
+    virtual void operator()(hilti::declaration::Option*) {}
     virtual void operator()(hilti::declaration::Property*) {}
     virtual void operator()(hilti::declaration::Type*) {}
     virtual void operator()(hilti::expression::Assign*) {}

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -129,6 +129,8 @@ private:
 
     void operator()(declaration::Module* n) final { insert(n); }
 
+    void operator()(declaration::Option* n) final { insert(n); }
+
     void operator()(declaration::Type* n) final { insert(n); }
 
     void operator()(QualifiedType* n) final {

--- a/hilti/toolchain/src/ast/expressions/name.cc
+++ b/hilti/toolchain/src/ast/expressions/name.cc
@@ -20,6 +20,7 @@ QualifiedType* expression::Name::type() const {
         void operator()(declaration::Function* n) final { result = n->function()->type(); }
         void operator()(declaration::GlobalVariable* n) final { result = n->type(); }
         void operator()(declaration::LocalVariable* n) final { result = n->type(); }
+        void operator()(declaration::Option* n) final { result = n->type(); }
         void operator()(declaration::Parameter* n) final { result = n->type(); }
         void operator()(declaration::Type* n) final { result = name->child<QualifiedType>(0); }
     };

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -251,6 +251,19 @@ struct GlobalsVisitor : hilti::visitor::PostOrder {
         unit->add(x);
     }
 
+    void operator()(declaration::Option* n) final {
+        auto type = cg->compile(n->type(), codegen::TypeUsage::Storage);
+
+        cxx::declaration::Global* glob = nullptr;
+
+        if ( include_implementation )
+            glob = new cxx::declaration::Global({cxxNamespace(), n->id()}, type, {}, cg->compile(n->init()));
+        else
+            glob = new cxx::declaration::Global({cxxNamespace(), n->id()}, type, {}, std::nullopt, "extern");
+
+        unit->add(*glob);
+    }
+
     void operator()(declaration::Type* n) final {
         assert(n->typeID());
 

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -179,6 +179,11 @@ struct Visitor : hilti::visitor::PreOrder {
             return;
         }
 
+        if ( decl->isA<declaration::Option>() ) {
+            result = {cxx::ID(cg->options().cxx_namespace_intern, cxx::ID(fqid)), Side::LHS};
+            return;
+        }
+
         if ( auto p = decl->tryAs<declaration::Parameter>(); p && p->isTypeParameter() ) {
             if ( p->type()->type()->isReferenceType() )
                 // Need to adjust here for potential automatic change to a weak reference.

--- a/hilti/toolchain/src/compiler/parser/parser.yy
+++ b/hilti/toolchain/src/compiler/parser/parser.yy
@@ -36,7 +36,7 @@ namespace hilti { namespace detail { class Parser; } }
 
 %glr-parser
 %expect 113
-%expect-rr 211
+%expect-rr 213
 
 %{
 
@@ -192,6 +192,7 @@ static int _field_width = 0;
 %token NEQ "!="
 %token NETWORK "net"
 %token NOT_IN "!in"
+%token OPTION "option"
 %token OPTIONAL "optional"
 %token OR "||"
 %token OVERLAY "overlay"
@@ -244,7 +245,7 @@ static int _field_width = 0;
 %token YIELD "yield"
 
 %type <hilti::ID>                             local_id scoped_id dotted_id function_id scoped_function_id
-%type <hilti::Declaration*>                   local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl struct_field union_field
+%type <hilti::Declaration*>                   local_decl local_init_decl global_decl type_decl import_decl constant_decl function_decl global_scope_decl property_decl option_decl struct_field union_field
 %type <hilti::Declarations>                     struct_fields union_fields opt_union_fields
 %type <hilti::UnqualifiedType*>               base_type_no_attrs base_type type function_type tuple_type struct_type enum_type union_type func_param_type bitfield_type
 %type <hilti::QualifiedType*>                 qtype
@@ -330,6 +331,7 @@ global_scope_decl
               | function_decl                    { $$ = std::move($1); }
               | import_decl                      { $$ = std::move($1); }
               | property_decl                    { $$ = std::move($1); }
+              | option_decl                      { $$ = std::move($1); }
 
 type_decl     : opt_linkage TYPE scoped_id '=' qtype opt_attributes ';'
                                                  { $$ = builder->declarationType(std::move($3), std::move($5), std::move($6), std::move($1), __loc__); }
@@ -386,6 +388,10 @@ import_decl   : IMPORT local_id ';'              { $$ = builder->declarationImpo
 
 property_decl : PROPERTY ';'                     { $$ = builder->declarationProperty(ID(std::move($1)), __loc__); }
               | PROPERTY '=' expr ';'            { $$ = builder->declarationProperty(ID(std::move($1)), std::move($3), __loc__); }
+
+option_decl   : OPTION scoped_id '=' expr ';'    { $$ = builder->declarationOption($2, $4, __loc__); }
+              | OPTION scoped_id ':' qtype '=' expr ';'
+                                                 { $$ = builder->declarationOption($2, $4, $6, __loc__); }
 
 opt_linkage   : PUBLIC                           { $$ = hilti::declaration::Linkage::Public; }
               | PRIVATE                          { $$ = hilti::declaration::Linkage::Private; }

--- a/hilti/toolchain/src/compiler/parser/scanner.ll
+++ b/hilti/toolchain/src/compiler/parser/scanner.ll
@@ -133,6 +133,7 @@ module                return token::MODULE;
 move                  return token::MOVE;
 net                   return token::NETWORK;
 new                   return token::NEW;
+option                return token::OPTION;
 optional              return token::OPTIONAL;
 pack                  return token::PACK;
 port                  return token::PORT;

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -151,6 +151,8 @@ struct Printer : visitor::PreOrder {
         print_decls(
             util::filter(n->declarations(), [](const auto& d) { return d->template isA<declaration::Type>(); }));
         print_decls(
+            util::filter(n->declarations(), [](const auto& d) { return d->template isA<declaration::Option>(); }));
+        print_decls(
             util::filter(n->declarations(), [](const auto& d) { return d->template isA<declaration::Constant>(); }));
         print_decls(util::filter(n->declarations(),
                                  [](const auto& d) { return d->template isA<declaration::GlobalVariable>(); }));
@@ -455,6 +457,15 @@ struct Printer : visitor::PreOrder {
             _out << " = " << n->init();
 
         _out << ';';
+        _out.endLine();
+    }
+
+    void operator()(declaration::Option* n) final {
+        printDoc(n->documentation());
+        _out.beginLine();
+        _out << linkage(n->linkage()) << "option ";
+        _out << n->type();
+        _out << ' ' << n->id() << " = " << n->init() << ';';
         _out.endLine();
     }
 

--- a/hilti/toolchain/src/compiler/scope-builder.cc
+++ b/hilti/toolchain/src/compiler/scope-builder.cc
@@ -100,6 +100,8 @@ struct Visitor : visitor::PostOrder {
         root->getOrCreateScope()->insert(m->scopeID(), m);
     }
 
+    void operator()(declaration::Option* n) final { n->parent()->getOrCreateScope()->insert(n); }
+
     void operator()(declaration::Type* n) final {
         if ( n->parent()->isA<declaration::Module>() )
             n->parent()->getOrCreateScope()->insert(n);

--- a/spicy/toolchain/src/compiler/parser/scanner.ll
+++ b/spicy/toolchain/src/compiler/parser/scanner.ll
@@ -159,6 +159,7 @@ network               return token::NETWORK;
 new                   return token::NEW;
 object                return token::OBJECT;
 on                    return token::ON;
+option                return token::OPTION;
 optional              return token::OPTIONAL;
 pack                  return token::PACK;
 port                  return token::PORT;

--- a/spicy/toolchain/src/compiler/resolver.cc
+++ b/spicy/toolchain/src/compiler/resolver.cc
@@ -647,6 +647,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 else
                     n->addError("field value must be a constant");
             }
+
             else
                 n->addError(hilti::util::fmt("field value must be a constant or type (but is a %s)",
                                              resolved->first->as<hilti::Declaration>()->displayName()));

--- a/spicy/toolchain/src/compiler/validator.cc
+++ b/spicy/toolchain/src/compiler/validator.cc
@@ -323,6 +323,11 @@ struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
             error("constant cannot be declared at local scope", n);
     }
 
+    void operator()(hilti::declaration::Option* n) final {
+        if ( ! n->parent()->isA<hilti::declaration::Module>() )
+            error("option cannot be declared at local scope", n);
+    }
+
     void operator()(hilti::expression::Name* n) final {
         if ( n->id() == ID("__dd") ) {
             if ( auto hook = n->parent<spicy::declaration::Hook>();


### PR DESCRIPTION
Syntax:

    module Foo {
        option MySwitch = False;
        option MyValue: uint64 = 5;

        [...]

        MySwitch = True;
    }

Options are meant to capture a tunable parameter where a parser picks
a suitable default for something, but allows changing that value
externally. An `option` is something "in between" a global constant
and a global variable: Like a global constant, it's "semantically
constant" in the sense that it's something that's explicitly set to
some chosen value; it's not meant for dynamically collecting state.
But like a global, its value *can* change during runtime.

Access to options works through normal scoping, so that their values
can modified externally through assignments inside other modules, in
particular at initialization time through global statements. If
multiple modules change an option at init time, it's undefined which
change will win out.

This isn't fully finished yet, and up for discussion at this point.
Some notes/thoughts:

    - I have tested that this works from the Zeek side to feed
      script-level values back into a parser through global statements
      (`Foo::MyValue = zeek::get_count("Foo:MyValue");`)

    - This commit currently does not implement the equivalent of
      `cxx_enable_dynamic_globals` for options. Like globals, options
      aren't thread-safe by default, and we'd need to take similar
      measures to make them so. In fact, at that point, options could
      just be merged into the set of globals during codegen, although
      we'd get similar overhead then. Alternatively, because changes
      are supposed to be rare, if we'd allow only assignments to
      change a value, it might be viable to use actual locks around
      accesses, not sure.

    - The similarity to globals on the implementation side suggests
      that options are really primarily a semantic language construct,
      but nothing fundamentally new. I'm kind of torn if we actually
      need them, or should simply use globals for tunable parameters.

    - I considered making options read-only during runtime, allowing
      changes only at module initialization time (i.e., through global
      statements). However, that would prevent updating them from
      inside a change handler for a Zeek-side option, which would be
      unfortunate.

TODO:
    - Do we want this?
    - More tests
    - Documentation
