### PR TITLE
Drop unnecessary Bison include from CMake function.

### DIFF
--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -2,11 +2,12 @@
 
 ### A collection of small helpers for the HILTI/Spicy build system.
 
-# Add the likely Bison include directory to Bison sources to avoid version mismatches.
-function (bison_source src output_dir)
-    string(REGEX REPLACE "/bin/bison" "/include" bison_include "${BISON_EXECUTABLE}")
-    set_source_files_properties(
-        ${src} PROPERTIES INCLUDE_DIRECTORIES "${bison_include};${FLEX_INCLUDE_DIR};${output_dir}")
+# Add required Flex/Bison include directories to source files.
+function (flex_bison_source src output_dir)
+    # cmake-format: off
+    set_source_files_properties(${src} PROPERTIES
+        INCLUDE_DIRECTORIES "${FLEX_INCLUDE_DIR};${output_dir}")
+    # cmake-format: on
 endfunction ()
 
 # Install a set of header files from a directory location.

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -17,10 +17,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
     set_source_files_properties(${BISON_parser_hilti_OUTPUTS} PROPERTIES SKIP_LINTING ON)
 endif ()
 
-bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
-bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})
-bison_source(${AUTOGEN_CC}/__scanner.cc ${AUTOGEN_CC})
-bison_source(${AUTOGEN_CC}/__parser.cc ${AUTOGEN_CC})
+flex_bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
+flex_bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})
+flex_bison_source(${AUTOGEN_CC}/__scanner.cc ${AUTOGEN_CC})
+flex_bison_source(${AUTOGEN_CC}/__parser.cc ${AUTOGEN_CC})
 
 set(SOURCES
     src/ast/ast-context.cc

--- a/spicy/toolchain/CMakeLists.txt
+++ b/spicy/toolchain/CMakeLists.txt
@@ -19,10 +19,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
     set_source_files_properties(${BISON_parser_spicy_OUTPUTS} PROPERTIES SKIP_LINTING ON)
 endif ()
 
-bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
-bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})
-bison_source(${AUTOGEN_CC}/__scanner.cc ${AUTOGEN_CC})
-bison_source(${AUTOGEN_CC}/__parser.cc ${AUTOGEN_CC})
+flex_bison_source(src/compiler/plugin.cc ${AUTOGEN_CC})
+flex_bison_source(src/compiler/parser/driver.cc ${AUTOGEN_CC})
+flex_bison_source(${AUTOGEN_CC}/__scanner.cc ${AUTOGEN_CC})
+flex_bison_source(${AUTOGEN_CC}/__parser.cc ${AUTOGEN_CC})
 
 set(SOURCES_COMPILER
     src/ast/builder/builder.cc


### PR DESCRIPTION
We do not seem to need any includes from Bison, but where previously adding some include path in a pretty ad hoc way. This patch performs minimal cleanup of this. There is probably the opportunity to clean up how we add dependencies with Flex and Bison (e.g., using by refactoring how we propagate this and using functionality like `add_flex_bison_dependency` at the lowest level), but I punt on that here.