### PR TITLE
Bump minimal GCC version to gcc-12.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -202,7 +202,7 @@ To build Spicy from source, you will need:
 
     - For compiling the toolchain:
 
-        * A C++ compiler that supports C++20 (known to work are Clang >= 9 and GCC >= 9)
+        * A C++ compiler that supports C++20 (known to work are Clang >= 9 and GCC >= 12)
         * `CMake <https://cmake.org>`_  >= 3.15
         * `Bison <https://www.gnu.org/software/bison>`_  >= 3.0
         * `Flex <https://www.gnu.org/software/flex>`_  >= 2.6

--- a/docker/Dockerfile.ubuntu-22
+++ b/docker/Dockerfile.ubuntu-22
@@ -13,11 +13,14 @@ ENV PATH="/opt/spicy/bin:${PATH}"
 
 # Spicy build and test dependencies.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git cmake ninja-build ccache bison flex g++ libfl-dev zlib1g-dev libssl-dev jq locales-all make \
+ && apt-get install -y --no-install-recommends git cmake ninja-build ccache bison flex g++-12 libfl-dev zlib1g-dev libssl-dev jq locales-all make \
  # Spicy doc dependencies.
  && apt-get install -y --no-install-recommends python3 python3-pip python3-sphinx python3-sphinx-rtd-theme python3-setuptools python3-wheel doxygen \
  && pip3 install "btest>=0.66" pre-commit \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ # Spicy needs gcc-12.
+ && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 0 \
+ && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 0
 
 WORKDIR /root


### PR DESCRIPTION
C++20 support in gcc-11 is incomplete, e.g., constructs involving range adapters fail to compile. It looks like gcc-12 has sufficient support, and it is available on all supported platforms.

Closes #2204.