### PR TITLE
Remove `nodes::transform` and `nodes::filter`.

### DIFF
--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -1189,66 +1189,6 @@ Nodes flatten(T t, Ts... ts)
     return util::concat(std::move(flatten(std::move(t))), flatten(std::move(ts)...));
 }
 
-/**
- * Filters a node vector through a boolean predicate, returning a set
- * containing the matching ones.
- */
-template<typename X, typename F>
-auto filter(const hilti::node::Range<X>& x, F f) {
-    hilti::node::Set<X> y;
-    for ( const auto& i : x ) {
-        if ( f(i) )
-            y.push_back(i);
-    }
-
-    return y;
-}
-
-/**
- * Filters a node set through a boolean predicate, returning a new set
- * containing the matching ones.
- */
-template<typename X, typename F>
-auto filter(const hilti::node::Set<X>& x, F f) {
-    hilti::node::Set<X> y;
-    for ( const auto& i : x ) {
-        if ( f(i) )
-            y.push_back(i);
-    }
-
-    return y;
-}
-
-/**
- * Applies a function to each element of a node range, returning a new vector
- * with the results.
- */
-template<typename X, typename F>
-auto transform(const hilti::node::Range<X>& x, F f) {
-    using Y = std::invoke_result_t<F, X*>;
-    std::vector<Y> y;
-    y.reserve(x.size());
-    for ( const auto& i : x )
-        y.push_back(f(i));
-
-    return y;
-}
-
-/**
- * Applies a function to each element of a node set, returning a new vector of
- * with the results.
- */
-template<typename X, typename F>
-auto transform(const hilti::node::Set<X>& x, F f) {
-    using Y = std::invoke_result_t<F, X*>;
-    std::vector<Y> y;
-    y.reserve(x.size());
-    for ( const auto& i : x )
-        y.push_back(f(i));
-
-    return y;
-}
-
 } // namespace node
 
 /** Renders a node as HILTI source code. */

