### PR TITLE
Fully implement iterator interface for `set::Iterator`.

### DIFF
--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -38,6 +38,12 @@ class Iterator {
     typename S::V::iterator _iterator;
 
 public:
+    using iterator_category = typename S::V::iterator::iterator_category;
+    using value_type = typename S::V::value_type;
+    using difference_type = typename S::V::difference_type;
+    using pointer = typename S::V::pointer;
+    using reference = typename S::V::reference;
+
     Iterator() = default;
 
     typename S::reference operator*() const {


### PR DESCRIPTION
We use our container iterators like stdlib iterators, e.g., we expect that they can work with `std::back_inserter`. This requires that our iterators implement the stdlib iterator interface, either by deriving from `std::iterator_category`, or by providing needed dependent types by hand. In fact, with C++20 and its support for concepts the standard library might more strictly enforce this requirement and non-complying iterators might stop compiling.

This patch implements the full iterator interface for `set::Iterator`.