### PR TITLE
Fix doc link to Zeek's Slack

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,7 +53,7 @@ doxygen:
 
 .PHONY: check
 check:
-	@$(SPHINXBUILD) -q -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
+	@$(SPHINXBUILD) -v -b linkcheck $(SOURCEDIR) $(DESTDIR)/linkcheck
 
 spicy-%:
 	git clone https://github.com/zeek/$@

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,7 +65,7 @@ like to hear from you!
 
     - Report issues on the GitHub `ticket tracker <https://github.com/zeek/spicy/issues>`_.
 
-    - Ask the ``#spicy`` channel on `Zeek's Slack <https://zeek.org/connect>`_.
+    - Ask the ``#spicy`` channel on `Zeek's Slack <https://zeek.org/slack>`_.
 
     - Check out the `Zeek community Discourse
       <https://community.zeek.org>`_ and discuss Spicy under the


### PR DESCRIPTION
The previous link seems to have gone away some time ago.