### PR TITLE
Backport bumps to freebsd platforms in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -644,7 +644,7 @@ freebsd13_task:
 
 freebsd14_task:
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
     cpu: 8
     memory: 8GB
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -608,7 +608,7 @@ docker_opensuse15_5_task:
 
 freebsd13_task:
   freebsd_instance:
-    image_family: freebsd-13-3
+    image_family: freebsd-13-4
     cpu: 8
     memory: 8GB
 


### PR DESCRIPTION
Unfortunately freebsd images go away in cirrus, so we have to bump them to be able to continue running CI.