### PR TITLE
Sort the CFG for constant propagation

### DIFF
--- a/hilti/toolchain/include/base/graph.h
+++ b/hilti/toolchain/include/base/graph.h
@@ -126,7 +126,7 @@ public:
     std::vector<NodeId> neighborsDownstream(NodeId id) const { return neighbors(id, Direction::Out); }
 
     /**
-     * Get downstream neighbors of a node, i.e., nodes connected to the node by
+     * Get upstream neighbors of a node, i.e., nodes connected to the node by
      * an edge where the node is a target.
      *
      * @param id the node ID of the node to query

--- a/hilti/toolchain/include/compiler/detail/cfg.h
+++ b/hilti/toolchain/include/compiler/detail/cfg.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <string>
@@ -204,6 +205,12 @@ public:
 
     /** Get control flow. */
     const Graph& graph() const { return g; }
+
+    /**
+     * Sorts the graph in postorder, from the beginning node. Any nodes that are
+     * unreachable downstream from the beginning node are excluded.
+     */
+    std::deque<GraphNode> postorder() const;
 
 private:
     GraphNode _getOrAddNode(GraphNode n);

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <optional>
@@ -68,6 +69,31 @@
 #include <hilti/hilti/ast/types/vector.h>
 
 namespace hilti::detail::cfg {
+
+std::deque<GraphNode> CFG::postorder() const {
+    std::deque<GraphNode> sorted;
+
+    std::unordered_set<NodeId> visited;
+
+    std::function<void(NodeId)> dfs_visit = [&](NodeId node_id) {
+        if ( visited.contains(node_id) )
+            return;
+
+        visited.insert(node_id);
+
+        for ( const auto& neighbor_id : g.neighborsDownstream(node_id) )
+            dfs_visit(neighbor_id);
+
+        const auto* node = g.getNode(node_id);
+        assert(node);
+        sorted.push_back(*node);
+    };
+
+    // This will sort all reachable nodes.
+    dfs_visit(_begin->identity());
+
+    return sorted;
+}
 
 // Helper function to check whether some `inner` node is a child of an `outer` node.
 static bool _contains(const Node& outer, const Node& inner) {

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -606,7 +606,7 @@ struct DataflowVisitor : visitor::PreOrder {
                     transfer.gen[decl] = root;
                     break;
                 };
-            };
+            }
         }
 
         // Since we do not know whether the called function is pure always keep it.

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -987,6 +987,10 @@ struct ConstantPropagationVisitor : OptimizerVisitor {
         bool not_a_constant = false;
 
         bool operator==(const ConstantValue& other) const {
+            // If both are NAC, what's in expr doesn't matter
+            if ( not_a_constant && other.not_a_constant )
+                return true;
+
             return expr == other.expr && not_a_constant == other.not_a_constant;
         }
     };


### PR DESCRIPTION
This is a followup from [this comment](https://github.com/zeek/spicy/pull/2138#discussion_r2282952585). Instead of using a set, it adds a sort to the CFG so we can traverse it the most effective way. For constant propagation, that's reverse postorder. Note that it doesn't store the result because we currently treat CFGs as pretty ephemeral, happy to change that if it seems useful

I took the mean number of iterations until convergence in `populate_dataflow` for three scenarios: unsorted, postorder, and reverse-postorder when compiling the Redis analyzer. Here are the results:

```
Mean for out-postorder: 105.69
Mean for out-reverse-postorder: 27.41
Mean for out-unsorted: 97.59
```

So reverse postorder wins pretty easily, since fewer iterations == better

I also touched up a couple parts. The change for equality with not-a-constant in `operator==` helped fix a possible infinite loop :)