### PR TITLE
Add missing deref operations for struct try-member/has-member operators.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -910,7 +910,11 @@ struct Visitor : hilti::visitor::PreOrder {
     void operator()(operator_::struct_::HasMember* n) final {
         const auto& id = n->op1()->as<expression::Member>()->id();
 
-        if ( auto* f = n->op0()->type()->type()->as<type::Struct>()->field(id); f->isOptional() )
+        auto* type = n->op0()->type()->type();
+        if ( type->isReferenceType() )
+            type = type->dereferencedType()->type();
+
+        if ( auto* f = type->as<type::Struct>()->field(id); f->isOptional() )
             result = fmt("%s.has_value()", memberAccess(n, id));
         else
             result = "true";
@@ -920,7 +924,11 @@ struct Visitor : hilti::visitor::PreOrder {
         const auto& id = n->op1()->as<expression::Member>()->id();
         assert(! lhs);
 
-        if ( auto* f = n->op0()->type()->type()->as<type::Struct>()->field(id); f->isOptional() ) {
+        auto* type = n->op0()->type()->type();
+        if ( type->isReferenceType() )
+            type = type->dereferencedType()->type();
+
+        if ( auto* f = type->as<type::Struct>()->field(id); f->isOptional() ) {
             auto attr = memberAccess(n, id);
 
             if ( auto* d = f->default_() )

--- a/tests/spicy/types/struct/ref-has-member.spicy
+++ b/tests/spicy/types/struct/ref-has-member.spicy
@@ -1,0 +1,16 @@
+# @TEST-EXEC: spicyc -c -d %INPUT
+#
+# @TEST-DOC: Check compilation of struct has-member operator on value_ref; regression test for issue #2100
+
+module Test;
+
+function stringify(data: Data) {
+    local elements = data?.elements ? data.elements : data.elements;
+    for (ele in elements) {
+        stringify(ele);
+    }
+}
+
+type Data = unit {
+    elements: Data[1];
+};


### PR DESCRIPTION
The regular member access operators already did this.

Closes #2100.
