### PR TITLE
Fix compilation error for GCC15

### DIFF
--- a/hilti/toolchain/include/ast/node-tag.h
+++ b/hilti/toolchain/include/ast/node-tag.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 namespace hilti::node {


### PR DESCRIPTION
Include cstdint header to support uint8_t/uint64_t in GCC 15+

