### PR TITLE
Enforce naming conventions across toolchain using clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -62,7 +62,6 @@ Checks: '
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
-  -readability-identifier-naming,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-make-member-function-const,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,7 @@ Checks: '
   -performance-enum-size,
 
   portability-*,
+  -portability-avoid-pragma-once,
 
   readability-*,
   -readability-braces-around-statements,
@@ -70,6 +71,7 @@ Checks: '
   -readability-use-anyofallof,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
+  -readability-use-concise-preprocessor-directives,
   '
 
 HeaderFilterRegex: '(hilti|spicy)/[a-zA-Z-]+/include/([a-zA-Z-]+/)*[a-zA-Z-]+\.h'

--- a/.clang-tidy.toolchain
+++ b/.clang-tidy.toolchain
@@ -6,6 +6,8 @@ InheritParentConfig: true
 CheckOptions:
   - key:  readability-identifier-naming.ClassCase
     value: CamelCase
+  - key:  readability-identifier-naming.ClassIgnoredRegexp
+    value: '.*_$'
   - key:  readability-identifier-naming.StructCase
     value: CamelCase
   - key:  readability-identifier-naming.UnionCase
@@ -28,10 +30,16 @@ CheckOptions:
     value: '^_.*|.*_$|^to_.*|^from_.*'
   - key:  readability-identifier-naming.ConstantCase
     value: CamelCase
-  - key:  readability-identifier-naming.LocalConstantIgnoredRegexp
+  - key:  readability-identifier-naming.ConstantIgnoredRegexp
+    value: '.*_$'
+  - key: readability-identifier-naming.LocalConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.LocalConstantIgnoredRegexp
     value: '.*_$'
   - key:  readability-identifier-naming.EnumCase
     value: CamelCase
+  - key:  readability-identifier-naming.EnumIgnoredRegexp
+    value: '.*_$'
   - key:  readability-identifier-naming.FunctionCase
     value: camelBack
   - key: readability-identifier-naming.FunctionIgnoredRegexp
@@ -40,13 +48,19 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.NamespaceIgnoredRegexp
     value: '.*_$'
+  - key:  readability-identifier-naming.ConstantParameterCase
+    value: lower_case
   - key:  readability-identifier-naming.ParameterCase
     value: lower_case
   - key:  readability-identifier-naming.ParameterIgnoredRegexp
     value: '.*_$'
   - key:  readability-identifier-naming.MacroDefinitionCase
     value: UPPER_CASE
+  - key:  readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value: '^_.*'
   - key:  readability-identifier-naming.PrivateMemberPrefix
     value: _
   - key:  readability-identifier-naming.PrivateMethodPrefix
     value: _
+
+HeaderFilterRegex: '(hilti|spicy)/toolchain/include/([a-zA-Z-]+/)*[a-zA-Z-]+\.h'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,11 @@ set(SPICY_C_COMPILER "${CMAKE_C_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_
 set(SPICY_CXX_COMPILER
     "${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})")
 
+set(SPICY_CLANG_TIDY "no")
+if (CMAKE_CXX_CLANG_TIDY)
+    set(SPICY_CLANG_TIDY "yes (${CMAKE_CXX_CLANG_TIDY})")
+endif ()
+
 set(SPICY_SANITIZERS "no")
 if (USE_SANITIZERS)
     set(SPICY_SANITIZERS "yes (${USE_SANITIZERS})")
@@ -384,6 +389,7 @@ message(
     "\nBuilding toolchain:    ${HAVE_TOOLCHAIN}"
     "\n"
     "\nUse ccache:            ${USE_CCACHE}"
+    "\nUse clang-tidy:        ${SPICY_CLANG_TIDY}"
     "\nUse gold linker:       ${GOLD_FOUND}"
     "\nUse sanitizers:        ${SPICY_SANITIZERS}"
     "\nUse backtrace:         ${HILTI_HAVE_BACKTRACE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,11 @@ set(SPICY_C_COMPILER "${CMAKE_C_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_
 set(SPICY_CXX_COMPILER
     "${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})")
 
+set(SPICY_SANITIZERS "no")
+if (USE_SANITIZERS)
+    set(SPICY_SANITIZERS "yes (${USE_SANITIZERS})")
+endif ()
+
 message(
     "\n====================|  Spicy Build Summary  |===================="
     "\n"
@@ -380,7 +385,7 @@ message(
     "\n"
     "\nUse ccache:            ${USE_CCACHE}"
     "\nUse gold linker:       ${GOLD_FOUND}"
-    "\nUse sanitizers:        ${USE_SANITIZERS}"
+    "\nUse sanitizers:        ${SPICY_SANITIZERS}"
     "\nUse backtrace:         ${HILTI_HAVE_BACKTRACE}"
     "\n"
     "\nWarnings are errors:   ${USE_WERROR}"

--- a/configure
+++ b/configure
@@ -18,6 +18,7 @@ cmake_build_toolchain="yes"
 cmake_build_type="Release"
 cmake_c_compiler=""
 cmake_cxx_compiler=""
+cmake_clang_tidy=""
 cmake_flex_root=""
 cmake_generator=""
 cmake_install_prefix="/usr/local"
@@ -64,12 +65,14 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-tests                       Disable building of tests and benchmarks
     --enable-ccache                       Build using the compiler cache cache if in PATH [default: ${cmake_use_ccache}]
     --enable-debug                        Compile debug version (same as --build-type=Debug) [default: off]
+    --enable-clang-tidy                   Run clang-tidy from PATH during compilation [default: off]
     --enable-sanitizer[=<names>]          Enable sanitizer(s), default if not further specified is \"address\"
     --enable-werror                       Treat compiler warnings as errors [default: ${cmake_use_werror}]
     --generator=<generator>               CMake generator to use (see cmake --help)
     --prefix=PATH                         Installation prefix [default: ${cmake_install_prefix}]
     --with-bison=<prefix>                 Set prefix of Bison installation
     --with-c-compiler=<path>              Set C compiler to use
+    --with-clang-tidy=<path>              Set clang-tidy binary and enable use during compilation
     --with-cxx-compiler=<path>            Set C++ compiler to use
     --with-hilti-compiler-launcher=<cmd>  Set compiler launcher to use during JIT, e.g., ccache.
     --with-flex=<prefix>                  Set prefix of Flex installation
@@ -119,6 +122,15 @@ while [ $# -ne 0 ]; do
         --disable-tests)                   cmake_spicy_enable_tests="no";;
         --enable-ccache)                   cmake_use_ccache="yes";;
         --enable-debug)                    cmake_build_type="Debug";;
+        --enable-clang-tidy)
+            if ! which clang-tidy >/dev/null 2>&1; then
+                echo "Error: clang-tidy not found in PATH" >&2
+                exit 1
+            fi
+
+            cmake_clang_tidy="$(which clang-tidy)"
+        ;;
+
         --enable-sanitizer)                cmake_use_sanitizers="address";;
         --enable-sanitizer=*)              cmake_use_sanitizers="${optarg}";;
         --enable-werror)                   cmake_use_werror="yes";;
