### PR TITLE
Fix fiber abortion.

### DIFF
--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -257,8 +257,11 @@ detail::Fiber::Fiber(Type type) : _type(type), _fiber(std::make_unique<::Fiber>(
     };
 }
 
-HILTI_EXCEPTION(AbortException, RuntimeError);
-AbortException::~AbortException() = default;
+// Exception raised by a fiber resuming operation in case it has been aborted
+// in the meantime. This must not be derived from `std::exception` to guarantee
+// that it will bubble back up to the fiber code, without being caught by any
+// intermediary catch handlers.
+struct AbortException {};
 
 detail::Fiber::~Fiber() {
 #ifndef NDEBUG
@@ -531,7 +534,7 @@ void detail::Fiber::yield() {
     _yield("yield");
 
     if ( _state == State::Aborting )
-        throw AbortException("processing aborted for input");
+        throw AbortException();
 }
 
 void detail::Fiber::resume() {
@@ -546,7 +549,12 @@ void detail::Fiber::abort() {
     if ( ! context::detail::get(true) )
         return;
 
-    run();
+    try {
+        run();
+    } catch ( const AbortException& ) {
+        // Exception is expected here when the fiber realizes it has been
+        // aborted.
+    }
 }
 
 std::unique_ptr<detail::Fiber> detail::Fiber::create() {


### PR DESCRIPTION
When aborting a fiber, we need to activate it once more, to then leave
it for good by raising an `AbortException`. Problem was that that
exception ended up being caught by user code because it was derived
from `std::exception`. This change removes the base class so that the
exception is guaranteed to go back to the managing fiber code, where
we just ignore it.
