### PR TITLE
Fix C++ code generation for struct parameters passed as references.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/cxx/elements.h
+++ b/hilti/toolchain/include/compiler/detail/cxx/elements.h
@@ -290,6 +290,8 @@ struct Argument : public DeclarationBase {
     }
 
     bool operator!=(const Argument& other) const { return ! operator==(other); }
+
+    bool isPassedByRef() const { return std::string_view(type).ends_with("&"); }
 };
 
 } // namespace declaration

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -563,7 +563,11 @@ std::string cxx::type::Struct::code() const {
             util::join(util::transform(args, [&](const auto& x) { return fmt("%s %s", x.type, x.id); }), ", ");
 
         auto ctor_inits =
-            util::join(util::transform(args, [&](const auto& x) { return fmt("%s(std::move(%s))", x.id, x.id); }),
+            util::join(util::transform(args,
+                                       [&](const auto& x) {
+                                           auto arg = x.isPassedByRef() ? fmt("%s", x.id) : fmt("std::move(%s)", x.id);
+                                           return fmt("%s(%s)", x.id, arg);
+                                       }),
                        ", ");
 
         code += fmt("%s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits, init_locals_user(),

--- a/tests/hilti/codegen/struct-parameter-passing.hlt
+++ b/tests/hilti/codegen/struct-parameter-passing.hlt
@@ -1,0 +1,21 @@
+# @TEST-DOC: Validate generated C++ argument passing of struct parameters.
+#
+# @TEST-REQUIRES: which FileCheck
+# @TEST-EXEC: hiltic -c %INPUT -o output.cc
+# @TEST-EXEC: FileCheck %INPUT < output.cc
+
+module foo {
+
+# `in` parameters are passed as references.
+# CHECK: X1::X1(const ::hilti::rt::integer::safe<uint8_t>& __p_y) : __p_y(__p_y) {
+public type X1 = struct (uint<8> y) {};
+
+# `copy` parameters are passed as values and moved from.
+# CHECK: X2::X2(::hilti::rt::integer::safe<uint8_t> __p_y) : __p_y(std::move(__p_y)) {
+public type X2 = struct (copy uint<8> y) {};
+
+# `inout` parameters are passed as references.
+# CHECK: X3::X3(::hilti::rt::integer::safe<uint8_t>& __p_y) : __p_y(__p_y) {
+public type X3 = struct (inout uint<8> y) {};
+
+}


### PR DESCRIPTION
Previously we could generate C++ moves for constructor arguments passed as references. This is semantically incorrect, but seems to have had no ill effects on code we generated. Since it could still confuse readers and static analysis tools fix this to only generate moves if the argument was passed as `copy`, but write out copies for all other argument passing. This more clearly reflects what was already happening.