### PR TITLE
Clean up temporary JIT output files.

### DIFF
--- a/hilti/toolchain/include/compiler/jit.h
+++ b/hilti/toolchain/include/compiler/jit.h
@@ -191,9 +191,11 @@ private:
     std::vector<hilti::rt::filesystem::path> _objects;
 
     struct Job {
+        ~Job();
+
         std::string cmdline;
         std::unique_ptr<reproc::process> process;
-        hilti::rt::filesystem::path output; // path to file capturing process output
+        hilti::rt::filesystem::path output; // path to file capturing process output; file will be deleted by destructor
     };
 
     struct JobRunner {

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -249,6 +249,8 @@ hilti::Result<Nothing> JIT::_checkCompiler() {
     return Nothing();
 }
 
+JIT::Job::~Job() { hilti::rt::filesystem::remove(output); }
+
 void JIT::JobRunner::finish() {
     for ( auto&& [id, job] : jobs ) {
         auto [status, ec] = job.process->stop(reproc::stop_actions{


### PR DESCRIPTION
Closes https://github.com/zeek/zeek/issues/4658.
