### PR TITLE
Enforce that block-local declarations must be variables.

### DIFF
--- a/hilti/toolchain/src/compiler/validator.cc
+++ b/hilti/toolchain/src/compiler/validator.cc
@@ -555,6 +555,11 @@ struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
         }
     }
 
+    void operator()(statement::Declaration* n) final {
+        if ( ! n->declaration()->isA<declaration::LocalVariable>() )
+            error("only variables can be declared inside local scopes", n);
+    }
+
     void operator()(statement::Return* n) final {
         auto* func = n->parent<Function>();
 


### PR DESCRIPTION
Logically we already had this restriction in place, but so far it
would lead to either a crash or an internal error.

Closes #1988.
