### PR TITLE
Coverity fixes

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -260,7 +260,7 @@ struct Visitor : hilti::visitor::PreOrder {
             auto body = cg->compile(c->body());
 
             if ( first ) {
-                block->addIf(fmt("%s %s = %s", cxx_type, cxx_id, cxx_init), std::move(cond), body);
+                block->addIf(fmt("%s %s = %s", cxx_type, cxx_id, cxx_init), std::move(cond), std::move(body));
                 first = false;
             }
             else
@@ -274,7 +274,7 @@ struct Visitor : hilti::visitor::PreOrder {
         else
             default_.addStatement(
                 fmt("throw ::hilti::rt::UnhandledSwitchCase(::hilti::rt::to_string_for_print(%s), \"%s\")",
-                    (first ? cxx_init : std::move(cxx_id)), n->meta().location()));
+                    (first ? std::move(cxx_init) : std::move(cxx_id)), n->meta().location()));
 
         if ( first )
             block->addBlock(std::move(default_));
@@ -385,10 +385,10 @@ struct Visitor : hilti::visitor::PreOrder {
         auto body = cg->compile(n->body());
 
         if ( sinit.empty() )
-            block->addWhile(cond, body);
+            block->addWhile(std::move(cond), body);
 
         else if ( cond.empty() )
-            block->addWhile(sinit, body);
+            block->addWhile(std::move(sinit), body);
 
         else
             // C++ doesn't support having both init and cond in a while-loop.

--- a/spicy/toolchain/bin/spicy-doc.cc
+++ b/spicy/toolchain/bin/spicy-doc.cc
@@ -141,8 +141,8 @@ int main(int argc, char** argv) try {
         jop["commutative"] = hilti::operator_::isCommutative(op.kind());
         jop["operands"] = json::array();
 
-        if ( auto rtype = op.signature().result_doc; ! rtype.empty() )
-            jop["rtype"] = std::move(rtype);
+        if ( const auto& rtype = op.signature().result_doc; ! rtype.empty() )
+            jop["rtype"] = rtype;
         else
             jop["rtype"] = formatType(op.result(&builder, {}, hilti::Meta())->type());
 

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -2044,7 +2044,7 @@ struct ProductionVisitor : public production::Visitor {
                                     syncProductionNext(*p);
                                 });
 
-                    pushBuilder(builder_default,
+                    pushBuilder(std::move(builder_default),
                                 [&]() { pb->parseError("no expected look-ahead token found", p->location()); });
                 }
                 else {

--- a/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
@@ -358,7 +358,7 @@ struct Visitor : public visitor::PreOrder {
                 for ( const auto& b : n->bits() ) {
                     auto error =
                         builder()->addIf(builder()->unequal(builder()->member(value, b->id()), b->expression()));
-                    pushBuilder(error);
+                    pushBuilder(std::move(error));
                     builder()->addAssign(state().cur, old_cur);
                     pb()->parseError(fmt("unexpected value for bitfield element '%s'", b->id()), n->meta());
                     popBuilder();

--- a/spicy/toolchain/src/compiler/codegen/parsers/types.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/types.cc
@@ -109,7 +109,7 @@ struct Visitor : public visitor::PreOrder {
     Expression* result = nullptr;
 
     auto pb() { return tp->pb; }
-    auto state() { return pb()->state(); }
+    const auto& state() { return pb()->state(); }
     auto builder() { return pb()->builder(); }
     auto context() { return pb()->context(); }
     auto pushBuilder(std::shared_ptr<Builder> b) { return pb()->pushBuilder(std::move(b)); }


### PR DESCRIPTION
Round of fixes for some issues marked as being fixed but were probably missed in the awesome UI. I did not dig to find out if they're actually fine, I'd rather just shut them up :)

There are a couple of "uncaught" exceptions in `spicy-driver.cc` that may need to be manually resolved, I think they were fixed by 6fc414d? Not looking super hard, though - maybe I missed something. CIDs 1586737 & 1586307

Also fixing 1586205 caused a `stack-use-after-scope` address sanitizer issue [in CI](https://cirrus-ci.com/task/6232057568821248?logs=build#L462) so I dumped it