@@ -136,6 +148,7 @@ while [ $# -ne 0 ]; do
 
         --with-hilti-compiler-launcher=*)  hilti_compiler_launcher="${optarg}";;
 
+        --with-clang-tidy=*)               cmake_clang_tidy="${optarg}";;
         --with-flex=*)                     cmake_flex_root="${optarg}";;
         --with-bison=*)                    cmake_bison_root="${optarg}";;
         --without-bison=*)                 cmake_bison_root="";;
@@ -157,6 +170,8 @@ append_cache_entry BUILD_TOOLCHAIN              BOOL   "${cmake_build_toolchain}
 append_cache_entry CMAKE_BUILD_TYPE             STRING "${cmake_build_type}"
 append_cache_entry CMAKE_C_COMPILER             PATH   "${cmake_c_compiler}"
 append_cache_entry CMAKE_CXX_COMPILER           PATH   "${cmake_cxx_compiler}"
+append_cache_entry CMAKE_C_CLANG_TIDY           PATH   "${cmake_clang_tidy}"
+append_cache_entry CMAKE_CXX_CLANG_TIDY         PATH   "${cmake_clang_tidy}"
 append_cache_entry CMAKE_INSTALL_PREFIX         PATH   "${cmake_install_prefix}"
 append_cache_entry HILTI_COMPILER_LAUNCHER      STRING "${hilti_compiler_launcher}"
 append_cache_entry FLEX_ROOT                    PATH   "${cmake_flex_root}"

--- a/hilti/runtime/include/safe-int.h
+++ b/hilti/runtime/include/safe-int.h
@@ -11,8 +11,8 @@ namespace hilti::rt::integer {
 namespace detail {
 class SafeIntException {
 public:
+    // SafeInt API methods.
     static void SafeIntOnOverflow() __attribute__((noreturn)) { throw Overflow("integer overflow"); }
-
     static void SafeIntOnDivZero() __attribute__((noreturn)) { throw DivisionByZero("integer division by zero"); }
 };
 } // namespace detail

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -265,7 +265,7 @@ public:
         if ( &b == this )
             return *this;
 
-        invalidateIterators();
+        _invalidateIterators();
         this->Base::operator=(b);
         return *this;
     }
@@ -278,7 +278,7 @@ public:
      * @return a reference to the changed `Bytes`
      */
     Bytes& operator=(Bytes&& b) noexcept {
-        invalidateIterators();
+        _invalidateIterators();
         this->Base::operator=(std::move(b));
         return *this;
     }
@@ -636,7 +636,7 @@ public:
 private:
     friend bytes::SafeIterator;
 
-    void invalidateIterators() { _control.Reset(); }
+    void _invalidateIterators() { _control.Reset(); }
 
     control::Block<Base, InvalidIterator> _control{this};
 };

--- a/hilti/toolchain/include/ast/builder/node-factory.h
+++ b/hilti/toolchain/include/ast/builder/node-factory.h
@@ -362,9 +362,10 @@ public:
     auto statementAssert(Expression* expr, Expression* msg = nullptr, Meta meta = {}) {
         return hilti::statement::Assert::create(context(), expr, msg, std::move(meta));
     }
