### PR TITLE
Fix cyclic usage of units types inside other types.

### DIFF
--- a/hilti/toolchain/include/ast/builder/builder.h
+++ b/hilti/toolchain/include/ast/builder/builder.h
@@ -314,8 +314,8 @@ public:
         return expressionUnresolvedOperator(operator_::Kind::Call, {id(id_, m), tuple(v, m)}, m);
     }
 
-    auto index(Expression* value, unsigned int index, const Meta& m = Meta()) {
-        return expressionUnresolvedOperator(operator_::Kind::Index, {value, integer(index, m)}, m);
+    auto index(Expression* value, Expression* index, const Meta& m = Meta()) {
+        return expressionUnresolvedOperator(operator_::Kind::Index, {value, index}, m);
     }
 
     auto size(Expression* op, const Meta& m = Meta()) {

--- a/hilti/toolchain/include/ast/ctor.h
+++ b/hilti/toolchain/include/ast/ctor.h
@@ -18,6 +18,9 @@ public:
     /** Returns the HILTI type of the constructor's value. */
     virtual QualifiedType* type() const = 0;
 
+    /** Returns true for constructors creating a reference to another type. */
+    virtual bool isReferenceCtor() const { return false; }
+
 protected:
     Ctor(ASTContext* ctx, node::Tags node_tags, Nodes children, Meta meta)
         : Node::Node(ctx, node_tags, std::move(children), std::move(meta)) {}

--- a/hilti/toolchain/include/ast/ctors/reference.h
+++ b/hilti/toolchain/include/ast/ctors/reference.h
@@ -18,6 +18,7 @@ public:
     QualifiedType* dereferencedType() const { return type()->type()->as<type::StrongReference>()->dereferencedType(); }
 
     QualifiedType* type() const final { return child<QualifiedType>(0); }
+    bool isReferenceCtor() const final { return true; }
 
     static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
         return ctx->make<StrongReference>(ctx,
@@ -39,6 +40,7 @@ public:
     QualifiedType* dereferencedType() const { return type()->type()->as<type::WeakReference>()->dereferencedType(); }
 
     QualifiedType* type() const final { return child<QualifiedType>(0); }
+    bool isReferenceCtor() const final { return true; }
 
     static auto create(ASTContext* ctx, QualifiedType* t, const Meta& meta = {}) {
         return ctx->make<WeakReference>(ctx,
@@ -57,10 +59,11 @@ protected:
 /** AST node for a `value_ref<T>` constructor value. */
 class ValueReference : public Ctor {
 public:
-    QualifiedType* type() const final { return child<QualifiedType>(0); }
+    QualifiedType* dereferencedType() const { return type()->type()->as<type::ValueReference>()->dereferencedType(); }
     Expression* expression() const { return child<Expression>(1); }
 
-    QualifiedType* dereferencedType() const { return type()->type()->as<type::ValueReference>()->dereferencedType(); }
+    QualifiedType* type() const final { return child<QualifiedType>(0); }
+    bool isReferenceCtor() const final { return true; }
 
     void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
 

--- a/hilti/toolchain/include/ast/ctors/struct.h
+++ b/hilti/toolchain/include/ast/ctors/struct.h
@@ -61,7 +61,11 @@ public:
     }
 
     QualifiedType* type() const final { return child<QualifiedType>(0); }
-    void setType(ASTContext* ctx, QualifiedType* t) { setChild(ctx, 0, t); }
+
+    void setType(ASTContext* ctx, QualifiedType* t) {
+        assert(t->type()->isA<type::Struct>());
+        setChild(ctx, 0, t);
+    }
 
     /** Implements the node interface. */
     node::Properties properties() const override {
@@ -79,7 +83,9 @@ public:
 
 protected:
     Struct(ASTContext* ctx, Nodes children, Meta meta)
-        : Ctor(ctx, NodeTags, std::move(children), std::move(meta)), WithUniqueID("struct") {}
+        : Ctor(ctx, NodeTags, std::move(children), std::move(meta)), WithUniqueID("struct") {
+        assert(type()->type()->isA<type::Auto>() || type()->type()->isA<type::Struct>());
+    }
 
     HILTI_NODE_1(ctor::Struct, Ctor, final);
 };

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -311,11 +311,9 @@ struct Visitor : hilti::visitor::PreOrder {
             return cxx::Expression("{}");
         };
 
-        result = fmt("%s(%s)", id,
-                     util::join(node::transform(node::filter(n->type()->type()->as<type::Struct>()->fields(),
-                                                             is_public_field),
-                                                convert_field),
-                                ", "));
+        result =
+            fmt("%s(%s)", id,
+                util::join(node::transform(node::filter(n->stype()->fields(), is_public_field), convert_field), ", "));
     }
 
     void operator()(ctor::Time* n) final {

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -848,14 +848,7 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     auto memberAccess(const expression::ResolvedOperator* o, const std::string& member, bool lhs = false) {
-        cxx::Expression op0;
-
-        if ( o->op0()->type()->type()->isReferenceType() )
-            op0 = fmt("(*%s)", cg->compile(o->op0()));
-        else
-            op0 = cg->compile(o->op0());
-
-        return memberAccess(o, op0, member);
+        return memberAccess(o, cg->compile(o->op0()), member);
     }
 
     cxx::Expression structMember(const expression::ResolvedOperator* o) {

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -920,9 +920,11 @@ struct VisitorTypeInfoDynamic : hilti::visitor::PreOrder {
             if ( auto x = n->cxxID() )
                 cxx_type_id = x;
 
-            fields.push_back(fmt("::hilti::rt::type_info::struct_::Field{ \"%s\", %s, offsetof(%s, %s), %s, %s%s }",
-                                 cxx::ID(f->id()), cg->typeInfo(f->type()), cxx_type_id, cxx::ID(f->id()),
-                                 f->isInternal(), f->isAnonymous(), accessor));
+            fields.push_back(
+                fmt("::hilti::rt::type_info::struct_::Field{ \"%s\", %s, static_cast<std::ptrdiff_t>(offsetof(%s, "
+                    "%s)), %s, %s%s }",
+                    cxx::ID(f->id()), cg->typeInfo(f->type()), cxx_type_id, cxx::ID(f->id()), f->isInternal(),
+                    f->isAnonymous(), accessor));
         }
 
         result = fmt("::hilti::rt::type_info::Struct(std::vector<::hilti::rt::type_info::struct_::Field>({%s}))",

--- a/hilti/toolchain/src/compiler/coercer.cc
+++ b/hilti/toolchain/src/compiler/coercer.cc
@@ -351,8 +351,7 @@ struct VisitorCtor : visitor::PreOrder {
     void operator()(ctor::Struct* n) final {
         auto* dst_ = dst;
 
-        if ( (dst->type()->isA<type::ValueReference>() || dst->type()->isA<type::StrongReference>()) &&
-             ! dst->type()->isReferenceType() )
+        if ( dst->type()->isA<type::ValueReference>() || dst->type()->isA<type::StrongReference>() )
             // Allow coercion from value to reference type with new instance.
             dst_ = dst->type()->dereferencedType();
 
@@ -361,7 +360,7 @@ struct VisitorCtor : visitor::PreOrder {
                 // Wait for this to be resolved.
                 return;
 
-            auto* stype = n->type()->type()->as<type::Struct>();
+            auto* stype = n->stype();
 
             std::set<ID> src_fields;
             for ( const auto& f : stype->fields() )

--- a/spicy/toolchain/src/compiler/codegen/codegen.cc
+++ b/spicy/toolchain/src/compiler/codegen/codegen.cc
@@ -11,7 +11,10 @@
 #include <hilti/ast/expressions/ctor.h>
 #include <hilti/ast/expressions/resolved-operator.h>
 #include <hilti/ast/operators/function.h>
+#include <hilti/ast/operators/map.h>
 #include <hilti/ast/operators/struct.h>
+#include <hilti/ast/operators/tuple.h>
+#include <hilti/ast/operators/vector.h>
 #include <hilti/ast/types/bitfield.h>
 #include <hilti/ast/types/integer.h>
 #include <hilti/ast/types/reference.h>
@@ -211,6 +214,16 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
         replaceNode(n, func);
     }
 
+    void operator()(hilti::operator_::map::IndexConst* n) final {
+        auto* x = builder()->index(n->op0(), n->op1(), n->meta());
+        replaceNode(n, x);
+    }
+
+    void operator()(hilti::operator_::map::IndexNonConst* n) final {
+        auto* x = builder()->index(n->op0(), n->op1(), n->meta());
+        replaceNode(n, x);
+    }
+
     void operator()(operator_::unit::Unset* n) final {
         const auto& id = n->op1()->as<hilti::expression::Member>()->id();
         replaceNode(n, builder()->unset(n->op0(), id, n->meta()));
@@ -309,6 +322,21 @@ struct VisitorPass2 : public visitor::MutatingPostOrder {
 
     void operator()(operator_::unit::Stream* n) final {
         replaceNode(n, builder()->deref(builder()->member(n->op0(), ID("__stream"))));
+    }
+
+    void operator()(hilti::operator_::tuple::Index* n) final {
+        auto* x = builder()->index(n->op0(), n->op1(), n->meta());
+        replaceNode(n, x);
+    }
+
+    void operator()(hilti::operator_::vector::IndexConst* n) final {
+        auto* x = builder()->index(n->op0(), n->op1(), n->meta());
+        replaceNode(n, x);
+    }
+
+    void operator()(hilti::operator_::vector::IndexNonConst* n) final {
+        auto* x = builder()->index(n->op0(), n->op1(), n->meta());
+        replaceNode(n, x);
     }
 
     void operator()(operator_::sink::Close* n) final {

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -398,7 +398,8 @@ struct ProductionVisitor : public production::Visitor {
                     run_finally();
 
                     if ( profiler ) {
-                        auto* offset = builder()->memberCall(builder()->index(store_result, 0), "offset");
+                        auto* offset =
+                            builder()->memberCall(builder()->index(store_result, builder()->integer(0U)), "offset");
                         builder()->stopProfiler(profiler, offset);
                     }
 
@@ -800,7 +801,7 @@ struct ProductionVisitor : public production::Visitor {
             auto* index = builder()->addTmp("index", builder()->integer(*field->index()));
             builder()->addMemberCall(__offsets, "resize", {builder()->sum(index, builder()->integer(1))});
 
-            builder()->addAssign(builder()->index(__offsets, *field->index()),
+            builder()->addAssign(builder()->index(__offsets, builder()->integer(*field->index())),
                                  builder()->tuple(
                                      {cur_offset,
                                       builder()->optional(builder()->qualifiedType(builder()->typeUnsignedInteger(64),
@@ -922,9 +923,10 @@ struct ProductionVisitor : public production::Visitor {
             assert(field->index());
             auto* __offsets = builder()->member(state().self, "__offsets");
             auto* cur_offset = builder()->memberCall(state().cur, "offset");
-            auto* offsets = builder()->index(__offsets, *field->index());
+            auto* offsets = builder()->index(__offsets, builder()->integer(*field->index()));
             builder()->addAssign(offsets,
-                                 builder()->tuple({builder()->index(builder()->deref(offsets), 0), cur_offset}));
+                                 builder()->tuple({builder()->index(builder()->deref(offsets), builder()->integer(0U)),
+                                                   cur_offset}));
         }
 
         auto* val = destination();

--- a/tests/spicy/types/tuple/self-recursive.spicy
+++ b/tests/spicy/types/tuple/self-recursive.spicy
@@ -1,0 +1,12 @@
+# @TEST-EXEC: spicyc -j %INPUT
+#
+# @TEST-DOC: Ensure we can compile a self-recursive tuple type; regression test for #2061.
+module Test;
+
+public type Data = unit {
+    on %done {
+        print self.x;
+    }
+
+    var x: tuple<Data>;
+};


### PR DESCRIPTION
We had cyclic dependencies partially solved through the `&on-heap`
conversion, but weren't consistently applying it to types nested
inside others.

Closes #2061.

- **Add API method to ctors to see if they create a reference.**
- **Small tweak to builder API so that we can create index expression with operands other than integers.**
- **Fix cyclic usage of units types inside other types.**
