### PR TITLE
Fix dataflow extraction of reads and writes in assignments.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/cfg.h
+++ b/hilti/toolchain/include/compiler/detail/cfg.h
@@ -137,7 +137,7 @@ struct Transfer {
     std::unordered_map<Declaration*, std::unordered_set<GraphNode>> out;
 
     /** The previous nodes killed by this node. */
-    std::unordered_set<GraphNode> kill;
+    std::unordered_map<Declaration*, std::unordered_set<GraphNode>> kill;
 
     /** Set of declarations this node may alias. */
     std::unordered_set<Declaration*> maybe_alias;

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -453,9 +453,11 @@ std::string CFG::dot() const {
             auto in_out = [&]() -> std::string {
                 auto to_str = [&](const auto& xs) {
                     std::vector<std::string> ys;
-                    for ( const auto& [_, stmts] : xs ) {
+                    for ( const auto& [decl, stmts] : xs ) {
+                        std::vector<std::string> xs;
                         for ( const auto& stmt : stmts )
-                            ys.push_back(escape(stmt->print()));
+                            xs.push_back(escape(stmt->print()));
+                        ys.push_back(util::fmt("%s: %s", decl->id(), util::join(xs, ", ")));
                     }
 
                     std::ranges::sort(ys);

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <map>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -439,31 +440,26 @@ std::string CFG::dot() const {
                     return std::string();
             }();
 
-            auto kill = [&]() {
-                auto xs = util::transformToVector(transfer.kill, [&](const auto& stmt) {
-                    return util::fmt("%s", escape(stmt->print()));
-                });
-                std::ranges::sort(xs);
-                if ( ! xs.empty() )
-                    return util::fmt("kill: [%s]", util::join(xs, " "));
-                else
-                    return std::string();
+            auto to_str = [&](const auto& xs) {
+                std::vector<std::string> ys;
+                for ( const auto& [decl, stmts] : xs ) {
+                    std::vector<std::string> xs;
+                    for ( const auto& stmt : stmts )
+                        xs.push_back(escape(stmt->print()));
+                    ys.push_back(util::fmt("%s: %s", decl->id(), util::join(xs, ", ")));
+                }
+
+                std::ranges::sort(ys);
+                return util::join(ys, ", ");
+            };
+
+            auto kill = [&]() -> std::string {
+                if ( transfer.kill.empty() )
+                    return "";
+                return util::fmt("kill: [%s]", to_str(transfer.kill));
             }();
 
             auto in_out = [&]() -> std::string {
-                auto to_str = [&](const auto& xs) {
-                    std::vector<std::string> ys;
-                    for ( const auto& [decl, stmts] : xs ) {
-                        std::vector<std::string> xs;
-                        for ( const auto& stmt : stmts )
-                            xs.push_back(escape(stmt->print()));
-                        ys.push_back(util::fmt("%s: %s", decl->id(), util::join(xs, ", ")));
-                    }
-
-                    std::ranges::sort(ys);
-                    return util::join(ys, ", ");
-                };
-
                 return util::fmt("in: [%s] out: [%s]", to_str(transfer.in), to_str(transfer.out));
             }();
 
@@ -855,8 +851,11 @@ void CFG::_populateDataflow() {
                 if ( auto it = transfer.in.find(decl); it != transfer.in.end() ) {
                     const auto& [_, prev] = *it;
 
+                    changed |= ! transfer.kill.contains(decl);
+                    auto& kill = transfer.kill[decl];
+
                     for ( const auto& p : prev ) {
-                        auto [_, inserted] = transfer.kill.insert(p);
+                        auto [_, inserted] = kill.insert(p);
                         changed |= inserted;
                     }
                 }
@@ -866,8 +865,11 @@ void CFG::_populateDataflow() {
             if ( const auto* scope_end = n->tryAs<End>() ) {
                 for ( auto& [decl, stmts] : transfer.in ) {
                     if ( _contains(*scope_end->scope, *decl) ) {
+                        changed |= ! transfer.kill.contains(decl);
+                        auto& kill = transfer.kill[decl];
+
                         for ( const auto& stmt : stmts ) {
-                            auto [_, inserted] = transfer.kill.insert(stmt);
+                            auto [_, inserted] = kill.insert(stmt);
                             changed |= inserted;
                         }
                     }
@@ -883,7 +885,7 @@ void CFG::_populateDataflow() {
             for ( const auto& [decl, stmt] : transfer.in ) {
                 // Add the incoming statements to the out set.
                 for ( const auto& in : stmt ) {
-                    if ( transfer.kill.contains(in) )
+                    if ( transfer.kill.contains(decl) && transfer.kill.at(decl).contains(in) )
                         continue;
 
                     // Make sure the entry exists.

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -589,25 +589,34 @@ struct DataflowVisitor : visitor::PreOrder {
         if ( auto* assign = stmt->tryAs<expression::Assign>() ) {
             // Figure out which side of the assignment this name is on.
             std::set<Side> uses;
-            Node* x = name;
+
+            Node* node = name;
             do {
-                if ( x == assign->target() ) {
-                    uses.insert(Side::LHS);
-                    break;
-                }
+                if ( auto* assign_ = node->tryAs<expression::Assign>() ) {
+                    if ( _contains(*assign_->target(), *name) )
+                        uses.insert(Side::LHS);
 
-                if ( x == assign->source() ) {
-                    uses.insert(Side::RHS);
-                    break;
+                    if ( _contains(*assign_->source(), *name) )
+                        uses.insert(Side::RHS);
                 }
+                node = node->parent();
 
-                x = x->parent();
-            } while ( x && x != root.value() );
-            assert(! uses.empty());
+                // We either climb up to the original statement, or stop when
+                // we have found a use. A particular name can only appear on a
+                // single side of an assignment (if the same identifier appears
+                // elsewhere it would be a different name instance), so
+                // stopping once we have the first use extracts the desired
+                // information, e.g., `x = (x = 1)` only ever writes to `x`,
+                // but does not read it, even though `x` also appears on the
+                // RHS.
+            } while ( node && node != root.value() && uses.empty() );
 
             for ( auto side : uses )
                 switch ( side ) {
-                    case Side::RHS: transfer.read.insert(decl); break;
+                    case Side::RHS: {
+                        transfer.read.insert(decl);
+                        break;
+                    }
                     case Side::LHS: {
                         transfer.write.insert(decl);
 

--- a/tests/Baseline/hilti.cfg.assign/output
+++ b/tests/Baseline/hilti.cfg.assign/output
@@ -2,8 +2,8 @@
 [debug/cfg-initial] Module 'foo'
 digraph {
     0 [label=start shape=Mdiamond xlabel="in: [] out: []"];
-    1 [label="end <...>/assign.hlt:4:1-12:1" shape=triangle xlabel="in: [] out: []"];
-    2 [label="end <...>/assign.hlt:4:1-12:1" shape=triangle xlabel="in: [] out: []"];
+    1 [label="end <...>/assign.hlt:4:1-27:1" shape=triangle xlabel="in: [] out: []"];
+    2 [label="end <...>/assign.hlt:4:1-27:1" shape=triangle xlabel="in: [] out: []"];
     0 -> 2 [label="0"];
     2 -> 1 [label="1"];
 }
@@ -11,13 +11,41 @@ digraph {
 digraph {
     0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
     1 [label="x = x + 1;" xlabel="read: [x] write: [x] gen: [x: x = x + 1;] kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;] out: [x = x + 1;]"];
-    2 [label="return x;" xlabel="read: [x] in: [x = x + 1;] out: [x = x + 1;] keep"];
-    3 [label=start shape=Mdiamond xlabel="in: [] out: []"];
-    4 [label="end <...>/assign.hlt:6:24-10:1" shape=triangle xlabel="kill: [x = x + 1;] in: [x = x + 1;] out: []"];
-    3 -> 0 [label="0"];
+    2 [label=start shape=Mdiamond xlabel="in: [] out: []"];
+    3 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="in: [] out: []"];
+    4 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="kill: [x = x + 1;] in: [x = x + 1;] out: []"];
+    2 -> 0 [label="0"];
+    0 -> 1 [label="1"];
+    1 -> 4 [label="2"];
+    4 -> 3 [label="3"];
+}
+[debug/cfg-initial] Function 'fn2'
+digraph {
+    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
+    1 [label="local uint<64> y = 1;" xlabel="gen: [y: local uint<64> y = 1;] in: [local uint<64> x = 1;] out: [local uint<64> x = 1;, local uint<64> y = 1;]"];
+    2 [label="x = (x = 1);" xlabel="write: [x] gen: [x: x = (x = 1);] kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;, local uint<64> y = 1;] out: [local uint<64> y = 1;, x = (x = 1);]"];
+    3 [label="x = (y = 1);" xlabel="write: [x, y] gen: [x: x = (y = 1);, y: x = (y = 1);] kill: [local uint<64> y = 1; x = (x = 1);] in: [local uint<64> y = 1;, x = (x = 1);] out: [x = (y = 1);, x = (y = 1);]"];
+    4 [label="x = (x = (y = 1));" xlabel="write: [x, y] gen: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] kill: [x = (y = 1);] in: [x = (y = 1);, x = (y = 1);] out: [x = (x = (y = 1));, x = (x = (y = 1));]"];
+    5 [label="(x = 1) = x;" xlabel="read: [x] write: [x] gen: [x: (x = 1) = x;] kill: [x = (x = (y = 1));] in: [x = (x = (y = 1));, x = (x = (y = 1));] out: [(x = 1) = x;]"];
+    6 [label="(y = 1) = x;" xlabel="read: [x] write: [y] gen: [y: (y = 1) = x;] in: [(x = 1) = x;] out: [(x = 1) = x;, (y = 1) = x;]"];
+    7 [label="(x = (y = 1)) = x;" xlabel="read: [x] write: [x, y] gen: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] kill: [(x = 1) = x; (y = 1) = x;] in: [(x = 1) = x;, (y = 1) = x;] out: [(x = (y = 1)) = x;, (x = (y = 1)) = x;]"];
+    8 [label="(x = 1) = (y = 1);" xlabel="write: [x, y] gen: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] kill: [(x = (y = 1)) = x;] in: [(x = (y = 1)) = x;, (x = (y = 1)) = x;] out: [(x = 1) = (y = 1);, (x = 1) = (y = 1);]"];
+    9 [label="(y = 1) = (x = (y = 1));" xlabel="write: [x, y] gen: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] kill: [(x = 1) = (y = 1);] in: [(x = 1) = (y = 1);, (x = 1) = (y = 1);] out: [(y = 1) = (x = (y = 1));, (y = 1) = (x = (y = 1));]"];
+    10 [label=start shape=Mdiamond xlabel="in: [] out: []"];
+    11 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="in: [] out: []"];
+    12 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="kill: [(y = 1) = (x = (y = 1));] in: [(y = 1) = (x = (y = 1));, (y = 1) = (x = (y = 1));] out: []"];
+    10 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 2 [label="2"];
-    2 -> 4 [label="3"];
+    2 -> 3 [label="3"];
+    3 -> 4 [label="4"];
+    4 -> 5 [label="5"];
+    5 -> 6 [label="6"];
+    6 -> 7 [label="7"];
+    7 -> 8 [label="8"];
+    8 -> 9 [label="9"];
+    9 -> 12 [label="10"];
+    12 -> 11 [label="11"];
 }
 [debug/cfg-initial] Module 'hilti'
 digraph {

--- a/tests/Baseline/hilti.cfg.assign/output
+++ b/tests/Baseline/hilti.cfg.assign/output
@@ -9,11 +9,11 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn'
 digraph {
-    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
-    1 [label="x = x + 1;" xlabel="read: [x] write: [x] gen: [x: x = x + 1;] kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;] out: [x = x + 1;]"];
+    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
+    1 [label="x = x + 1;" xlabel="read: [x] write: [x] gen: [x: x = x + 1;] kill: [local uint<64> x = 1;] in: [x: local uint<64> x = 1;] out: [x: x = x + 1;]"];
     2 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     3 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="in: [] out: []"];
-    4 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="kill: [x = x + 1;] in: [x = x + 1;] out: []"];
+    4 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="kill: [x = x + 1;] in: [x: x = x + 1;] out: []"];
     2 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 4 [label="2"];
@@ -21,19 +21,19 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn2'
 digraph {
-    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
-    1 [label="local uint<64> y = 1;" xlabel="gen: [y: local uint<64> y = 1;] in: [local uint<64> x = 1;] out: [local uint<64> x = 1;, local uint<64> y = 1;]"];
-    2 [label="x = (x = 1);" xlabel="write: [x] gen: [x: x = (x = 1);] kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;, local uint<64> y = 1;] out: [local uint<64> y = 1;, x = (x = 1);]"];
-    3 [label="x = (y = 1);" xlabel="write: [x, y] gen: [x: x = (y = 1);, y: x = (y = 1);] kill: [local uint<64> y = 1; x = (x = 1);] in: [local uint<64> y = 1;, x = (x = 1);] out: [x = (y = 1);, x = (y = 1);]"];
-    4 [label="x = (x = (y = 1));" xlabel="write: [x, y] gen: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] kill: [x = (y = 1);] in: [x = (y = 1);, x = (y = 1);] out: [x = (x = (y = 1));, x = (x = (y = 1));]"];
-    5 [label="(x = 1) = x;" xlabel="read: [x] write: [x] gen: [x: (x = 1) = x;] kill: [x = (x = (y = 1));] in: [x = (x = (y = 1));, x = (x = (y = 1));] out: [(x = 1) = x;]"];
-    6 [label="(y = 1) = x;" xlabel="read: [x] write: [y] gen: [y: (y = 1) = x;] in: [(x = 1) = x;] out: [(x = 1) = x;, (y = 1) = x;]"];
-    7 [label="(x = (y = 1)) = x;" xlabel="read: [x] write: [x, y] gen: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] kill: [(x = 1) = x; (y = 1) = x;] in: [(x = 1) = x;, (y = 1) = x;] out: [(x = (y = 1)) = x;, (x = (y = 1)) = x;]"];
-    8 [label="(x = 1) = (y = 1);" xlabel="write: [x, y] gen: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] kill: [(x = (y = 1)) = x;] in: [(x = (y = 1)) = x;, (x = (y = 1)) = x;] out: [(x = 1) = (y = 1);, (x = 1) = (y = 1);]"];
-    9 [label="(y = 1) = (x = (y = 1));" xlabel="write: [x, y] gen: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] kill: [(x = 1) = (y = 1);] in: [(x = 1) = (y = 1);, (x = 1) = (y = 1);] out: [(y = 1) = (x = (y = 1));, (y = 1) = (x = (y = 1));]"];
+    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
+    1 [label="local uint<64> y = 1;" xlabel="gen: [y: local uint<64> y = 1;] in: [x: local uint<64> x = 1;] out: [x: local uint<64> x = 1;, y: local uint<64> y = 1;]"];
+    2 [label="x = (x = 1);" xlabel="write: [x] gen: [x: x = (x = 1);] kill: [local uint<64> x = 1;] in: [x: local uint<64> x = 1;, y: local uint<64> y = 1;] out: [x: x = (x = 1);, y: local uint<64> y = 1;]"];
+    3 [label="x = (y = 1);" xlabel="write: [x, y] gen: [x: x = (y = 1);, y: x = (y = 1);] kill: [local uint<64> y = 1; x = (x = 1);] in: [x: x = (x = 1);, y: local uint<64> y = 1;] out: [x: x = (y = 1);, y: x = (y = 1);]"];
+    4 [label="x = (x = (y = 1));" xlabel="write: [x, y] gen: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] kill: [x = (y = 1);] in: [x: x = (y = 1);, y: x = (y = 1);] out: [x: x = (x = (y = 1));, y: x = (x = (y = 1));]"];
+    5 [label="(x = 1) = x;" xlabel="read: [x] write: [x] gen: [x: (x = 1) = x;] kill: [x = (x = (y = 1));] in: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] out: [x: (x = 1) = x;]"];
+    6 [label="(y = 1) = x;" xlabel="read: [x] write: [y] gen: [y: (y = 1) = x;] in: [x: (x = 1) = x;] out: [x: (x = 1) = x;, y: (y = 1) = x;]"];
+    7 [label="(x = (y = 1)) = x;" xlabel="read: [x] write: [x, y] gen: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] kill: [(x = 1) = x; (y = 1) = x;] in: [x: (x = 1) = x;, y: (y = 1) = x;] out: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;]"];
+    8 [label="(x = 1) = (y = 1);" xlabel="write: [x, y] gen: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] kill: [(x = (y = 1)) = x;] in: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] out: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);]"];
+    9 [label="(y = 1) = (x = (y = 1));" xlabel="write: [x, y] gen: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] kill: [(x = 1) = (y = 1);] in: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] out: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));]"];
     10 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     11 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="in: [] out: []"];
-    12 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="kill: [(y = 1) = (x = (y = 1));] in: [(y = 1) = (x = (y = 1));, (y = 1) = (x = (y = 1));] out: []"];
+    12 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="kill: [(y = 1) = (x = (y = 1));] in: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] out: []"];
     10 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 2 [label="2"];

--- a/tests/Baseline/hilti.cfg.assign/output
+++ b/tests/Baseline/hilti.cfg.assign/output
@@ -10,10 +10,10 @@ digraph {
 [debug/cfg-initial] Function 'fn'
 digraph {
     0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
-    1 [label="x = x + 1;" xlabel="read: [x] write: [x] gen: [x: x = x + 1;] kill: [local uint<64> x = 1;] in: [x: local uint<64> x = 1;] out: [x: x = x + 1;]"];
+    1 [label="x = x + 1;" xlabel="read: [x] write: [x] gen: [x: x = x + 1;] kill: [x: local uint<64> x = 1;] in: [x: local uint<64> x = 1;] out: [x: x = x + 1;]"];
     2 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     3 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="in: [] out: []"];
-    4 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="kill: [x = x + 1;] in: [x: x = x + 1;] out: []"];
+    4 [label="end <...>/assign.hlt:6:24-9:1" shape=triangle xlabel="kill: [x: x = x + 1;] in: [x: x = x + 1;] out: []"];
     2 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 4 [label="2"];
@@ -23,17 +23,17 @@ digraph {
 digraph {
     0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
     1 [label="local uint<64> y = 1;" xlabel="gen: [y: local uint<64> y = 1;] in: [x: local uint<64> x = 1;] out: [x: local uint<64> x = 1;, y: local uint<64> y = 1;]"];
-    2 [label="x = (x = 1);" xlabel="write: [x] gen: [x: x = (x = 1);] kill: [local uint<64> x = 1;] in: [x: local uint<64> x = 1;, y: local uint<64> y = 1;] out: [x: x = (x = 1);, y: local uint<64> y = 1;]"];
-    3 [label="x = (y = 1);" xlabel="write: [x, y] gen: [x: x = (y = 1);, y: x = (y = 1);] kill: [local uint<64> y = 1; x = (x = 1);] in: [x: x = (x = 1);, y: local uint<64> y = 1;] out: [x: x = (y = 1);, y: x = (y = 1);]"];
-    4 [label="x = (x = (y = 1));" xlabel="write: [x, y] gen: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] kill: [x = (y = 1);] in: [x: x = (y = 1);, y: x = (y = 1);] out: [x: x = (x = (y = 1));, y: x = (x = (y = 1));]"];
-    5 [label="(x = 1) = x;" xlabel="read: [x] write: [x] gen: [x: (x = 1) = x;] kill: [x = (x = (y = 1));] in: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] out: [x: (x = 1) = x;]"];
-    6 [label="(y = 1) = x;" xlabel="read: [x] write: [y] gen: [y: (y = 1) = x;] in: [x: (x = 1) = x;] out: [x: (x = 1) = x;, y: (y = 1) = x;]"];
-    7 [label="(x = (y = 1)) = x;" xlabel="read: [x] write: [x, y] gen: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] kill: [(x = 1) = x; (y = 1) = x;] in: [x: (x = 1) = x;, y: (y = 1) = x;] out: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;]"];
-    8 [label="(x = 1) = (y = 1);" xlabel="write: [x, y] gen: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] kill: [(x = (y = 1)) = x;] in: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] out: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);]"];
-    9 [label="(y = 1) = (x = (y = 1));" xlabel="write: [x, y] gen: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] kill: [(x = 1) = (y = 1);] in: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] out: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));]"];
+    2 [label="x = (x = 1);" xlabel="write: [x] gen: [x: x = (x = 1);] kill: [x: local uint<64> x = 1;] in: [x: local uint<64> x = 1;, y: local uint<64> y = 1;] out: [x: x = (x = 1);, y: local uint<64> y = 1;]"];
+    3 [label="x = (y = 1);" xlabel="write: [x, y] gen: [x: x = (y = 1);, y: x = (y = 1);] kill: [x: x = (x = 1);, y: local uint<64> y = 1;] in: [x: x = (x = 1);, y: local uint<64> y = 1;] out: [x: x = (y = 1);, y: x = (y = 1);]"];
+    4 [label="x = (x = (y = 1));" xlabel="write: [x, y] gen: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] kill: [x: x = (y = 1);, y: x = (y = 1);] in: [x: x = (y = 1);, y: x = (y = 1);] out: [x: x = (x = (y = 1));, y: x = (x = (y = 1));]"];
+    5 [label="(x = 1) = x;" xlabel="read: [x] write: [x] gen: [x: (x = 1) = x;] kill: [x: x = (x = (y = 1));] in: [x: x = (x = (y = 1));, y: x = (x = (y = 1));] out: [x: (x = 1) = x;, y: x = (x = (y = 1));]"];
+    6 [label="(y = 1) = x;" xlabel="read: [x] write: [y] gen: [y: (y = 1) = x;] kill: [y: x = (x = (y = 1));] in: [x: (x = 1) = x;, y: x = (x = (y = 1));] out: [x: (x = 1) = x;, y: (y = 1) = x;]"];
+    7 [label="(x = (y = 1)) = x;" xlabel="read: [x] write: [x, y] gen: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] kill: [x: (x = 1) = x;, y: (y = 1) = x;] in: [x: (x = 1) = x;, y: (y = 1) = x;] out: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;]"];
+    8 [label="(x = 1) = (y = 1);" xlabel="write: [x, y] gen: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] kill: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] in: [x: (x = (y = 1)) = x;, y: (x = (y = 1)) = x;] out: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);]"];
+    9 [label="(y = 1) = (x = (y = 1));" xlabel="write: [x, y] gen: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] kill: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] in: [x: (x = 1) = (y = 1);, y: (x = 1) = (y = 1);] out: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));]"];
     10 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     11 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="in: [] out: []"];
-    12 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="kill: [(y = 1) = (x = (y = 1));] in: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] out: []"];
+    12 [label="end <...>/assign.hlt:11:25-25:1" shape=triangle xlabel="kill: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] in: [x: (y = 1) = (x = (y = 1));, y: (y = 1) = (x = (y = 1));] out: []"];
     10 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 2 [label="2"];

--- a/tests/Baseline/hilti.cfg.dead-write-shadowed/output
+++ b/tests/Baseline/hilti.cfg.dead-write-shadowed/output
@@ -13,13 +13,13 @@ digraph {
 }
 [debug/cfg-final] Function 'f'
 digraph {
-    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
-    1 [label="x = 5;" xlabel="write: [x] gen: [x: x = 5;] kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;] out: [x = 5;]"];
-    2 [label="hilti::print(x, True);" xlabel="read: [print, x] write: [print, x] in: [x = 5;] out: [x = 5;] keep"];
+    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
+    1 [label="x = 5;" xlabel="write: [x] gen: [x: x = 5;] kill: [x: local uint<64> x = 1;] in: [x: local uint<64> x = 1;] out: [x: x = 5;]"];
+    2 [label="hilti::print(x, True);" xlabel="read: [print, x] write: [print, x] in: [x: x = 5;] out: [x: x = 5;] keep"];
     3 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     4 [label="end <...>/dead-write-shadowed.hlt:10:19-18:1" shape=triangle xlabel="in: [] out: []"];
-    5 [label="end <...>/dead-write-shadowed.hlt:10:19-18:1" shape=triangle xlabel="kill: [x = 5;] in: [x = 5;] out: []"];
-    6 [label="end <...>/dead-write-shadowed.hlt:12:5-16:5" shape=triangle xlabel="in: [x = 5;] out: [x = 5;]"];
+    5 [label="end <...>/dead-write-shadowed.hlt:10:19-18:1" shape=triangle xlabel="kill: [x: x = 5;] in: [x: x = 5;] out: []"];
+    6 [label="end <...>/dead-write-shadowed.hlt:12:5-16:5" shape=triangle xlabel="in: [x: x = 5;] out: [x: x = 5;]"];
     3 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 6 [label="2"];

--- a/tests/Baseline/hilti.cfg.for/output
+++ b/tests/Baseline/hilti.cfg.for/output
@@ -9,14 +9,14 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn'
 digraph {
-    0 [label="[1, 2, 3]" xlabel="in: [local uint<64> i] out: [local uint<64> i] keep"];
-    1 [label="i++;" xlabel="read: [i] write: [i] in: [local uint<64> i] out: [local uint<64> i] keep"];
-    2 [label="local uint<64> i" xlabel="gen: [i: local uint<64> i] kill: [local uint<64> i] in: [local uint<64> i] out: [local uint<64> i]"];
+    0 [label="[1, 2, 3]" xlabel="in: [i: local uint<64> i] out: [i: local uint<64> i] keep"];
+    1 [label="i++;" xlabel="read: [i] write: [i] in: [i: local uint<64> i] out: [i: local uint<64> i] keep"];
+    2 [label="local uint<64> i" xlabel="gen: [i: local uint<64> i] kill: [i: local uint<64> i] in: [i: local uint<64> i] out: [i: local uint<64> i]"];
     3 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     4 [label="end <...>/for.hlt:6:20-9:1" shape=triangle xlabel="in: [] out: []"];
     5 [label="end <...>/for.hlt:6:20-9:1" shape=triangle xlabel="in: [] out: []"];
-    6 [label="end <...>/for.hlt:8:9-8:12" shape=triangle xlabel="in: [local uint<64> i] out: [local uint<64> i]"];
-    7 [label="end <...>/for.hlt:7:5-8:12" shape=triangle xlabel="kill: [local uint<64> i] in: [local uint<64> i] out: []"];
+    6 [label="end <...>/for.hlt:8:9-8:12" shape=triangle xlabel="in: [i: local uint<64> i] out: [i: local uint<64> i]"];
+    7 [label="end <...>/for.hlt:7:5-8:12" shape=triangle xlabel="kill: [i: local uint<64> i] in: [i: local uint<64> i] out: []"];
     3 -> 0 [label="0"];
     0 -> 2 [label="1"];
     2 -> 1 [label="2"];

--- a/tests/Baseline/hilti.cfg.return/output
+++ b/tests/Baseline/hilti.cfg.return/output
@@ -27,11 +27,11 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn2'
 digraph {
-    0 [label="local bool x = True;" xlabel="gen: [x: local bool x = True;] in: [] out: [local bool x = True;]"];
-    1 [label="return x;" xlabel="read: [x] in: [local bool x = True;] out: [local bool x = True;] keep"];
+    0 [label="local bool x = True;" xlabel="gen: [x: local bool x = True;] in: [] out: [x: local bool x = True;]"];
+    1 [label="return x;" xlabel="read: [x] in: [x: local bool x = True;] out: [x: local bool x = True;] keep"];
     2 [label="2;" xlabel="in: [] out: []"];
     3 [label=start shape=Mdiamond xlabel="in: [] out: []"];
-    4 [label="end <...>/return.hlt:12:21-16:1" shape=triangle xlabel="kill: [local bool x = True;] in: [local bool x = True;] out: []"];
+    4 [label="end <...>/return.hlt:12:21-16:1" shape=triangle xlabel="kill: [x: local bool x = True;] in: [x: local bool x = True;] out: []"];
     5 [label="end <...>/return.hlt:12:21-16:1" shape=triangle xlabel="in: [] out: []"];
     6 [label="end <...>/return.hlt:12:21-16:1" shape=triangle xlabel="in: [] out: []"];
     7 [shape=point xlabel="in: [] out: []"];
@@ -60,10 +60,10 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn4'
 digraph {
-    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [local uint<64> x = 1;]"];
-    1 [label="return x;" xlabel="read: [x] in: [local uint<64> x = 1;] out: [local uint<64> x = 1;] keep"];
+    0 [label="local uint<64> x = 1;" xlabel="gen: [x: local uint<64> x = 1;] in: [] out: [x: local uint<64> x = 1;]"];
+    1 [label="return x;" xlabel="read: [x] in: [x: local uint<64> x = 1;] out: [x: local uint<64> x = 1;] keep"];
     2 [label=start shape=Mdiamond xlabel="in: [] out: []"];
-    3 [label="end <...>/return.hlt:24:25-27:1" shape=triangle xlabel="kill: [local uint<64> x = 1;] in: [local uint<64> x = 1;] out: []"];
+    3 [label="end <...>/return.hlt:24:25-27:1" shape=triangle xlabel="kill: [x: local uint<64> x = 1;] in: [x: local uint<64> x = 1;] out: []"];
     2 -> 0 [label="0"];
     0 -> 1 [label="1"];
     1 -> 3 [label="2"];

--- a/tests/Baseline/hilti.cfg.while/output
+++ b/tests/Baseline/hilti.cfg.while/output
@@ -26,14 +26,14 @@ digraph {
 }
 [debug/cfg-initial] Function 'fn2'
 digraph {
-    0 [label="local uint<64> i = 0" xlabel="gen: [i: local uint<64> i = 0] in: [] out: [local uint<64> i = 0]"];
-    1 [label="True" xlabel="in: [local uint<64> i = 0] out: [local uint<64> i = 0] keep"];
-    2 [label="1;" xlabel="in: [local uint<64> i = 0] out: [local uint<64> i = 0]"];
+    0 [label="local uint<64> i = 0" xlabel="gen: [i: local uint<64> i = 0] in: [] out: [i: local uint<64> i = 0]"];
+    1 [label="True" xlabel="in: [i: local uint<64> i = 0] out: [i: local uint<64> i = 0] keep"];
+    2 [label="1;" xlabel="in: [i: local uint<64> i = 0] out: [i: local uint<64> i = 0]"];
     3 [label=start shape=Mdiamond xlabel="in: [] out: []"];
     4 [label="end <...>/while.hlt:10:21-12:1" shape=triangle xlabel="in: [] out: []"];
-    5 [label="end <...>/while.hlt:10:21-12:1" shape=triangle xlabel="kill: [local uint<64> i = 0] in: [local uint<64> i = 0] out: []"];
-    6 [label="end <...>/while.hlt:11:38-11:43" shape=triangle xlabel="in: [local uint<64> i = 0] out: [local uint<64> i = 0]"];
-    7 [shape=point xlabel="in: [local uint<64> i = 0] out: [local uint<64> i = 0]"];
+    5 [label="end <...>/while.hlt:10:21-12:1" shape=triangle xlabel="kill: [i: local uint<64> i = 0] in: [i: local uint<64> i = 0] out: []"];
+    6 [label="end <...>/while.hlt:11:38-11:43" shape=triangle xlabel="in: [i: local uint<64> i = 0] out: [i: local uint<64> i = 0]"];
+    7 [shape=point xlabel="in: [i: local uint<64> i = 0] out: [i: local uint<64> i = 0]"];
     3 -> 0 [label="0"];
     0 -> 5 [label="1"];
     0 -> 1 [label="2"];

--- a/tests/hilti/cfg/assign.hlt
+++ b/tests/hilti/cfg/assign.hlt
@@ -6,7 +6,22 @@ module foo {
 function uint<64> fn() {
     local auto x = 1;
     x = x + 1;
-    return x;
+}
+
+function uint<64> fn2() {
+    local auto x = 1;
+    local auto y = 1;
+
+    x = (x = 1);
+    x = (y = 1);
+    x = (x = (y = 1));
+
+    (x = 1) = x;
+    (y = 1) = x;
+    (x = (y = 1)) = x;
+
+    (x = 1) = (y = 1);
+    (y = 1) = (x = (y = 1));
 }
 
 }


### PR DESCRIPTION
We previously would not correctly recognize value assignments if they
were contained in other assignments, e.g., constructs of the form

    x = (y = 1);

This patch fixes the extraction for such cases.

Closes #2123.