### PR TITLE
Prefer `this` over `self` where possible.

### DIFF
--- a/hilti/toolchain/include/ast/types/struct.h
+++ b/hilti/toolchain/include/ast/types/struct.h
@@ -63,6 +63,9 @@ public:
     bool isMutable() const final { return true; }
     bool isNameType() const final { return true; }
     bool isResolved(node::CycleDetector* cd) const final;
+    bool isTrivialSelf() const { return _trivial_self; }
+
+    void setTrivialSelf(bool b) { _trivial_self = b; }
 
     static auto create(ASTContext* ctx, const declaration::Parameters& params, const Declarations& fields,
                        Meta meta = {}) {
@@ -102,6 +105,9 @@ protected:
 
 private:
     void _setSelf(ASTContext* ctx);
+
+    bool _trivial_self = true; // If all uses of this struct's self() are replaceable
+                               // with a trivial form.
 };
 
 } // namespace hilti::type

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -65,7 +65,10 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
                 cxx::Block ctor;
 
                 cxx::Block self_body;
-                self_body.addStatement(util::fmt("return ::hilti::rt::ValueReference<%s>::self(this)", id));
+                if ( n->isTrivialSelf() )
+                    self_body.addStatement("return this");
+                else
+                    self_body.addStatement(util::fmt("return ::hilti::rt::ValueReference<%s>::self(this)", id));
 
                 auto self = cxx::declaration::Function(cxx::declaration::Function::Free, "auto", "__self", {}, "",
                                                        cxx::declaration::Function::Inline(), std::move(self_body));

--- a/tests/hilti/output/optimization/change-self.hlt
+++ b/tests/hilti/output/optimization/change-self.hlt
@@ -1,0 +1,41 @@
+# @TEST-REQUIRES: which FileCheck
+# @TEST-EXEC: hiltic %INPUT -c | FileCheck %INPUT
+# @TEST-EXEC: hiltic %INPUT -dj
+#
+# @TEST-DOC: Tests changing __self to return just 'this'
+
+module Test {
+
+import hilti;
+
+# CHECK: struct NeedsSelfValRef
+type NeedsSelfValRef = struct {
+    # CHECK: __self() { return {{.*}}ValueReference{{.*}}this
+    bool b;
+
+    # Since it has a hook, it needs self as a value reference (to pass to the hook)
+    hook void hook_one(uint<64> x);
+};
+
+# CHECK: struct Trivial
+type Trivial = struct {
+    # CHECK: __self() { return this; }
+    bool b;
+
+    # This has a method, but it doesn't need self as a value reference
+    method void my_method(uint<64> x) {
+        hilti::print(x);
+    }
+};
+
+global Trivial x1 = [$b = True];
+global NeedsSelfValRef x2 = [$b = True];
+
+hook void NeedsSelfValRef::hook_one(uint<64> x) {
+    hilti::print(x);
+}
+
+x1.my_method(1);
+x2.hook_one(1);
+
+}


### PR DESCRIPTION
Closes #2117

This switches `__self` to use `this` if it's possible to do so, therefore hopefully reducing `shared_ptr` usage.

tl;dr: This might be a complete nothing-PR - I saw no (or almost no) performance improvements anywhere. If we decide it's not worth it to add extra code for *possible* *marginal* benefits, then this should be closed (& the issue).

I tried some multithreaded test cases and found no speedup, even when each unit was swapped to use `this`. It *might* be 1% sometimes, but only with GCC 15 on my Fedora Linux machine, not my Mac with Clang.

I also tested the SSL analyzer, which also has no noticeable changes. Also, 8% of samples have `__exchange_and_add` before & after the change, so it doesn't seem to actually reduce the overhead in that case. For the SSL analyzer a bit under half of the units swapped to use `this`, but I think most of the units my PCAP exercises aren't those, so I don't know what I expected.

Overall I'd say this probably won't provide a speedup, but I had the code and it seems to work. And it could technically provide speedup & simplification in some cases (or in debug code - I'd suspect that would see greater improvements). I'm ok if we just close this out, but thought I'd open the PR to immortalize the thoughts. I'm also happy iterating and merging later if this seems like we could expand it to help. IDK, I'll leave it up to others.

Luckily I simplified this a lot, so it didn't sink a bunch of time, it went pretty quickly.