-    auto statementAssert(statement::assert::Exception _unused, Expression* expr, UnqualifiedType* excpt,
+    auto statementAssert(statement::assert::Exception /* excpt */, Expression* expr, UnqualifiedType* excpt,
                          Expression* msg = nullptr, Meta meta = {}) {
-        return hilti::statement::Assert::create(context(), _unused, expr, excpt, msg, std::move(meta));
+        return hilti::statement::Assert::create(context(), statement::assert::Exception{}, expr, excpt, msg,
+                                                std::move(meta));
     }
     auto statementBlock(const Meta& meta = {}) { return hilti::statement::Block::create(context(), meta); }
     auto statementBlock(const Statements& stmts, Meta meta = {}) {
@@ -411,8 +412,8 @@ public:
     auto statementSwitchCase(const Expressions& exprs, Statement* body, Meta meta = {}) {
         return hilti::statement::switch_::Case::create(context(), exprs, body, std::move(meta));
     }
-    auto statementSwitchCase(statement::switch_::Default _unused, Statement* body, Meta meta = {}) {
-        return hilti::statement::switch_::Case::create(context(), _unused, body, std::move(meta));
+    auto statementSwitchCase(statement::switch_::Default /* default */, Statement* body, Meta meta = {}) {
+        return hilti::statement::switch_::Case::create(context(), statement::switch_::Default{}, body, std::move(meta));
     }
     auto statementThrow(Meta meta = {}) { return hilti::statement::Throw::create(context(), std::move(meta)); }
     auto statementThrow(Expression* expr, Meta meta = {}) {

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -176,22 +176,22 @@ template<typename T>
 class RetainedPtr {
 public:
     RetainedPtr() = default;
-    RetainedPtr(T* n) : _node(n) { retain(); }
-    RetainedPtr(const RetainedPtr& other) : _node(other._node) { retain(); }
+    RetainedPtr(T* n) : _node(n) { _retain(); }
+    RetainedPtr(const RetainedPtr& other) : _node(other._node) { _retain(); }
     RetainedPtr(RetainedPtr&& other) noexcept : _node(other._node) {
         other._node = nullptr;
         // reuse the other's retain
     }
 
-    ~RetainedPtr() { release(); }
+    ~RetainedPtr() { _release(); }
 
     RetainedPtr& operator=(const RetainedPtr& other) {
         if ( this == &other )
             return *this;
 
-        release();
+        _release();
         _node = other._node;
-        retain();
+        _retain();
         return *this;
     }
 
@@ -199,7 +199,7 @@ public:
         if ( this == &other )
             return *this;
 
-        release();
+        _release();
         _node = other._node;
         other._node = nullptr;
         // reuse the other's retain
@@ -207,7 +207,7 @@ public:
     }
 
     void reset() {
-        release();
+        _release();
         _node = nullptr;
     }
 
@@ -219,12 +219,12 @@ public:
     T* get() const { return _node; }
 
 private:
-    void retain() {
+    void _retain() {
         if ( _node )
             _node->retain();
     }
 
-    void release() {
+    void _release() {
         if ( _node ) {
             _node->release();
             _node = nullptr;

--- a/hilti/toolchain/include/ast/types/operand-list.h
+++ b/hilti/toolchain/include/ast/types/operand-list.h
@@ -71,7 +71,7 @@ protected:
     HILTI_NODE_0(type::operand_list::Operand, final);
 
 private:
-    static QualifiedType* _makeOperandType(ASTContext* ctx, parameter::Kind _kind, UnqualifiedType* type,
+    static QualifiedType* _makeOperandType(ASTContext* ctx, parameter::Kind kind, UnqualifiedType* type,
                                            bool make_external_type);
 
     ID _id;

--- a/hilti/toolchain/include/base/code-formatter.h
+++ b/hilti/toolchain/include/base/code-formatter.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <utility>
 
@@ -103,6 +102,7 @@ class isManipulator {};
     };
 
 namespace code_formatter {
+// NOLINTBEGIN(readability-identifier-naming)
 __DEFINE_MANIPULATOR0(dedent)
 __DEFINE_MANIPULATOR0(eol)
 __DEFINE_MANIPULATOR0(eos)
@@ -110,6 +110,7 @@ __DEFINE_MANIPULATOR0(indent)
 __DEFINE_MANIPULATOR0(separator)
 __DEFINE_MANIPULATOR1(quoted, std::string)
 __DEFINE_MANIPULATOR1(comment, std::string)
+// NOLINTEND(readability-identifier-naming)
 } // namespace code_formatter
 
 } // namespace hilti

--- a/hilti/toolchain/include/base/graph.h
+++ b/hilti/toolchain/include/base/graph.h
@@ -67,14 +67,14 @@ public:
         _nodes.erase(id);
 
         std::set<EdgeId> edges_to_remove;
-        for ( auto&& [edgeId, nodes] : _edges ) {
+        for ( auto&& [edge_id, nodes] : _edges ) {
             auto&& [from, to] = nodes;
 
             if ( from == id || to == id )
-                edges_to_remove.insert(edgeId);
+                edges_to_remove.insert(edge_id);
         }
-        for ( auto&& edgeId : edges_to_remove )
-            _edges.erase(edgeId);
+        for ( auto&& edge_id : edges_to_remove )
+            _edges.erase(edge_id);
     }
 
     /**
@@ -123,7 +123,7 @@ public:
      * @param id the node ID of the node to query
      * @return a vector of node IDs of downstream neighbor nodes
      */
-    std::vector<NodeId> neighborsDownstream(NodeId id) const { return neighbors(id, Direction::Out); }
+    std::vector<NodeId> neighborsDownstream(NodeId id) const { return _neighbors(id, Direction::Out); }
 
     /**
      * Get upstream neighbors of a node, i.e., nodes connected to the node by
@@ -132,7 +132,7 @@ public:
      * @param id the node ID of the node to query
      * @return a vector of node IDs of upstream neighbor nodes
      */
-    std::vector<NodeId> neighborsUpstream(NodeId id) const { return neighbors(id, Direction::In); }
+    std::vector<NodeId> neighborsUpstream(NodeId id) const { return _neighbors(id, Direction::In); }
 
 private:
     std::unordered_map<NodeId, T> _nodes;                         //< nodes in the graph.
@@ -153,7 +153,7 @@ private:
      * @param dir edge selection
      * @return a vector of node IDs of neighbor nodes
      */
-    std::vector<NodeId> neighbors(NodeId id, Direction dir) const {
+    std::vector<NodeId> _neighbors(NodeId id, Direction dir) const {
         std::vector<NodeId> xs;
 
         for ( auto&& [edge_id, nodes] : _edges ) {

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -144,7 +144,7 @@ extern std::pair<std::string, std::string> rsplit1(std::string s, const std::str
  *
  * Returns a vector of substrings, or an error.
  */
-Result<std::vector<std::string>> split_shell_unsafe(const std::string& s);
+Result<std::vector<std::string>> splitShellUnsafe(const std::string& s);
 
 /**
  * Returns a subrange of a vector, specified through zero-based indices. If

--- a/hilti/toolchain/include/compiler/detail/cfg.h
+++ b/hilti/toolchain/include/compiler/detail/cfg.h
@@ -82,12 +82,12 @@ struct End : MetaNode {
  */
 class GraphNode {
 public:
-    GraphNode(operator_::function::Call* x) : node(x) {}
-    GraphNode(Expression* x) : node(x) {}
-    GraphNode(statement::Return* x) : node(x) {}
-    GraphNode(Statement* x) : node(x) {}
-    GraphNode(MetaNode* x) : node(x) {}
-    GraphNode(Declaration* x) : node(x) {}
+    GraphNode(operator_::function::Call* x) : _node(x) {}
+    GraphNode(Expression* x) : _node(x) {}
+    GraphNode(statement::Return* x) : _node(x) {}
+    GraphNode(Statement* x) : _node(x) {}
+    GraphNode(MetaNode* x) : _node(x) {}
+    GraphNode(Declaration* x) : _node(x) {}
 
     GraphNode() = default;
     GraphNode(const GraphNode&) = default;
@@ -96,22 +96,22 @@ public:
         if ( &x == this )
             return *this;
 
-        node = x.node;
+        _node = x._node;
         return *this;
     }
 
-    Node* operator->() { return node; }
-    const Node* operator->() const { return node; }
+    Node* operator->() { return _node; }
+    const Node* operator->() const { return _node; }
 
-    Node* value() const { return node; }
+    Node* value() const { return _node; }
 
-    friend bool operator==(const GraphNode& a, const GraphNode& b) { return a.node == b.node; }
-    friend bool operator!=(const GraphNode& a, const GraphNode& b) { return ! (a.node == b.node); }
+    friend bool operator==(const GraphNode& a, const GraphNode& b) { return a._node == b._node; }
+    friend bool operator!=(const GraphNode& a, const GraphNode& b) { return ! (a._node == b._node); }
 
-    friend bool operator<(const GraphNode& a, const GraphNode& b) { return a.node < b.node; }
+    friend bool operator<(const GraphNode& a, const GraphNode& b) { return a._node < b._node; }
 
 private:
-    Node* node = nullptr;
+    Node* _node = nullptr;
 };
 
 } // namespace detail::cfg
@@ -203,7 +203,7 @@ public:
     const auto& dataflow() const { return _dataflow; }
 
     /** Get control flow. */
-    const Graph& graph() const { return g; }
+    const Graph& graph() const { return _graph; }
 
     /**
      * Sorts the graph in postorder, from the beginning node. Any nodes that are
@@ -251,7 +251,7 @@ private:
         return r;
     }
 
-    Graph g;
+    Graph _graph;
 
     std::unordered_set<std::unique_ptr<MetaNode>> _meta_nodes;
     std::unordered_map<GraphNode, Transfer> _dataflow;

--- a/hilti/toolchain/include/compiler/jit.h
+++ b/hilti/toolchain/include/compiler/jit.h
@@ -18,7 +18,7 @@
 #include <hilti/compiler/detail/cxx/unit.h>
 
 namespace reproc {
-class process;
+class process; // NOLINT(readability-identifier-naming)
 }
 
 namespace hilti {

--- a/hilti/toolchain/src/ast/node.cc
+++ b/hilti/toolchain/src/ast/node.cc
@@ -167,7 +167,7 @@ Node* node::detail::deepcopy(ASTContext* ctx, Node* n, bool force) {
 }
 
 // Helper looking up an ID inside a node's direct scope, applying visibility rules.
-static std::pair<bool, Result<std::pair<Declaration*, ID>>> _lookupID(const ID& id, const Node* n) {
+static std::pair<bool, Result<std::pair<Declaration*, ID>>> lookupIDBackend(const ID& id, const Node* n) {
     assert(n->scope());
     auto resolved = n->scope()->lookupAll(id);
 
@@ -219,7 +219,7 @@ Result<std::pair<Declaration*, ID>> Node::lookupID(const ID& id, const std::stri
         if ( ! n->scope() )
             continue;
 
-        auto [stop, resolved] = _lookupID(id, n);
+        auto [stop, resolved] = lookupIDBackend(id, n);
         if ( resolved )
             // Found it.
             return resolved;

--- a/hilti/toolchain/src/ast/operator.cc
+++ b/hilti/toolchain/src/ast/operator.cc
@@ -11,7 +11,7 @@ using namespace hilti::util;
 using namespace hilti::operator_;
 
 namespace {
-std::string _printOperator(operator_::Kind kind, const std::vector<std::string>& ops, const Meta& meta) {
+std::string printOperator(operator_::Kind kind, const std::vector<std::string>& ops, const Meta& meta) {
     auto render = [&]() {
         switch ( kind ) {
             case operator_::Kind::Add: return fmt("add %s[%s]", ops[0], ops[1]);
@@ -74,9 +74,9 @@ std::string _printOperator(operator_::Kind kind, const std::vector<std::string>&
         return render();
 }
 
-std::string _printOperator(operator_::Kind kind, const Expressions& operands, bool print_signature, const Meta& meta) {
+std::string printOperator(operator_::Kind kind, const Expressions& operands, bool print_signature, const Meta& meta) {
     if ( ! print_signature )
-        return _printOperator(kind, util::transform(operands, [](const auto& x) { return x->print(); }), meta);
+        return printOperator(kind, util::transform(operands, [](const auto& x) { return x->print(); }), meta);
 
     auto render_one = [](QualifiedType* t) {
         if ( t->type()->template isA<type::Member>() )
@@ -96,9 +96,8 @@ std::string _printOperator(operator_::Kind kind, const Expressions& operands, bo
             else
                 args = render_one(operands[2]->type());
 
-            return _printOperator(kind,
-                                  {render_one(operands[0]->type()), operands[1]->print(), util::fmt("(%s)", args)},
-                                  meta);
+            return printOperator(kind, {render_one(operands[0]->type()), operands[1]->print(), util::fmt("(%s)", args)},
+                                 meta);
         }
 
         case operator_::Kind::Call: {
@@ -111,19 +110,19 @@ std::string _printOperator(operator_::Kind kind, const Expressions& operands, bo
             else
                 args = render_one(operands[1]->type());
 
-            return _printOperator(kind, {operands[0]->print(), util::fmt("(%s)", args)}, meta);
+            return printOperator(kind, {operands[0]->print(), util::fmt("(%s)", args)}, meta);
         }
 
 
         default:
-            return _printOperator(kind,
-                                  util::transform(operands,
-                                                  [&render_one](const auto& op) { return render_one(op->type()); }),
-                                  meta);
+            return printOperator(kind,
+                                 util::transform(operands,
+                                                 [&render_one](const auto& op) { return render_one(op->type()); }),
+                                 meta);
     }
 }
 
-std::string _printOperator(operator_::Kind kind, const Operands& operands, const Meta& meta) {
+std::string printOperator(operator_::Kind kind, const Operands& operands, const Meta& meta) {
     auto render_one = [](Operand* t) {
         if ( t->type()->type()->template isA<type::Member>() )
             return t->print();
@@ -142,8 +141,8 @@ std::string _printOperator(operator_::Kind kind, const Operands& operands, const
             else
                 args = render_one(operands[2]);
 
-            return _printOperator(kind, {render_one(operands[0]), render_one(operands[1]), util::fmt("(%s)", args)},
-                                  meta);
+            return printOperator(kind, {render_one(operands[0]), render_one(operands[1]), util::fmt("(%s)", args)},
+                                 meta);
         }
 
         case operator_::Kind::Call: {
@@ -154,22 +153,22 @@ std::string _printOperator(operator_::Kind kind, const Operands& operands, const
             else
                 args = render_one(operands[1]);
 
-            return _printOperator(kind, {render_one(operands[0]), util::fmt("(%s)", args)}, meta);
+            return printOperator(kind, {render_one(operands[0]), util::fmt("(%s)", args)}, meta);
         }
 
 
-        default: return _printOperator(kind, util::transform(operands, render_one), meta);
+        default: return printOperator(kind, util::transform(operands, render_one), meta);
     }
 }
 
 } // namespace
 
 std::string operator_::detail::print(Kind kind, const Expressions& operands) {
-    return _printOperator(kind, operands, false, {});
+    return printOperator(kind, operands, false, {});
 }
 
 std::string operator_::detail::printSignature(Kind kind, const Expressions& operands, const Meta& meta) {
-    return _printOperator(kind, operands, true, meta);
+    return printOperator(kind, operands, true, meta);
 }
 
 class OperandResolver : public visitor::PreOrder {
@@ -320,7 +319,7 @@ std::string Operator::print() const {
     if ( ! hasOperands() )
         return "<dynamic>";
 
-    return _printOperator(kind(), operands(), meta());
+    return printOperator(kind(), operands(), meta());
 }
 
 std::string Operator::dump() const {
@@ -340,4 +339,4 @@ Operand* Operator::operandForType(Builder* builder, parameter::Kind kind, Unqual
         return type::operand_list::Operand::create(builder->context(), kind, t, false, std::move(doc), t->meta());
 }
 
-std::string BuiltInMemberCall::print() const { return _printOperator(kind(), operands(), meta()); }
+std::string BuiltInMemberCall::print() const { return printOperator(kind(), operands(), meta()); }

--- a/hilti/toolchain/src/ast/operators/bitfield.cc
+++ b/hilti/toolchain/src/ast/operators/bitfield.cc
@@ -16,7 +16,7 @@ using namespace hilti::operator_;
 namespace {
 namespace bitfield {
 
-QualifiedType* _itemType(Builder* builder, const Expressions& operands) {
+QualifiedType* itemType(Builder* builder, const Expressions& operands) {
     if ( auto* range =
              operands[0]->type()->type()->as<type::Bitfield>()->bits(operands[1]->as<expression::Member>()->id()) )
         return range->itemType();
@@ -24,7 +24,7 @@ QualifiedType* _itemType(Builder* builder, const Expressions& operands) {
         return builder->qualifiedType(builder->typeUnknown(), Constness::Const);
 }
 
-void _checkName(expression::ResolvedOperator* op) {
+void checkName(expression::ResolvedOperator* op) {
     const auto& id = op->op1()->as<expression::Member>()->id();
     if ( ! op->op0()->type()->type()->as<type::Bitfield>()->bits(id) )
         op->addError(util::fmt("bitfield type does not have attribute '%s'", id));
@@ -50,10 +50,10 @@ right.
     }
 
     QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return _itemType(builder, operands);
+        return itemType(builder, operands);
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, bitfield::Member)
 };
@@ -72,7 +72,7 @@ public:
         };
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, bitfield::HasMember)
 };

--- a/hilti/toolchain/src/ast/operators/struct.cc
+++ b/hilti/toolchain/src/ast/operators/struct.cc
@@ -46,7 +46,7 @@ Result<expression::ResolvedOperator*> hilti::struct_::MemberCall::instantiate(Bu
 namespace {
 namespace struct_ {
 
-QualifiedType* _itemType(Builder* builder, const Expressions& operands) {
+QualifiedType* itemType(Builder* builder, const Expressions& operands) {
     auto* stype = operands[0]->type()->type()->tryAs<type::Struct>();
     if ( ! stype )
         return builder->qualifiedType(builder->typeUnknown(), Constness::Const);
@@ -57,7 +57,7 @@ QualifiedType* _itemType(Builder* builder, const Expressions& operands) {
         return builder->qualifiedType(builder->typeUnknown(), Constness::Const);
 }
 
-void _checkName(expression::ResolvedOperator* op, bool check_optional = false) {
+void checkName(expression::ResolvedOperator* op, bool check_optional = false) {
     const auto& id = op->op1()->as<expression::Member>()->id();
     auto* t = op->op0()->type()->type();
 
@@ -98,7 +98,7 @@ Clears an optional field.
         };
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n, true); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n, true); }
 
     HILTI_OPERATOR(hilti, struct_::Unset)
 };
@@ -122,10 +122,10 @@ triggers an exception.
     }
 
     QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return _itemType(builder, operands)->recreateAsLhs(builder->context());
+        return itemType(builder, operands)->recreateAsLhs(builder->context());
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, struct_::MemberNonConst)
 };
@@ -150,10 +150,10 @@ triggers an exception.
     }
 
     QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return _itemType(builder, operands)->recreateAsConst(builder->context());
+        return itemType(builder, operands)->recreateAsConst(builder->context());
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, struct_::MemberConst)
 };
@@ -180,10 +180,10 @@ exception differently).
     }
 
     QualifiedType* result(Builder* builder, const Expressions& operands, const Meta& meta) const final {
-        return _itemType(builder, operands);
+        return itemType(builder, operands);
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, struct_::TryMember)
 };
@@ -202,7 +202,7 @@ public:
         };
     }
 
-    void validate(expression::ResolvedOperator* n) const final { _checkName(n); }
+    void validate(expression::ResolvedOperator* n) const final { checkName(n); }
 
     HILTI_OPERATOR(hilti, struct_::HasMember)
 };

--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -83,7 +83,7 @@ std::pair<std::string, std::string> util::rsplit1(std::string s, const std::stri
     return std::make_pair("", std::move(s));
 }
 
-Result<std::vector<std::string>> util::split_shell_unsafe(const std::string& s) {
+Result<std::vector<std::string>> util::splitShellUnsafe(const std::string& s) {
     // On FreeBSD running `wordexp` on an empty string errors with
     // `WRDE_SYNTAX`; construct the result by hand.
     if ( s.empty() )

--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -274,7 +274,7 @@ struct Visitor : hilti::visitor::PreOrder {
         else
             default_.addStatement(
                 fmt("throw ::hilti::rt::UnhandledSwitchCase(::hilti::rt::to_string_for_print(%s), \"%s\")",
-                    (first ? std::move(cxx_init) : std::move(cxx_id)), n->meta().location()));
+                    (first ? cxx_init : cxx_id), n->meta().location()));
 
         if ( first )
             block->addBlock(std::move(default_));

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -21,7 +21,7 @@ static const unsigned int AddSeparatorAfter = (1U << 2U);  // Force adding a sep
 static const unsigned int AddSeparatorBefore = (1U << 4U); // Force adding a separator before block.
 } // namespace flags
 
-static const std::set<std::string_view> reserved_keywords = {
+static const std::set<std::string_view> ReservedKeywords = {
     "NULL",
     "_Alignas",
     "_Alignof",
@@ -140,7 +140,7 @@ std::optional<std::string> cxx::normalizeID(std::string_view id) {
     if ( id.empty() )
         return std::nullopt;
 
-    if ( reserved_keywords.contains(id) )
+    if ( ReservedKeywords.contains(id) )
         return std::string(id) + "_";
 
     if ( std::ranges::all_of(id, [](auto c) { return std::isalnum(c) || c == '_'; }) )

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -47,7 +47,7 @@ void Unit::_addHeader(Formatter& f) {
 }
 
 void Unit::_addModuleInitFunction() {
-    auto addInitFunction = [&](Context* ctx, auto f, const std::string& id_) {
+    auto add_init_function = [&](Context* ctx, auto f, const std::string& id_) {
         auto id = cxx::ID{cxxInternalNamespace(), id_};
 
         cxx::Block body;
@@ -60,13 +60,13 @@ void Unit::_addModuleInitFunction() {
     };
 
     if ( _init_globals )
-        addInitFunction(context().get(), _init_globals, "__init_globals");
+        add_init_function(context().get(), _init_globals, "__init_globals");
 
     if ( _init_module )
-        addInitFunction(context().get(), _init_module, "__init_module");
+        add_init_function(context().get(), _init_module, "__init_module");
 
     if ( _preinit_module )
-        addInitFunction(context().get(), _preinit_module, "__preinit_module");
+        add_init_function(context().get(), _preinit_module, "__preinit_module");
 
     if ( cxxModuleID() != cxx::ID("__linker__") ) {
         auto scope = fmt("%s_hlto_scope", context()->options().cxx_namespace_intern);
@@ -84,7 +84,7 @@ void Unit::_addModuleInitFunction() {
         if ( _preinit_module )
             register_.addStatement(fmt("__preinit_module()"));
 
-        auto id = addInitFunction(context().get(), std::move(register_), "__register_module");
+        auto id = add_init_function(context().get(), std::move(register_), "__register_module");
         add(fmt("HILTI_PRE_INIT(%s)", id));
     }
 }

--- a/hilti/toolchain/src/compiler/jit.cc
+++ b/hilti/toolchain/src/compiler/jit.cc
@@ -350,7 +350,7 @@ hilti::Result<Nothing> JIT::_compile() {
         }
 
         if ( auto flags_ = hilti::rt::getenv("HILTI_CXX_FLAGS") ) {
-            if ( auto flags = util::split_shell_unsafe(*flags_) )
+            if ( auto flags = util::splitShellUnsafe(*flags_) )
                 args.insert(args.end(), std::make_move_iterator(flags->begin()), std::make_move_iterator(flags->end()));
             else
                 return {util::fmt("invalid HILTI_CXX_FLAGS '%s': %s", *flags_, flags.error().description())};
@@ -678,15 +678,15 @@ JIT::JobRunner::JobRunner() {
         logger().internalError(
             util::fmt("cannot get limit for number of open files ('ulimit -n'): %s", ::strerror(errno)));
 
-    constexpr auto REPROC_MAX_FD_LIMIT = 1024 * 1024;
+    constexpr auto reproc_max_fd_limit = 1024 * 1024;
 
-    if ( limit.rlim_cur >= REPROC_MAX_FD_LIMIT ) {
-        limit.rlim_cur = REPROC_MAX_FD_LIMIT;
+    if ( limit.rlim_cur >= reproc_max_fd_limit ) {
+        limit.rlim_cur = reproc_max_fd_limit;
         if ( ::setrlimit(RLIMIT_NOFILE, &limit) != 0 ) {
             logger().internalError(
                 util::fmt("cannot set limit for number of open files ('ulimit -n %d'), please set it in your "
                           "environment: %s",
-                          REPROC_MAX_FD_LIMIT, ::strerror(errno)));
+                          reproc_max_fd_limit, ::strerror(errno)));
         }
     }
 }

--- a/hilti/toolchain/src/compiler/validator.cc
+++ b/hilti/toolchain/src/compiler/validator.cc
@@ -136,7 +136,7 @@ struct VisitorPre : visitor::PreOrder, public validator::VisitorMixIn {
 struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
     using hilti::validator::VisitorMixIn::VisitorMixIn;
 
-    std::unordered_set<ast::DeclarationIndex> _method_declarations; // tracks methods already seen
+    std::unordered_set<ast::DeclarationIndex> method_declarations; // tracks methods already seen
 
     // Ensures that the node represented by tag is allowed to have all of the
     // provided attributes. This does not use any context, if more information
@@ -312,10 +312,10 @@ struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
                 auto* prototype = context()->lookup(index);
                 if ( auto* field = prototype->tryAs<declaration::Field>(); field && field->inlineFunction() )
                     error(fmt("method '%s' is already defined inline", n->id()), n);
-                else if ( _method_declarations.contains(index) )
+                else if ( method_declarations.contains(index) )
                     error(fmt("method '%s' is already defined elsewhere", n->id()), n);
                 else
-                    _method_declarations.insert(index);
+                    method_declarations.insert(index);
             }
         }
     }

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -12,11 +12,11 @@
 
 using namespace hilti;
 
-const auto flatten = util::flattenParts;
-const auto prefix = util::prefixParts;
+const auto flatten = util::flattenParts; // NOLINT(readability-identifier-naming)
+const auto prefix = util::prefixParts; // NOLINT(readability-identifier-naming)
 
 namespace {
-std::optional<hilti::rt::filesystem::path> precompiled_libhilti(const Configuration& configuration, bool debug) {
+std::optional<hilti::rt::filesystem::path> precompiledLibhilti(const Configuration& configuration, bool debug) {
     // We disable use of precompiled headers for sanitizers builds since the
     // sanitizer flags are not exposed on the config level.
     //
@@ -162,10 +162,10 @@ void Configuration::init(bool use_build_directory) {
         prefix("${HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE}", "", installation_tag),
     });
 
-    if ( auto libhilti_pch = precompiled_libhilti(*this, true) )
+    if ( auto libhilti_pch = precompiledLibhilti(*this, true) )
         runtime_cxx_flags_debug.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
 
-    if ( auto libhilti_pch = precompiled_libhilti(*this, false) )
+    if ( auto libhilti_pch = precompiledLibhilti(*this, false) )
         runtime_cxx_flags_release.push_back(rt::fmt("-include%s", libhilti_pch->c_str()));
 
     runtime_ld_flags_debug = flatten({

--- a/hilti/toolchain/tests/util.cc
+++ b/hilti/toolchain/tests/util.cc
@@ -18,13 +18,13 @@
 TEST_SUITE_BEGIN("util");
 
 enum class Foo { AAA, BBB, CCC };
-constexpr hilti::util::enum_::Value<Foo> values[] = {
+constexpr hilti::util::enum_::Value<Foo> Values[] = {
     {.value = Foo::AAA, .name = "aaa"},
     {.value = Foo::BBB, .name = "bbb"},
     {.value = Foo::CCC, .name = "ccc"},
 };
 
-constexpr static auto from_string(std::string_view s) { return hilti::util::enum_::from_string<Foo>(s, values); }
+constexpr static auto from_string(std::string_view s) { return hilti::util::enum_::from_string<Foo>(s, Values); }
 
 TEST_SUITE_BEGIN("util");
 
@@ -90,20 +90,19 @@ TEST_CASE("removeDuplicates") {
 }
 
 TEST_CASE("split_shell_unsafe") {
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"()"), std::vector<std::string>{});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"(1)"), std::vector<std::string>{"1"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"(1 2 3)"), std::vector<std::string>{"1", "2", "3"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"('1 2 3')"), std::vector<std::string>{"1 2 3"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"('1 2' 3)"), std::vector<std::string>{"1 2", "3"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"("1 2" 3)"), std::vector<std::string>{"1 2", "3"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"("\"1" 2\" 3)"), std::vector<std::string>{R"("1)", R"(2")", "3"});
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"(\\"1 2\\" 3)"), std::vector<std::string>{R"(\1 2\)", "3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"()"), std::vector<std::string>{});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"(1)"), std::vector<std::string>{"1"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"(1 2 3)"), std::vector<std::string>{"1", "2", "3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"('1 2 3')"), std::vector<std::string>{"1 2 3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"('1 2' 3)"), std::vector<std::string>{"1 2", "3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"("1 2" 3)"), std::vector<std::string>{"1 2", "3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"("\"1" 2\" 3)"), std::vector<std::string>{R"("1)", R"(2")", "3"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"(\\"1 2\\" 3)"), std::vector<std::string>{R"(\1 2\)", "3"});
 
     // Command substitutions are supported.
-    CHECK_EQ(hilti::util::split_shell_unsafe(R"(1 `true`)"), std::vector<std::string>{R"(1)"});
+    CHECK_EQ(hilti::util::splitShellUnsafe(R"(1 `true`)"), std::vector<std::string>{R"(1)"});
 
-    auto from_unset_var =
-        hilti::util::split_shell_unsafe(R"($SHELL_VARIABLE_WHICH_IS_EXTREMELY_LIKELY_TO_BE_UNDEFINED)");
+    auto from_unset_var = hilti::util::splitShellUnsafe(R"($SHELL_VARIABLE_WHICH_IS_EXTREMELY_LIKELY_TO_BE_UNDEFINED)");
     auto is_unset_or_empty = ! from_unset_var.hasValue() || from_unset_var->empty();
     CHECK(is_unset_or_empty);
 }

--- a/spicy/toolchain/include/ast/types/unit-items/block.h
+++ b/spicy/toolchain/include/ast/types/unit-items/block.h
@@ -57,6 +57,7 @@ protected:
 
     SPICY_NODE_2(type::unit::item::Block, type::unit::Item, Declaration, final);
 
+private:
     int _else_start;
 };
 

--- a/spicy/toolchain/src/compiler/codegen/productions/look-ahead.cc
+++ b/spicy/toolchain/src/compiler/codegen/productions/look-ahead.cc
@@ -6,7 +6,7 @@
 using namespace spicy;
 using namespace spicy::detail;
 
-static std::string _fmtAlt(const codegen::Production* alt, const spicy::detail::codegen::production::Set& lahs) {
+static std::string fmtAlt(const codegen::Production* alt, const spicy::detail::codegen::production::Set& lahs) {
     auto fmt = [&](const auto& lah) {
         auto str = hilti::util::trim(to_string(*lah));
 
@@ -20,5 +20,5 @@ static std::string _fmtAlt(const codegen::Production* alt, const spicy::detail::
 }
 
 std::string codegen::production::LookAhead::dump() const {
-    return _fmtAlt(_alternatives.first.get(), _lahs.first) + " | " + _fmtAlt(_alternatives.second.get(), _lahs.second);
+    return fmtAlt(_alternatives.first.get(), _lahs.first) + " | " + fmtAlt(_alternatives.second.get(), _lahs.second);
 }

--- a/spicy/toolchain/src/compiler/codegen/unit-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/unit-builder.cc
@@ -444,11 +444,11 @@ void CodeGen::_compileParserRegistration(const ID& public_id, const ID& struct_i
     // Register the parser if the `is_filter` or `supports_sinks` features are
     // active; `public` units we always register (by passing an empty list of
     // features to the feature guard).
-    const auto& dependentFeatureFlags = unit->isPublic() ?
-                                            std::vector<std::string_view>{} :
-                                            std::vector<std::string_view>({"is_filter", "supports_sinks"});
+    const auto& dependent_feature_flags = unit->isPublic() ?
+                                              std::vector<std::string_view>{} :
+                                              std::vector<std::string_view>({"is_filter", "supports_sinks"});
 
-    _pb.guardFeatureCode(unit, dependentFeatureFlags, [&]() {
+    _pb.guardFeatureCode(unit, dependent_feature_flags, [&]() {
         auto* ty_mime_types = builder()->typeVector(
             builder()->qualifiedType(builder()->typeName("spicy_rt::MIMEType"), hilti::Constness::Const));
         auto* ty_ports = builder()->typeVector(

--- a/spicy/toolchain/src/compiler/validator.cc
+++ b/spicy/toolchain/src/compiler/validator.cc
@@ -274,12 +274,12 @@ struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
     // the provided attributes. This is necessary since most attributes will apply
     // to the field but not its type, so this gives a bit more context-sensitive
     // validation for a common case.
-    void validateFieldTypeAttributes(node::Tag typeTag, AttributeSet* attributes, const std::string_view& clazz) {
+    void validateFieldTypeAttributes(node::Tag type_tag, AttributeSet* attributes, const std::string_view& clazz) {
         if ( ! attributes )
             return;
 
         std::unordered_set<hilti::attribute::Kind> type_specific_attrs = {};
-        auto it = allowed_attributes.find(typeTag);
+        auto it = allowed_attributes.find(type_tag);
         if ( it != allowed_attributes.end() )
             type_specific_attrs = it->second;
 
@@ -297,8 +297,8 @@ struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
     template<typename GlobalOrLocalVariable>
     void checkVariable(const GlobalOrLocalVariable& n) {
         // A variable initialized from a struct initializer always needs an explicit type.
-        const bool isTyped = ! n->type()->type()->typeID().empty();
-        if ( isTyped )
+        const bool is_typed = ! n->type()->type()->typeID().empty();
+        if ( is_typed )
             return;
 
         if ( auto init = n->init() ) {

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -11,11 +11,11 @@
 
 using namespace spicy;
 
-const auto flatten = hilti::util::flattenParts;
-const auto prefix = hilti::util::prefixParts;
+const auto flatten = hilti::util::flattenParts; // NOLINT(readability-identifier-naming)
+const auto prefix = hilti::util::prefixParts; // NOLINT(readability-identifier-naming)
 
 namespace {
-std::optional<hilti::rt::filesystem::path> precompiled_libspicy(const hilti::Configuration& config, bool debug) {
+std::optional<hilti::rt::filesystem::path> precompiledLibspicy(const hilti::Configuration& config, bool debug) {
     // We disable use of precompiled headers for sanitizers builds since the
     // sanitizer flags are not exposed on the config level.
     //
@@ -37,8 +37,8 @@ std::optional<hilti::rt::filesystem::path> precompiled_libspicy(const hilti::Con
 }
 
 // Helper function to ensure exactly one precompile header is used.
-void set_precompiled_header(const hilti::Configuration& config, bool debug, std::vector<std::string>& cxxflags) {
-    auto header = precompiled_libspicy(config, debug);
+void setPrecompiledHeader(const hilti::Configuration& config, bool debug, std::vector<std::string>& cxxflags) {
+    auto header = precompiledLibspicy(config, debug);
     if ( ! header )
         return;
 
@@ -73,8 +73,8 @@ void Configuration::extendHiltiConfiguration() {
 
     hlt.runtime_cxx_flags_debug = join(spcy.runtime_cxx_flags_debug, hlt.runtime_cxx_flags_debug);
     hlt.runtime_cxx_flags_release = join(spcy.runtime_cxx_flags_release, hlt.runtime_cxx_flags_release);
-    set_precompiled_header(hlt, true, hlt.runtime_cxx_flags_debug);
-    set_precompiled_header(hlt, false, hlt.runtime_cxx_flags_release);
+    setPrecompiledHeader(hlt, true, hlt.runtime_cxx_flags_debug);
+    setPrecompiledHeader(hlt, false, hlt.runtime_cxx_flags_release);
 
     hlt.runtime_cxx_include_paths = join(spcy.runtime_cxx_include_paths, hlt.runtime_cxx_include_paths);
     hlt.runtime_cxx_library_paths = join(spcy.runtime_cxx_library_paths, hlt.runtime_cxx_library_paths);

--- a/spicy/toolchain/tests/grammar.cc
+++ b/spicy/toolchain/tests/grammar.cc
@@ -16,7 +16,7 @@
 using Ps = std::vector<std::unique_ptr<spicy::detail::codegen::Production>>;
 
 template<class... Args>
-static auto make_prods(Args... args) {
+static auto makeProds(Args... args) {
     std::vector<std::unique_ptr<spicy::detail::codegen::Production>> rv;
     (rv.emplace_back(std::move(args)), ...);
     return rv;
@@ -37,7 +37,7 @@ static auto variable(hilti::ASTContext* ctx, const std::string& symbol, hilti::U
                                                       hilti::QualifiedType::create(ctx, t, hilti::Constness::Mutable));
 }
 
-static auto type_literal(hilti::ASTContext* ctx, const std::string& symbol, spicy::UnqualifiedType* t) {
+static auto typeLiteral(hilti::ASTContext* ctx, const std::string& symbol, spicy::UnqualifiedType* t) {
     return std::make_unique<
         spicy::detail::codegen::production::TypeLiteral>(ctx, symbol,
                                                          hilti::QualifiedType::create(ctx, t, hilti::Constness::Const));
@@ -83,13 +83,14 @@ TEST_CASE("basic") {
     hilti::ASTContext ctx(nullptr);
 
     auto g = spicy::detail::codegen::Grammar("basic");
-    auto prods =
-        make_prods(literal(&ctx, "l1", "l1-val"), literal(&ctx, "l2", "l2-val"), literal(&ctx, "l3", "l3-val"));
+    auto prods = makeProds(literal(&ctx, "l1", "l1-val"), literal(&ctx, "l2", "l2-val"), literal(&ctx, "l3", "l3-val"));
     auto r = sequence(&ctx, "S", std::move(prods));
     CHECK(finalize(&g, std::move(r)));
 }
 
 TEST_CASE("example1") {
+    // NOLINTBEGIN(readability-identifier-naming)
+
     // Simple example grammar from
     //
     // http://www.cs.uky.edu/~lewis/essays/compilers/td-parse.html
@@ -118,27 +119,29 @@ TEST_CASE("example1") {
     auto [D_, D] = resolved(&ctx);
     auto D_r1 = reference(&ctx, D);
 
-    auto cC = sequence(&ctx, "cC", make_prods(std::move(c), std::move(C)));
-    auto bD = sequence(&ctx, "bD", make_prods(std::move(b), std::move(D)));
-    auto AD = sequence(&ctx, "AD", make_prods(std::move(A), std::move(D_r1)));
-    auto aA = sequence(&ctx, "aA", make_prods(std::move(a), std::move(A_r1)));
+    auto cC = sequence(&ctx, "cC", makeProds(std::move(c), std::move(C)));
+    auto bD = sequence(&ctx, "bD", makeProds(std::move(b), std::move(D)));
+    auto AD = sequence(&ctx, "AD", makeProds(std::move(A), std::move(D_r1)));
+    auto aA = sequence(&ctx, "aA", makeProds(std::move(a), std::move(A_r1)));
 
     g.resolve(A_, lookAhead(&ctx, "A", epsilon(&ctx), std::move(a_r1)));
     auto B = lookAhead(&ctx, "B", epsilon(&ctx), std::move(bD));
     g.resolve(C_, lookAhead(&ctx, "C", std::move(AD), std::move(b_r1)));
     g.resolve(D_, lookAhead(&ctx, "D", std::move(aA), std::move(c_r1)));
 
-    auto ABA = sequence(&ctx, "ABA", make_prods(std::move(A_r2), std::move(B), std::move(A_r3)));
+    auto ABA = sequence(&ctx, "ABA", makeProds(std::move(A_r2), std::move(B), std::move(A_r3)));
     auto S = lookAhead(&ctx, "S", std::move(ABA), std::move(cC));
 
     auto rc = finalize(&g, std::move(S));
     CHECK_EQ(rc,
              hilti::Result<hilti::Nothing>(hilti::result::Error(
                  "grammar example1, production A is ambiguous for look-ahead symbol(s) { b\"a\" (const bytes) }\n")));
+    // NOLINTEND(readability-identifier-naming)
 }
 
 TEST_CASE("example2") {
     //  Simple example grammar from "Parsing Techniques", Fig. 8.9
+    // NOLINTBEGIN(readability-identifier-naming)
     hilti::init();
     hilti::ASTContext ctx(nullptr);
     auto g = spicy::detail::codegen::Grammar("example2");
@@ -155,19 +158,20 @@ TEST_CASE("example2") {
     auto [SS_, SS] = resolved(&ctx);
     auto [FFs_, FFs] = resolved(&ctx);
 
-    auto F = sequence(&ctx, "Fact", make_prods(std::move(no), std::move(st)));
-    auto Q = sequence(&ctx, "Question", make_prods(std::move(qu), std::move(st_r1)));
+    auto F = sequence(&ctx, "Fact", makeProds(std::move(no), std::move(st)));
+    auto Q = sequence(&ctx, "Question", makeProds(std::move(qu), std::move(st_r1)));
     auto S = lookAhead(&ctx, "Session", std::move(FsQ), std::move(SS));
     auto S_r1 = reference(&ctx, S);
     auto S_r2 = reference(&ctx, S);
 
-    g.resolve(SS_, sequence(&ctx, "SS", make_prods(std::move(pl), std::move(S), std::move(pr), std::move(S_r1))));
+    g.resolve(SS_, sequence(&ctx, "SS", makeProds(std::move(pl), std::move(S), std::move(pr), std::move(S_r1))));
     auto Fs = lookAhead(&ctx, "Facts", std::move(FFs), epsilon(&ctx));
     auto Fs_r1 = reference(&ctx, Fs);
-    g.resolve(FsQ_, sequence(&ctx, "FsQ", make_prods(std::move(Fs), std::move(Q))));
-    g.resolve(FFs_, sequence(&ctx, "FFs", make_prods(std::move(F), std::move(Fs_r1))));
-    auto root = sequence(&ctx, "Start", make_prods(std::move(S_r2), std::move(hs)));
+    g.resolve(FsQ_, sequence(&ctx, "FsQ", makeProds(std::move(Fs), std::move(Q))));
+    g.resolve(FFs_, sequence(&ctx, "FFs", makeProds(std::move(F), std::move(Fs_r1))));
+    auto root = sequence(&ctx, "Start", makeProds(std::move(S_r2), std::move(hs)));
     CHECK(finalize(&g, std::move(root)));
+    // NOLINTEND(readability-identifier-naming)
 }
 
 TEST_CASE("example3") {
@@ -175,20 +179,20 @@ TEST_CASE("example3") {
     hilti::ASTContext ctx(nullptr);
     auto g = spicy::detail::codegen::Grammar("example3");
 
-    auto hdrkey = ::type_literal(&ctx, "HdrKey", hilti::type::Bytes::create(&ctx));
-    auto hdrval = ::type_literal(&ctx, "HdrVal", hilti::type::Bytes::create(&ctx));
+    auto hdrkey = ::typeLiteral(&ctx, "HdrKey", hilti::type::Bytes::create(&ctx));
+    auto hdrval = ::typeLiteral(&ctx, "HdrVal", hilti::type::Bytes::create(&ctx));
     auto colon = literal(&ctx, "colon", ":");
     auto ws = literal(&ctx, "ws", "[ \t]*");
     auto ws_r1 = reference(&ctx, ws);
     auto nl = literal(&ctx, "nl", "[\r\n]");
     auto nl_r1 = reference(&ctx, nl);
     auto header = sequence(&ctx, "Header",
-                           make_prods(std::move(hdrkey), std::move(ws), std::move(colon), std::move(ws_r1),
-                                      std::move(hdrval), std::move(nl)));
+                           makeProds(std::move(hdrkey), std::move(ws), std::move(colon), std::move(ws_r1),
+                                     std::move(hdrval), std::move(nl)));
     auto [list1_, list1] = resolved(&ctx);
     auto list2 = lookAhead(&ctx, "List2", std::move(list1), epsilon(&ctx));
     auto list2_r1 = reference(&ctx, list2);
-    g.resolve(list1_, sequence(&ctx, "List1", make_prods(std::move(header), std::move(list2))));
+    g.resolve(list1_, sequence(&ctx, "List1", makeProds(std::move(header), std::move(list2))));
     auto all = lookAhead(&ctx, "All", std::move(list2_r1), std::move(nl_r1));
     CHECK(finalize(&g, std::move(all)));
 }
@@ -208,8 +212,8 @@ TEST_CASE("example4") {
     auto [list1_, list1] = resolved(&ctx);
     auto list2 = lookAhead(&ctx, "List2", std::move(ws), epsilon(&ctx));
     auto list2_r1 = reference(&ctx, list2);
-    g.resolve(list1_, sequence(&ctx, "List1", make_prods(std::move(list2))));
-    g.resolve(all_, sequence(&ctx, "All", make_prods(std::move(list2_r1), std::move(colon))));
+    g.resolve(list1_, sequence(&ctx, "List1", makeProds(std::move(list2))));
+    g.resolve(all_, sequence(&ctx, "All", makeProds(std::move(list2_r1), std::move(colon))));
     CHECK(finalize(&g, std::move(all)));
 }
 


### PR DESCRIPTION
This had gotten lost/deactivated at some point.

- **Prettify configure output for sanitizers.**
- **Add `--use-clang-tidy` flag to `configure`.**
- **Enable clang-tidy's naming check.**
- **Enforce naming conventions across toolchain using clang-tidy.**