--- a/hilti/toolchain/src/compiler/codegen/expressions.cc
+++ b/hilti/toolchain/src/compiler/codegen/expressions.cc
@@ -48,7 +48,7 @@ struct Visitor : hilti::visitor::PreOrder {
         cxx::Block block;
         cg->pushCxxBlock(&block);
         auto arguments =
-            util::join(node::transform(n->arguments(), [this](auto x) { return cg->compile(x, lhs); }), ", ");
+            util::join(n->arguments() | std::views::transform([this](auto x) { return cg->compile(x, lhs); }), ", ");
         cg->popCxxBlock();
 
         block.addStatement(fmt("%s(%s)", cxx::ID(n->cxxname()), arguments));

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -42,7 +42,7 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     auto compileExpressions(const node::Range<Expression>& exprs) {
-        return node::transform(exprs, [&](auto e) { return cg->compile(e); });
+        return util::toVector(exprs | std::views::transform([&](auto e) { return cg->compile(e); }));
     }
 
     auto methodArguments(const expression::ResolvedOperator* o) {
@@ -794,7 +794,7 @@ struct Visitor : hilti::visitor::PreOrder {
             if ( auto* ctor = n->op1()->tryAs<expression::Ctor>() ) {
                 auto t = ctor->ctor()->as<ctor::Tuple>()->value();
                 result = fmt("::hilti::rt::fmt(%s, %s)", op0(n),
-                             util::join(node::transform(t, [this](auto x) { return cg->compile(x); }), ", "));
+                             util::join(t | std::views::transform([this](auto x) { return cg->compile(x); }), ", "));
                 return;
             }
         }
@@ -1108,7 +1108,7 @@ struct Visitor : hilti::visitor::PreOrder {
 
     void operator()(operator_::tuple::CustomAssign* n) final {
         auto t = n->operands()[0]->as<expression::Ctor>()->ctor()->as<ctor::Tuple>()->value();
-        auto l = util::join(node::transform(t, [this](auto x) { return cg->compile(x, true); }), ", ");
+        auto l = util::join(t | std::views::transform([this](auto x) { return cg->compile(x, true); }), ", ");
         result = {fmt("::hilti::rt::tuple::assign(std::tie(%s), %s)", l, op1(n)), Side::LHS};
     }
 

--- a/hilti/toolchain/src/compiler/codegen/statements.cc
+++ b/hilti/toolchain/src/compiler/codegen/statements.cc
@@ -255,7 +255,7 @@ struct Visitor : hilti::visitor::PreOrder {
             if ( exprs.size() == 1 )
                 cond = cg->compile(*exprs.begin());
             else
-                cond = util::join(node::transform(exprs, [&](auto e) { return cg->compile(e); }), " || ");
+                cond = util::join(exprs | std::views::transform([&](auto e) { return cg->compile(e); }), " || ");
 
             auto body = cg->compile(c->body());
 

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -373,9 +373,9 @@ struct VisitorStorage : hilti::visitor::PreOrder {
     void operator()(type::Bool* n) final { result = CxxTypes{.base_type = "::hilti::rt::Bool"}; }
 
     void operator()(type::Bitfield* n) final {
-        auto x = node::transform(n->bits(true), [this](const auto& b) {
-            return cg->compile(b->itemType(), codegen::TypeUsage::Storage);
-        });
+        auto x = n->bits(true) | std::views::transform([this](const auto& b) {
+                     return cg->compile(b->itemType(), codegen::TypeUsage::Storage);
+                 });
 
         auto t = fmt("::hilti::rt::Bitfield<%s>", util::join(x, ", "));
         auto ti = cg->typeInfo(type);

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1819,10 +1819,6 @@ struct MemberVisitor : OptimizerVisitor {
                     if ( features.contains(type_id) ) {
                         const auto& features_ = features.at(type_id);
 
-                        auto dependent_features =
-                            hilti::node::transform(n->attributes()->findAll(hilti::attribute::kind::NeededByFeature),
-                                                   [](const auto& attr) { return *attr->valueAsString(); });
-
                         for ( const auto& dependent_feature_ :
                               n->attributes()->findAll(hilti::attribute::kind::NeededByFeature) ) {
                             auto dependent_feature = *dependent_feature_->valueAsString();

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <ranges>
 
+#include <hilti/rt/util.h>
+
 #include <hilti/ast/all.h>
 #include <hilti/ast/function.h>
 #include <hilti/ast/type.h>
@@ -226,10 +228,10 @@ struct Printer : visitor::PreOrder {
     void operator()(ctor::List* n) final { _out << '[' << std::make_pair(n->value(), ", ") << ']'; }
 
     void operator()(ctor::Map* n) final {
-        auto elems = node::transform(n->value(), [](const auto& e) -> std::string {
-            return fmt("%s: %s", *e->key(), *e->value());
-        });
-        _out << "map(" << std::make_pair(elems, ", ") << ')';
+        auto elems = n->value() | std::views::transform([](const auto& e) -> std::string {
+                         return fmt("%s: %s", *e->key(), *e->value());
+                     });
+        _out << "map(" << std::make_pair(util::toVector(elems), ", ") << ')';
     }
 
     void operator()(ctor::Network* n) final { _out << n->value(); }
@@ -483,7 +485,7 @@ struct Printer : visitor::PreOrder {
 
     void operator()(expression::BuiltInFunction* n) final {
         _out << n->name() << "("
-             << util::join(node::transform(n->arguments(), [](auto p) { return fmt("%s", p); }), ", ") << ")";
+             << util::join(n->arguments() | std::views::transform([](auto p) { return fmt("%s", p); }), ", ") << ")";
     }
 
     void operator()(expression::Coerced* n) final { _out << n->expression(); }

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -673,8 +673,9 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
     void operator()(ctor::Tuple* n) final {
         if ( ! n->type()->isResolved() && expression::areResolved(n->value()) ) {
-            auto elems = node::transform(n->value(), [](const auto& e) { return e->type(); });
-            auto* t = builder()->qualifiedType(builder()->typeTuple(elems, n->meta()), Constness::Const);
+            auto elems = n->value() | std::views::transform([](const auto& e) { return e->type(); });
+            auto* t =
+                builder()->qualifiedType(builder()->typeTuple(util::toVector(elems), n->meta()), Constness::Const);
             recordChange(n, t, "type");
             n->setType(context(), t);
         }

--- a/spicy/toolchain/src/compiler/codegen/parser-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/parser-builder.cc
@@ -2273,10 +2273,11 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, type::Unit* t, bool
             builder()->addLocal("__unit",
                                 builder()->valueReference(
                                     builder()->default_(builder()->typeName(t->typeID()),
-                                                        hilti::node::transform(t->parameters(),
-                                                                               [](const auto& p) -> Expression* {
-                                                                                   return p->default_();
-                                                                               }))));
+                                                        hilti::util::toVector(
+                                                            t->parameters() |
+                                                            std::views::transform([](const auto& p) -> Expression* {
+                                                                return p->default_();
+                                                            })))));
             builder()
                 ->addLocal("__ncur", builder()->qualifiedType(builder()->typeStreamView(), hilti::Constness::Mutable),
                            builder()->ternary(builder()->id("__cur"), builder()->deref(builder()->id("__cur")),
@@ -2325,10 +2326,11 @@ void ParserBuilder::addParserMethods(hilti::type::Struct* s, type::Unit* t, bool
             builder()->addLocal("__unit",
                                 builder()->valueReference(
                                     builder()->default_(builder()->typeName(t->typeID()),
-                                                        hilti::node::transform(t->parameters(),
-                                                                               [](const auto& p) -> Expression* {
-                                                                                   return p->default_();
-                                                                               }))));
+                                                        hilti::util::toVector(
+                                                            t->parameters() |
+                                                            std::views::transform([](const auto& p) -> Expression* {
+                                                                return p->default_();
+                                                            })))));
 
             builder()->addCall(ID("spicy_rt::initializeParsedUnit"),
                                {builder()->id("__gunit"), builder()->id("__unit")});

--- a/spicy/toolchain/src/compiler/codegen/production.cc
+++ b/spicy/toolchain/src/compiler/codegen/production.cc
@@ -55,12 +55,10 @@ std::string codegen::to_string(const Production& p) {
         std::string args;
 
         if ( auto x = f->arguments(); x.size() ) {
-            args = hilti::util::fmt(", args: (%s)",
-                                    hilti::util::join(hilti::node::transform(x,
-                                                                             [](auto a) {
-                                                                                 return hilti::util::fmt("%s", *a);
-                                                                             }),
-                                                      ", "));
+            args = hilti::util::fmt(", args: (%s)", hilti::util::join(x | std::views::transform([](auto a) {
+                                                                          return hilti::util::fmt("%s", *a);
+                                                                      }),
+                                                                      ", "));
 
             field = hilti::util::fmt(" (field '%s', id %s, parser%s)", f->id(), id, args);
         }


### PR DESCRIPTION
In C++20 these can be solved by `std::views::transform` and `std::views::filter` (but that particular one actually had no users).