### PR TITLE
Fix a few random flagged issues

### DIFF
--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -91,8 +91,12 @@ Result<std::vector<std::string>> util::splitShellUnsafe(const std::string& s) {
 
     wordexp_t we;
 
-    if ( wordexp(s.c_str(), &we, WRDE_UNDEF) != 0 )
-        return result::Error("could not split string");
+    switch ( wordexp(s.c_str(), &we, WRDE_UNDEF) ) {
+        case 0: break;
+        // WRDE_NOSPACE may allocate part of the result.
+        case WRDE_NOSPACE: wordfree(&we); [[fallthrough]];
+        default: return result::Error("could not split string");
+    }
 
     std::vector<std::string> result{we.we_wordv, we.we_wordv + we.we_wordc};
     wordfree(&we);

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -126,6 +126,7 @@ struct Visitor : hilti::visitor::PreOrder {
         }
 
         auto* decl = n->resolvedDeclaration();
+        assert(decl);
         const auto& fqid = decl->fullyQualifiedID();
         assert(fqid);
 

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1067,7 +1067,7 @@ struct ConstantPropagationVisitor : OptimizerVisitor {
             }
 
             void operator()(expression::ResolvedOperator* op) override {
-                auto sig = op->operator_().signature();
+                const auto& sig = op->operator_().signature();
                 std::size_t i = 0;
                 for ( const auto* operand : sig.operands->operands() ) {
                     if ( operand->kind() == parameter::Kind::InOut )

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1125,7 +1125,7 @@ struct ConstantPropagationVisitor : OptimizerVisitor {
             // If it changed, add successors to worklist
             ConstantMap old_out = result.out[n];
             if ( old_out != new_out ) {
-                result.out[n] = new_out;
+                result.out[n] = std::move(new_out);
                 for ( auto succ_id : result.cfg.graph().neighborsDownstream(n->identity()) ) {
                     const auto* succ_node = result.cfg.graph().getNode(succ_id);
                     if ( std::ranges::find(worklist, *succ_node) == worklist.end() )

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1103,7 +1103,10 @@ struct ConstantPropagationVisitor : OptimizerVisitor {
             ConstantMap new_in;
             auto preds = result.cfg.graph().neighborsUpstream(n->identity());
             for ( const uint64_t& pred : preds ) {
-                const auto& pred_out = result.out[*result.cfg.graph().getNode(pred)];
+                const auto* cfg_node = result.cfg.graph().getNode(pred);
+                // cfg_node was retrieved from the graph itself so should be present.
+                assert(cfg_node);
+                const auto& pred_out = result.out[*cfg_node];
 
                 for ( const auto& [decl, const_val] : pred_out ) {
                     // Add if we can, otherwise NAC if they're not the same const.


### PR DESCRIPTION
A few new Coverity findings, some were valid small things (in the constant propagation pass). The dereference null values are guaranteed non-null currently for us (I think) so I just added assertions.

The CID 1620855 is an FP I think - it's saying to return a reference when 2 of 3 branches return temporary values, just one returns a reference. It's saying change [this](https://github.com/zeek/spicy/blob/a61017994126e7890b1213210e6c7f60db78cacb/hilti/toolchain/src/ast/operator.cc#L126) to return a const reference, which makes `t->print()` and `fmt` try to reference a temporary.

The resource leak fix is basically directly from the [GNU manual example on `wordexp`](https://sourceware.org/glibc/manual/2.42/html_mono/libc.html#wordexp-Example)