### PR TITLE
Avoid removing `__captures` from non-public units.

### DIFF
--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1919,6 +1919,23 @@ struct FunctionParamVisitor : OptimizerVisitor {
             case Stage::PRUNE_DECLS: return;
         }
     }
+
+    void operator()(expression::Keyword* n) final {
+        auto opt_enclosing_fn = enclosingFunction(n);
+        if ( ! opt_enclosing_fn )
+            return;
+
+        auto [ftype, function_id] = *opt_enclosing_fn;
+        switch ( _stage ) {
+            case Stage::COLLECT:
+                // Only apply to captures, everything else seems handled by Name.
+                if ( n->kind() == expression::keyword::Kind::Captures )
+                    removeUsed(ftype, function_id, "__captures");
+                return;
+            case Stage::PRUNE_USES:
+            case Stage::PRUNE_DECLS: return;
+        }
+    }
 };
 
 struct FunctionBodyVisitor : OptimizerVisitor {

--- a/tests/spicy/optimization/remove-captures-param.spicy
+++ b/tests/spicy/optimization/remove-captures-param.spicy
@@ -1,0 +1,18 @@
+# @TEST-REQUIRES: which FileCheck
+# @TEST-EXEC: spicyc -p %INPUT | FileCheck %INPUT
+# @TEST-EXEC: spicyc -dj %INPUT
+
+# @TEST-DOC: Ensures captures are not removed from non-public units
+
+module Test;
+
+type Data = unit {
+    # CHECK: hook void __on_x(vector<bytes> __captures);
+    x: /(abc)/ {
+        print $1;
+    }
+
+    # Ensure it is removed when captures aren't used.
+    # CHECK: hook void __on_y();
+    y: /(def)/ {}
+};


### PR DESCRIPTION
This caused a regression/C++ compiler error in spicy-nats.

this is the same solution as before https://github.com/zeek/spicy/pull/2083#discussion_r2174989210 - but I made it specifically only apply for `__captures`. Apparently the other tests pass because their units are public, whereas when I hit the issue I hadn't made public units stable yet.

Not sure why it only applies to `__captures` but it seems like the case.