### PR TITLE
Remove uses of `std::views`.

### DIFF
--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -236,7 +236,7 @@ inline bool operator!=(const Empty& /*unused*/, const Set<T>& v) {
 namespace detail::adl {
 template<typename T>
 inline std::string to_string(const Set<T>& x, adl::tag /*unused*/) {
-    return fmt("{%s}", rt::join(x | std::views::transform([](const T& y) { return rt::to_string(y); }), ", "));
+    return fmt("{%s}", rt::join(std::ranges::transform_view(x, [](const T& y) { return rt::to_string(y); }), ", "));
 }
 
 inline std::string to_string(const set::Empty& x, adl::tag /*unused*/) { return "{}"; }

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -580,7 +580,7 @@ namespace detail::adl {
 template<typename T, typename Allocator>
 inline std::string to_string(const Vector<T, Allocator>& x, adl::tag /*unused*/) {
     using detail::adl::to_string;
-    return fmt("[%s]", rt::join(x | std::views::transform([](const T& y) { return rt::to_string(y); }), ", "));
+    return fmt("[%s]", rt::join(std::ranges::transform_view(x, [](const T& y) { return rt::to_string(y); }), ", "));
 }
 
 inline std::string to_string(const vector::Empty& /* x */, adl::tag /*unused*/) { return "[]"; }

--- a/hilti/runtime/src/types/regexp.cc
+++ b/hilti/runtime/src/types/regexp.cc
@@ -272,9 +272,10 @@ void regexp::detail::CompiledRegExp::_compileOne(regexp::Pattern pattern, int id
 
 RegExp::RegExp(const regexp::Patterns& patterns, regexp::Flags flags) {
     const auto& key =
-        (patterns.empty() ? std::string() :
-                            join(patterns | std::views::transform([](const auto& p) { return to_string(p); }), "|") +
-                                "|" + flags.cacheKey());
+        (patterns.empty() ?
+             std::string() :
+             join(std::ranges::transform_view(patterns, [](const auto& p) { return to_string(p); }), "|") + "|" +
+                 flags.cacheKey());
     auto& ptr = detail::globalState()->regexp_cache[key];
 
     if ( ! ptr )
@@ -443,7 +444,7 @@ std::string hilti::rt::detail::adl::to_string(const RegExp& x, adl::tag /*unused
     if ( x.patterns().empty() )
         return "<regexp w/o pattern>";
 
-    auto p = join(x.patterns() | std::views::transform([&](const auto& s) { return to_string(s); }), " | ");
+    auto p = join(std::ranges::transform_view(x.patterns(), [&](const auto& s) { return to_string(s); }), " | ");
     auto f = std::vector<std::string>();
 
     if ( x.flags().no_sub )

--- a/hilti/toolchain/include/ast/ctors/regexp.h
+++ b/hilti/toolchain/include/ast/ctors/regexp.h
@@ -38,7 +38,7 @@ public:
     node::Properties properties() const final {
         auto p = node::Properties{
             {"pattern",
-             util::join(_patterns | std::views::transform([](const auto& p) { return to_string(p); }), " | ")}};
+             util::join(std::ranges::transform_view(_patterns, [](const auto& p) { return to_string(p); }), " | ")}};
         return Ctor::properties() + std::move(p);
     }
 

--- a/hilti/toolchain/include/ast/types/tuple.h
+++ b/hilti/toolchain/include/ast/types/tuple.h
@@ -86,7 +86,7 @@ public:
 
     static auto create(ASTContext* ctx, const QualifiedTypes& types, Meta meta = {}) {
         auto elements =
-            types | std::views::transform([&](const auto& t) { return tuple::Element::create(ctx, t, meta); });
+            std::ranges::transform_view(types, [&](const auto& t) { return tuple::Element::create(ctx, t, meta); });
         return ctx->make<Tuple>(ctx, util::toVector(elements), std::move(meta));
     }
 

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -131,7 +131,7 @@ auto slice(R&& v, int begin, int end = -1) {
     begin = std::max(begin, 0);
     end = std::max(end, 0);
 
-    return v | std::views::drop(begin) | std::views::take(end - begin);
+    return std::ranges::take_view(std::ranges::drop_view(v, begin), end - begin);
 }
 
 /**

--- a/hilti/toolchain/include/compiler/plugin.h
+++ b/hilti/toolchain/include/compiler/plugin.h
@@ -271,7 +271,7 @@ public:
 
     /** Returns a range of all extensions that registered set of plugins handles. */
     auto supportedExtensions() const {
-        return _plugins | std::views::transform([](auto& p) { return p.extension; });
+        return std::ranges::transform_view(_plugins, [](auto& p) { return p.extension; });
     }
 
     /**

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -171,7 +171,8 @@ void DependencyTracker::computeAllDependencies(ASTRoot* root) {
                 continue;
 
             auto decl_ = fmt("[%s] %s", decl->displayName(), decl->canonicalID());
-            auto deps_ = util::join(deps | std::views::transform([](const auto* d) { return d->canonicalID(); }), ", ");
+            auto deps_ =
+                util::join(std::ranges::transform_view(deps, [](const auto* d) { return d->canonicalID(); }), ", ");
             HILTI_DEBUG(logging::debug::AstDeclarations, fmt("- %s -> %s", decl_, deps_));
         }
     }

--- a/hilti/toolchain/src/ast/node.cc
+++ b/hilti/toolchain/src/ast/node.cc
@@ -24,7 +24,7 @@ using namespace hilti::detail;
 uint64_t hilti::Node::_instances = 0;
 
 std::string node::to_string(const Tags& ti) {
-    return util::join(ti | std::views::transform([](auto i) { return std::to_string(i); }), ",");
+    return util::join(std::ranges::transform_view(ti, [](auto i) { return std::to_string(i); }), ",");
 }
 
 Node::~Node() {

--- a/hilti/toolchain/src/ast/operator.cc
+++ b/hilti/toolchain/src/ast/operator.cc
@@ -78,7 +78,8 @@ std::string printOperator(operator_::Kind kind, const std::vector<std::string>& 
 
 std::string printOperator(operator_::Kind kind, const Expressions& operands, bool print_signature, const Meta& meta) {
     if ( ! print_signature )
-        return printOperator(kind, toVector(operands | std::views::transform([](const auto& x) { return x->print(); })),
+        return printOperator(kind,
+                             toVector(std::ranges::transform_view(operands, [](const auto& x) { return x->print(); })),
                              meta);
 
     auto render_one = [](QualifiedType* t) {
@@ -93,9 +94,10 @@ std::string printOperator(operator_::Kind kind, const Expressions& operands, boo
             assert(operands.size() == 3);
             std::string args;
             if ( auto* ttype = operands[2]->type()->type()->tryAs<type::Tuple>() )
-                args = util::join(ttype->elements() | std::views::transform([&render_one](const auto& x) {
-                                      return render_one(x->type());
-                                  }),
+                args = util::join(std::ranges::transform_view(ttype->elements(),
+                                                              [&render_one](const auto& x) {
+                                                                  return render_one(x->type());
+                                                              }),
                                   ", ");
             else
                 args = render_one(operands[2]->type());
@@ -108,9 +110,10 @@ std::string printOperator(operator_::Kind kind, const Expressions& operands, boo
             assert(operands.size() == 2);
             std::string args;
             if ( auto* ttype = operands[1]->type()->type()->tryAs<type::Tuple>() )
-                args = util::join(ttype->elements() | std::views::transform([&render_one](const auto& x) {
-                                      return render_one(x->type());
-                                  }),
+                args = util::join(std::ranges::transform_view(ttype->elements(),
+                                                              [&render_one](const auto& x) {
+                                                                  return render_one(x->type());
+                                                              }),
                                   ", ");
             else
                 args = render_one(operands[1]->type());
@@ -120,9 +123,11 @@ std::string printOperator(operator_::Kind kind, const Expressions& operands, boo
 
 
         default:
-            return printOperator(kind, toVector(operands | std::views::transform([&render_one](const auto& op) {
-                                                    return render_one(op->type());
-                                                })),
+            return printOperator(kind,
+                                 toVector(std::ranges::transform_view(operands,
+                                                                      [&render_one](const auto& op) {
+                                                                          return render_one(op->type());
+                                                                      })),
                                  meta);
     }
 }
@@ -142,8 +147,9 @@ std::string printOperator(operator_::Kind kind, const Operands& operands, const 
             assert(operands.size() == 3);
             std::string args;
             if ( auto* ttype = operands[2]->type()->type()->tryAs<type::OperandList>() )
-                args = util::join(ttype->operands() | std::views::transform([](const auto& x) { return x->print(); }),
-                                  ", ");
+                args =
+                    util::join(std::ranges::transform_view(ttype->operands(), [](const auto& x) { return x->print(); }),
+                               ", ");
             else
                 args = render_one(operands[2]);
 
@@ -155,8 +161,9 @@ std::string printOperator(operator_::Kind kind, const Operands& operands, const 
             assert(operands.size() == 2);
             std::string args;
             if ( auto* ttype = operands[1]->type()->type()->tryAs<type::OperandList>() )
-                args = util::join(ttype->operands() | std::views::transform([](const auto& x) { return x->print(); }),
-                                  ", ");
+                args =
+                    util::join(std::ranges::transform_view(ttype->operands(), [](const auto& x) { return x->print(); }),
+                               ", ");
             else
                 args = render_one(operands[1]);
 
@@ -164,7 +171,7 @@ std::string printOperator(operator_::Kind kind, const Operands& operands, const 
         }
 
 
-        default: return printOperator(kind, toVector(operands | std::views::transform(render_one)), meta);
+        default: return printOperator(kind, toVector(std::ranges::transform_view(operands, render_one)), meta);
     }
 }
 

--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -282,27 +282,27 @@ std::string util::prefixParts(const std::string& in, const std::string& prefix, 
     if ( in.empty() )
         return "";
 
-    auto x = split(in, " ") | std::views::transform([&](auto s) {
-                 if ( s.empty() )
-                     return std::string();
+    auto x = std::ranges::transform_view(split(in, " "), [&](auto s) {
+        if ( s.empty() )
+            return std::string();
 
-                 if ( include_tag.size() ) {
-                     auto x = split(s, "!");
-                     if ( x.size() == 3 ) {
-                         if ( x[1] != include_tag )
-                             return std::string();
+        if ( include_tag.size() ) {
+            auto x = split(s, "!");
+            if ( x.size() == 3 ) {
+                if ( x[1] != include_tag )
+                    return std::string();
 
-                         s = x[2];
-                     }
-                 }
+                s = x[2];
+            }
+        }
 
-                 if ( auto x = trim(s); ! util::startsWith(s, "-") )
-                     return prefix + x;
-                 else
-                     return x;
-             });
+        if ( auto x = trim(s); ! util::startsWith(s, "-") )
+            return prefix + x;
+        else
+            return x;
+    });
 
-    return join(std::move(x) | std::views::filter([](const auto& s) -> bool { return s.size(); }), " ");
+    return join(std::ranges::filter_view(std::move(x), [](const auto& s) -> bool { return s.size(); }), " ");
 }
 
 std::vector<std::string> util::flattenParts(const std::vector<std::string>& in) {

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -549,8 +549,8 @@ std::string CFG::dot(bool omit_dataflow) const {
             const auto& transfer = it->second;
 
             auto read = [&]() {
-                auto xs = util::toVector(transfer.read |
-                                         std::views::transform([&](auto* decl) { return escape(decl->id()); }));
+                auto xs = util::toVector(
+                    std::ranges::transform_view(transfer.read, [&](auto* decl) { return escape(decl->id()); }));
                 std::ranges::sort(xs);
                 if ( ! xs.empty() )
                     return util::fmt("read: [%s]", util::join(xs, ", "));
@@ -559,8 +559,8 @@ std::string CFG::dot(bool omit_dataflow) const {
             }();
 
             auto write = [&]() {
-                auto xs = util::toVector(transfer.write |
-                                         std::views::transform([&](auto* decl) { return escape(decl->id()); }));
+                auto xs = util::toVector(
+                    std::ranges::transform_view(transfer.write, [&](auto* decl) { return escape(decl->id()); }));
                 std::ranges::sort(xs);
                 if ( ! xs.empty() )
                     return util::fmt("write: [%s]", util::join(xs, ", "));
@@ -569,10 +569,10 @@ std::string CFG::dot(bool omit_dataflow) const {
             }();
 
             auto gen = [&]() {
-                auto xs = util::toVector(transfer.gen | std::views::transform([&](const auto& kv) {
-                                             const auto& [decl, node] = kv;
-                                             return util::fmt("%s: %s", escape(decl->id()), escape(node->print()));
-                                         }));
+                auto xs = util::toVector(std::ranges::transform_view(transfer.gen, [&](const auto& kv) {
+                    const auto& [decl, node] = kv;
+                    return util::fmt("%s: %s", escape(decl->id()), escape(node->print()));
+                }));
                 std::ranges::sort(xs);
                 if ( ! xs.empty() )
                     return util::fmt("gen: [%s]", util::join(xs, ", "));
@@ -605,8 +605,8 @@ std::string CFG::dot(bool omit_dataflow) const {
             }();
 
             auto aliases = [&]() {
-                auto xs = util::toVector(transfer.maybe_alias |
-                                         std::views::transform([&](auto* decl) { return escape(decl->id()); }));
+                auto xs = util::toVector(
+                    std::ranges::transform_view(transfer.maybe_alias, [&](auto* decl) { return escape(decl->id()); }));
                 std::ranges::sort(xs);
                 if ( ! xs.empty() )
                     return util::fmt("aliases: [%s]", util::join(xs, ", "));
@@ -616,17 +616,18 @@ std::string CFG::dot(bool omit_dataflow) const {
 
             auto keep = [&]() -> std::string { return transfer.keep ? "keep" : ""; }();
 
-            xlabel = util::fmt("xlabel=\"%s\"", util::join(
-                                                    std::vector{
-                                                        std::move(read),
-                                                        std::move(write),
-                                                        std::move(gen),
-                                                        std::move(kill),
-                                                        std::move(in_out),
-                                                        std::move(aliases),
-                                                        std::move(keep),
-                                                    } | std::views::filter([](const auto& x) { return ! x.empty(); }),
-                                                    " "));
+            xlabel = util::fmt("xlabel=\"%s\"", util::join(std::ranges::filter_view(
+                                                               std::vector{
+                                                                   std::move(read),
+                                                                   std::move(write),
+                                                                   std::move(gen),
+                                                                   std::move(kill),
+                                                                   std::move(in_out),
+                                                                   std::move(aliases),
+                                                                   std::move(keep),
+                                                               },
+                                                               [](const auto& x) { return ! x.empty(); }),
+                                                           " "));
         }
 
         if ( const auto* meta = n->tryAs<MetaNode>() ) {

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -515,11 +515,14 @@ struct GlobalsVisitor : hilti::visitor::PostOrder {
             auto body = cxx::Block();
             auto cb = cxx::Block();
 
-            auto outer_args = util::join(cxx_func.args | std::views::transform([](auto& x) {
-                                             return fmt("::hilti::rt::resumable::detail::copyArg(%s)", x.id);
-                                         }),
+            auto outer_args =
+                util::join(std::ranges::transform_view(cxx_func.args,
+                                                       [](auto& x) {
+                                                           return fmt("::hilti::rt::resumable::detail::copyArg(%s)",
+                                                                      x.id);
+                                                       }),
 
-                                         ", ");
+                           ", ");
 
             body.addLocal({"args", "auto", {}, fmt("std::make_tuple(%s)", outer_args)});
 
@@ -530,10 +533,12 @@ struct GlobalsVisitor : hilti::visitor::PostOrder {
             body.addLocal({"args_on_heap", "auto", {}, "std::make_shared<decltype(args)>(std::move(args))"});
 
             int idx = 0;
-            auto inner_args = util::join(cxx_func.args | std::views::transform([&idx](auto& x) {
-                                             return fmt("std::get<%d>(*args_on_heap)", idx++);
-                                         }),
-                                         ", ");
+            auto inner_args =
+                util::join(std::ranges::transform_view(cxx_func.args,
+                                                       [&idx](auto& x) {
+                                                           return fmt("std::get<%d>(*args_on_heap)", idx++);
+                                                       }),
+                           ", ");
 
             // If the function returns void synthesize a `Nothing` return value here.
             if ( ! ft->result()->type()->isA<type::Void>() )

--- a/hilti/toolchain/src/compiler/codegen/ctors.cc
+++ b/hilti/toolchain/src/compiler/codegen/ctors.cc
@@ -219,14 +219,17 @@ struct Visitor : hilti::visitor::PreOrder {
         if ( n->isNoSub() )
             flags.emplace_back(".no_sub = true");
 
-        result = fmt("::hilti::rt::RegExp({%s}, {%s})",
-                     util::join(n->patterns() | std::views::transform([&](const auto& p) {
-                                    return fmt("::hilti::rt::regexp::Pattern{\"%s\", %s, %s}",
-                                               util::escapeUTF8(p.value(), hilti::rt::render_style::UTF8::EscapeQuotes),
-                                               (p.isCaseInsensitive() ? "true" : "false"), p.matchID());
-                                }),
-                                ", "),
-                     util::join(flags, ", "));
+        result =
+            fmt("::hilti::rt::RegExp({%s}, {%s})",
+                util::join(std::ranges::transform_view(
+                               n->patterns(),
+                               [&](const auto& p) {
+                                   return fmt("::hilti::rt::regexp::Pattern{\"%s\", %s, %s}",
+                                              util::escapeUTF8(p.value(), hilti::rt::render_style::UTF8::EscapeQuotes),
+                                              (p.isCaseInsensitive() ? "true" : "false"), p.matchID());
+                               }),
+                           ", "),
+                util::join(flags, ", "));
     }
 
     void operator()(ctor::Set* n) final {

--- a/hilti/toolchain/src/compiler/codegen/operators.cc
+++ b/hilti/toolchain/src/compiler/codegen/operators.cc
@@ -38,7 +38,7 @@ struct Visitor : hilti::visitor::PreOrder {
     }
 
     auto compileExpressions(const Expressions& exprs) {
-        return util::toVector(exprs | std::views::transform([&](auto e) { return cg->compile(e); }));
+        return util::toVector(std::ranges::transform_view(exprs, [&](auto e) { return cg->compile(e); }));
     }
 
     auto compileExpressions(const node::Range<Expression>& exprs) {
@@ -900,9 +900,10 @@ struct Visitor : hilti::visitor::PreOrder {
 
         result = memberAccess(n,
                               fmt("%s(%s)", id,
-                                  util::join(zipped | std::views::transform([this](const auto& x) {
-                                                 return cg->compile(x.first, x.second);
-                                             }),
+                                  util::join(std::ranges::transform_view(zipped,
+                                                                         [this](const auto& x) {
+                                                                             return cg->compile(x.first, x.second);
+                                                                         }),
                                              ", ")),
                               false);
     }

--- a/hilti/toolchain/src/compiler/codegen/types.cc
+++ b/hilti/toolchain/src/compiler/codegen/types.cc
@@ -161,7 +161,8 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
                                                    fmt("__hook_%s_%s", id_class, id_local));
                             auto id_type = cxx::ID(id_module, id_class);
 
-                            auto args = util::toVector(d.args | std::views::transform([](auto& a) { return a.id; }));
+                            auto args =
+                                util::toVector(std::ranges::transform_view(d.args, [](auto& a) { return a.id; }));
                             args.emplace_back("__self");
 
                             auto method_body = cxx::Block();
@@ -314,8 +315,8 @@ struct VisitorDeclaration : hilti::visitor::PreOrder {
             scope = scope.namespace_();
 
         auto id = cxx::ID(scope, sid);
-        auto labels =
-            n->labels() | std::views::transform([](auto l) { return std::make_pair(cxx::ID(l->id()), l->value()); });
+        auto labels = std::ranges::transform_view(n->labels(),
+                                                  [](auto l) { return std::make_pair(cxx::ID(l->id()), l->value()); });
         auto t = cxx::type::Enum{.labels = util::toVector(std::move(labels)), .type_name = cxx::ID(id.local())};
         auto decl = cxx::declaration::Type(std::move(id), t, {}, true);
         dependencies.push_back(decl);
@@ -406,11 +407,11 @@ struct VisitorStorage : hilti::visitor::PreOrder {
         auto id = cxx::ID(scope, sid);
 
         // Add tailored to_string() function.
-        auto cases = n->uniqueLabels() | std::views::transform([&](auto l) {
-                         auto b = cxx::Block();
-                         b.addReturn(fmt("\"%s::%s\"", tid.local(), l->id()));
-                         return std::make_pair(cxx::Expression(cxx::ID(id, l->id())), std::move(b));
-                     });
+        auto cases = std::ranges::transform_view(n->uniqueLabels(), [&](auto l) {
+            auto b = cxx::Block();
+            b.addReturn(fmt("\"%s::%s\"", tid.local(), l->id()));
+            return std::make_pair(cxx::Expression(cxx::ID(id, l->id())), std::move(b));
+        });
 
         auto default_ = cxx::Block();
         default_.addReturn(fmt(R"(::hilti::rt::fmt("%s::<unknown-%%" PRIu64 ">", x.value()))", id.local()));
@@ -706,31 +707,36 @@ struct VisitorStorage : hilti::visitor::PreOrder {
     }
 
     void operator()(type::Tuple* n) final {
-        auto types = util::join(n->elements() | std::views::transform([this](auto e) {
-                                    return cg->compile(e->type(), codegen::TypeUsage::Storage);
-                                }),
-                                ", ");
+        auto types =
+            util::join(std::ranges::transform_view(n->elements(),
+                                                   [this](auto e) {
+                                                       return cg->compile(e->type(), codegen::TypeUsage::Storage);
+                                                   }),
+                       ", ");
 
-        auto defaults = util::join(n->elements() | std::views::transform([this](auto e) {
-                                       if ( auto d = cg->typeDefaultValue(e->type()) )
-                                           // Engage the optional with the element's explicit default
-                                           // value.
-                                           return fmt("{%s}", *d);
-                                       else {
-                                           // No explicit default (e.g., Bool, integers, etc.).
-                                           // If the element type itself is an Optional<T>, leave it
-                                           // unset.
-                                           if ( e->type()->type()->template isA<type::Optional>() )
-                                               return fmt("::hilti::rt::optional::make<%s>({})",
-                                                          cg->compile(e->type(), codegen::TypeUsage::Storage));
+        auto defaults =
+            util::join(std::ranges::transform_view(n->elements(),
+                                                   [this](auto e) {
+                                                       if ( auto d = cg->typeDefaultValue(e->type()) )
+                                                           // Engage the optional with the element's explicit default
+                                                           // value.
+                                                           return fmt("{%s}", *d);
+                                                       else {
+                                                           // No explicit default (e.g., Bool, integers, etc.).
+                                                           // If the element type itself is an Optional<T>, leave it
+                                                           // unset.
+                                                           if ( e->type()->type()->template isA<type::Optional>() )
+                                                               return fmt("::hilti::rt::optional::make<%s>({})",
+                                                                          cg->compile(e->type(),
+                                                                                      codegen::TypeUsage::Storage));
 
-                                           // Otherwise engage the optional with a value-initialized T{}
-                                           // so required (non-optional) tuple elements start as set.
-                                           auto t = cg->compile(e->type(), codegen::TypeUsage::Storage);
-                                           return fmt("::hilti::rt::Optional<%s>(%s{})", t, t);
-                                       }
-                                   }),
-                                   ", ");
+                                                           // Otherwise engage the optional with a value-initialized T{}
+                                                           // so required (non-optional) tuple elements start as set.
+                                                           auto t = cg->compile(e->type(), codegen::TypeUsage::Storage);
+                                                           return fmt("::hilti::rt::Optional<%s>(%s{})", t, t);
+                                                       }
+                                                   }),
+                       ", ");
 
         auto base_type = fmt("::hilti::rt::Tuple<%s>", types);
         auto default_ = fmt("::hilti::rt::tuple::make_from_optionals<%s>(%s)", types, defaults);

--- a/hilti/toolchain/src/compiler/codegen/unpack.cc
+++ b/hilti/toolchain/src/compiler/codegen/unpack.cc
@@ -89,7 +89,7 @@ struct Visitor : hilti::visitor::PreOrder {
 } // anonymous namespace
 
 cxx::Expression CodeGen::pack(Expression* data, const Expressions& args) {
-    auto cxx_args = util::toVector(args | std::views::transform([&](const auto& e) { return compile(e, false); }));
+    auto cxx_args = util::toVector(std::ranges::transform_view(args, [&](const auto& e) { return compile(e, false); }));
     auto v = Visitor(this, Visitor::Kind::Pack, data->type(), nullptr, compile(data), cxx_args);
     if ( auto result =
              hilti::visitor::dispatch(v, data->type()->type(), [](const auto& v) -> const auto& { return v.result; }) )
@@ -108,7 +108,7 @@ cxx::Expression CodeGen::pack(QualifiedType* t, const cxx::Expression& data, con
 
 cxx::Expression CodeGen::unpack(QualifiedType* t, QualifiedType* data_type, Expression* data, const Expressions& args,
                                 bool throw_on_error) {
-    auto cxx_args = util::toVector(args | std::views::transform([&](const auto& e) { return compile(e, false); }));
+    auto cxx_args = util::toVector(std::ranges::transform_view(args, [&](const auto& e) { return compile(e, false); }));
     auto v = Visitor(this, Visitor::Kind::Unpack, t, data_type, compile(data), cxx_args);
     if ( auto result = hilti::visitor::dispatch(v, t->type(), [](const auto& v) -> const auto& { return v.result; }) ) {
         if ( throw_on_error )

--- a/hilti/toolchain/src/compiler/cxx/elements.cc
+++ b/hilti/toolchain/src/compiler/cxx/elements.cc
@@ -442,8 +442,8 @@ std::string cxx::type::Struct::str() const {
     };
 
     std::vector<std::string> struct_fields;
-    util::append(struct_fields, members | std::views::transform(fmt_member));
-    util::append(struct_fields, args | std::views::transform(fmt_argument));
+    util::append(struct_fields, std::ranges::transform_view(members, fmt_member));
+    util::append(struct_fields, std::ranges::transform_view(args, fmt_argument));
 
     if ( add_ctors ) {
         auto dctor = fmt("%s();", type_name);
@@ -455,17 +455,19 @@ std::string cxx::type::Struct::str() const {
         for ( auto x : {std::move(dctor), std::move(cctor), std::move(mctor), std::move(cassign), std::move(massign)} )
             struct_fields.emplace_back(std::move(x));
 
-        auto locals_user = members | std::views::filter([](const auto& m) {
-                               auto l = std::get_if<declaration::Local>(&m);
-                               return l && ! l->isInternal();
-                           });
+        auto locals_user = std::ranges::filter_view(members, [](const auto& m) {
+            auto l = std::get_if<declaration::Local>(&m);
+            return l && ! l->isInternal();
+        });
 
         if ( ! locals_user.empty() ) {
-            auto locals_ctor_args = util::join(locals_user | std::views::transform([&](const auto& x) {
-                                                   auto& l = std::get<declaration::Local>(x);
-                                                   return fmt("::hilti::rt::Optional<%s> %s", l.type, l.id);
-                                               }),
-                                               ", ");
+            auto locals_ctor_args =
+                util::join(std::ranges::transform_view(locals_user,
+                                                       [&](const auto& x) {
+                                                           auto& l = std::get<declaration::Local>(x);
+                                                           return fmt("::hilti::rt::Optional<%s> %s", l.type, l.id);
+                                                       }),
+                           ", ");
             auto locals_ctor = fmt("explicit %s(%s);", type_name, locals_ctor_args);
             struct_fields.emplace_back(std::move(locals_ctor));
         }
@@ -473,7 +475,7 @@ std::string cxx::type::Struct::str() const {
         if ( args.size() ) {
             // Add dedicated constructor to initialize the struct's arguments.
             auto params_ctor_args =
-                util::join(args | std::views::transform([&](const auto& x) { return fmt("%s %s", x.type, x.id); }),
+                util::join(std::ranges::transform_view(args, [&](const auto& x) { return fmt("%s %s", x.type, x.id); }),
                            ", ");
             auto params_ctor = fmt("%s(%s);", type_name, params_ctor_args);
             struct_fields.emplace_back(params_ctor);
@@ -481,7 +483,7 @@ std::string cxx::type::Struct::str() const {
     }
 
     auto struct_fields_as_str =
-        util::join(struct_fields | std::views::transform([&](const auto& x) { return fmt("    %s", x); }), "\n");
+        util::join(std::ranges::transform_view(struct_fields, [&](const auto& x) { return fmt("    %s", x); }), "\n");
 
     std::string has_params;
     if ( args.size() )
@@ -501,15 +503,15 @@ std::string cxx::type::Struct::code() const {
     if ( ! add_ctors )
         return "";
 
-    auto locals_user = members | std::views::filter([](const auto& m) {
-                           auto l = std::get_if<declaration::Local>(&m);
-                           return l && ! l->isInternal();
-                       });
+    auto locals_user = std::ranges::filter_view(members, [](const auto& m) {
+        auto l = std::get_if<declaration::Local>(&m);
+        return l && ! l->isInternal();
+    });
 
-    auto locals_non_user = members | std::views::filter([](const auto& m) {
-                               auto l = std::get_if<declaration::Local>(&m);
-                               return l && l->isInternal();
-                           });
+    auto locals_non_user = std::ranges::filter_view(members, [](const auto& m) {
+        auto l = std::get_if<declaration::Local>(&m);
+        return l && l->isInternal();
+    });
 
     auto init_locals_user = [&]() {
         cxx::Formatter init;
@@ -517,25 +519,32 @@ std::string cxx::type::Struct::code() const {
         init.ensure_braces_for_block = false;
         init << ctor;
 
-        return init.str() + util::join(locals_user | std::views::transform([&](const auto& x) {
-                                           auto& l = std::get<declaration::Local>(x);
-                                           return l.init ? fmt("    %s = %s;\n", l.id, *l.init) : std::string();
-                                       }),
+        return init.str() + util::join(std::ranges::transform_view(locals_user,
+                                                                   [&](const auto& x) {
+                                                                       auto& l = std::get<declaration::Local>(x);
+                                                                       return l.init ?
+                                                                                  fmt("    %s = %s;\n", l.id, *l.init) :
+                                                                                  std::string();
+                                                                   }),
                                        "");
     };
 
     auto init_locals_non_user = [&]() {
-        return util::join(locals_non_user | std::views::transform([&](const auto& x) {
-                              auto& l = std::get<declaration::Local>(x);
-                              return l.init ? fmt("    %s = %s;\n", l.id, *l.init) : std::string();
-                          }),
+        return util::join(std::ranges::transform_view(locals_non_user,
+                                                      [&](const auto& x) {
+                                                          auto& l = std::get<declaration::Local>(x);
+                                                          return l.init ? fmt("    %s = %s;\n", l.id, *l.init) :
+                                                                          std::string();
+                                                      }),
                           "");
     };
 
     auto init_parameters = [&]() {
-        return util::join(args | std::views::transform([&](const auto& x) {
-                              return x.default_ ? fmt("    %s = %s;\n", x.id, *x.default_) : std::string();
-                          }),
+        return util::join(std::ranges::transform_view(args,
+                                                      [&](const auto& x) {
+                                                          return x.default_ ? fmt("    %s = %s;\n", x.id, *x.default_) :
+                                                                              std::string();
+                                                      }),
                           "");
     };
 
@@ -556,12 +565,16 @@ std::string cxx::type::Struct::code() const {
     if ( args.size() ) {
         // Create constructor taking the struct's parameters.
         auto ctor_args =
-            util::join(args | std::views::transform([&](const auto& x) { return fmt("%s %s", x.type, x.id); }), ", ");
+            util::join(std::ranges::transform_view(args, [&](const auto& x) { return fmt("%s %s", x.type, x.id); }),
+                       ", ");
 
-        auto ctor_inits = util::join(args | std::views::transform([&](const auto& x) {
-                                         auto arg = x.isPassedByRef() ? fmt("%s", x.id) : fmt("std::move(%s)", x.id);
-                                         return fmt("%s(%s)", x.id, arg);
-                                     }),
+        auto ctor_inits = util::join(std::ranges::transform_view(args,
+                                                                 [&](const auto& x) {
+                                                                     auto arg = x.isPassedByRef() ?
+                                                                                    fmt("%s", x.id) :
+                                                                                    fmt("std::move(%s)", x.id);
+                                                                     return fmt("%s(%s)", x.id, arg);
+                                                                 }),
                                      ", ");
 
         code += fmt("%s::%s(%s) : %s {\n%s%s}\n\n", type_name, type_name, ctor_args, ctor_inits, init_locals_user(),
@@ -570,17 +583,22 @@ std::string cxx::type::Struct::code() const {
 
     if ( ! locals_user.empty() ) {
         // Create constructor taking the struct's (non-function) fields.
-        auto ctor_args = util::join(locals_user | std::views::transform([&](const auto& x) {
-                                        auto& l = std::get<declaration::Local>(x);
-                                        return fmt("::hilti::rt::Optional<%s> %s", l.type, l.id);
-                                    }),
-                                    ", ");
+        auto ctor_args =
+            util::join(std::ranges::transform_view(locals_user,
+                                                   [&](const auto& x) {
+                                                       auto& l = std::get<declaration::Local>(x);
+                                                       return fmt("::hilti::rt::Optional<%s> %s", l.type, l.id);
+                                                   }),
+                       ", ");
 
-        auto ctor_inits = util::join(locals_user | std::views::transform([&](const auto& x) {
-                                         auto& l = std::get<declaration::Local>(x);
-                                         return fmt("    if ( %s ) this->%s = std::move(*%s);\n", l.id, l.id, l.id);
-                                     }),
-                                     "");
+        auto ctor_inits =
+            util::join(std::ranges::transform_view(locals_user,
+                                                   [&](const auto& x) {
+                                                       auto& l = std::get<declaration::Local>(x);
+                                                       return fmt("    if ( %s ) this->%s = std::move(*%s);\n", l.id,
+                                                                  l.id, l.id);
+                                                   }),
+                       "");
 
         code += fmt("%s::%s(%s) : %s() {\n%s}\n\n", type_name, type_name, ctor_args, type_name, ctor_inits);
     }
@@ -615,7 +633,7 @@ std::string cxx::type::Union::str() const {
 
 std::string cxx::type::Enum::str() const {
     auto vals =
-        util::join(labels | std::views::transform([](const auto& l) { return fmt("%s = %d", l.first, l.second); }),
+        util::join(std::ranges::transform_view(labels, [](const auto& l) { return fmt("%s = %d", l.first, l.second); }),
                    ", ");
 
     return fmt("HILTI_RT_ENUM_WITH_DEFAULT(%s, Undef, %s);", type_name, vals);

--- a/hilti/toolchain/src/compiler/cxx/linker.cc
+++ b/hilti/toolchain/src/compiler/cxx/linker.cc
@@ -92,7 +92,7 @@ void cxx::Linker::finalize() {
             if ( c.declare_only )
                 continue;
 
-            auto args = impl->args | std::views::transform([](auto& a) { return a.id; });
+            auto args = std::ranges::transform_view(impl->args, [](auto& a) { return a.id; });
 
             if ( std::string(c.callee.result) != "void" ) {
                 cxx::Block done_body;

--- a/hilti/toolchain/src/compiler/optimizer.cc
+++ b/hilti/toolchain/src/compiler/optimizer.cc
@@ -1721,8 +1721,9 @@ public:
                 auto meta = n->meta();
                 auto comments = meta.comments();
 
-                if ( auto enabled_features = features.at(n->fullyQualifiedID()) |
-                                             std::views::filter([](const auto& feature) { return feature.second; });
+                if ( auto enabled_features =
+                         std::ranges::filter_view(features.at(n->fullyQualifiedID()),
+                                                  [](const auto& feature) { return feature.second; });
                      ! enabled_features.empty() ) {
                     comments.push_back(util::fmt("Type %s supports the following features:", n->id()));
                     for ( const auto& feature : enabled_features )

--- a/hilti/toolchain/src/compiler/printer.cc
+++ b/hilti/toolchain/src/compiler/printer.cc
@@ -154,16 +154,18 @@ struct Printer : visitor::PreOrder {
         };
 
 
-        print_decls(n->declarations() |
-                    std::views::filter([](const auto& d) { return d->template isA<declaration::ImportedModule>(); }));
-        print_decls(n->declarations() |
-                    std::views::filter([](const auto& d) { return d->template isA<declaration::Type>(); }));
-        print_decls(n->declarations() |
-                    std::views::filter([](const auto& d) { return d->template isA<declaration::Constant>(); }));
-        print_decls(n->declarations() |
-                    std::views::filter([](const auto& d) { return d->template isA<declaration::GlobalVariable>(); }));
-        print_decls(n->declarations() |
-                    std::views::filter([](const auto& d) { return d->template isA<declaration::Function>(); }));
+        print_decls(std::ranges::filter_view(n->declarations(), [](const auto& d) {
+            return d->template isA<declaration::ImportedModule>();
+        }));
+        print_decls(std::ranges::filter_view(n->declarations(),
+                                             [](const auto& d) { return d->template isA<declaration::Type>(); }));
+        print_decls(std::ranges::filter_view(n->declarations(),
+                                             [](const auto& d) { return d->template isA<declaration::Constant>(); }));
+        print_decls(std::ranges::filter_view(n->declarations(), [](const auto& d) {
+            return d->template isA<declaration::GlobalVariable>();
+        }));
+        print_decls(std::ranges::filter_view(n->declarations(),
+                                             [](const auto& d) { return d->template isA<declaration::Function>(); }));
 
         for ( const auto& s : n->statements()->statements() )
             _out << s;
@@ -258,7 +260,7 @@ struct Printer : visitor::PreOrder {
     void operator()(ctor::StrongReference* n) final { _out << "Null"; }
 
     void operator()(ctor::RegExp* n) final {
-        _out << std::make_pair(n->patterns() | std::views::transform([](const auto& p) { return to_string(p); }),
+        _out << std::make_pair(std::ranges::transform_view(n->patterns(), [](const auto& p) { return to_string(p); }),
                                " | ");
 
         if ( auto* attrs = n->attributes(); *attrs )
@@ -833,8 +835,9 @@ struct Printer : visitor::PreOrder {
 
         _out.setExpandSubsequentType(false);
 
-        auto x = n->labels() | std::views::filter([](auto l) { return l->id() != ID("Undef"); }) |
-                 std::views::transform([](const auto& l) { return l->print(); });
+        auto x = std::ranges::transform_view(std::ranges::filter_view(n->labels(),
+                                                                      [](auto l) { return l->id() != ID("Undef"); }),
+                                             [](const auto& l) { return l->print(); });
 
         _out << "enum { " << std::make_pair(util::toVector(std::move(x)), ", ") << " }";
     }
@@ -1029,12 +1032,12 @@ struct Printer : visitor::PreOrder {
         };
 
         _out << " {" << _out.newline();
-        print_fields(n->fields() | std::views::filter([](const auto& f) {
-                         return ! f->type()->type()->template isA<type::Function>();
-                     }));
-        print_fields(n->fields() | std::views::filter([](const auto& f) {
-                         return f->type()->type()->template isA<type::Function>();
-                     }));
+        print_fields(std::ranges::filter_view(n->fields(), [](const auto& f) {
+            return ! f->type()->type()->template isA<type::Function>();
+        }));
+        print_fields(std::ranges::filter_view(n->fields(), [](const auto& f) {
+            return f->type()->type()->template isA<type::Function>();
+        }));
         _out << "}";
     }
 

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -98,31 +98,35 @@ void Configuration::init(bool use_build_directory) {
     std::vector<std::string> library_paths;
 
     if ( auto* hilti_library_paths = std::getenv("HILTI_PATH") ) {
-        library_paths = util::toVector(hilti::rt::split(hilti_library_paths, ":") |
-                                       std::views::transform([](auto s) { return std::string(s); }));
+        library_paths = util::toVector(std::ranges::transform_view(hilti::rt::split(hilti_library_paths, ":"),
+                                                                   [](auto s) { return std::string(s); }));
     }
     else {
         library_paths = flatten({".", prefix("${HILTI_CONFIG_LIBRARY_DIRS}", "", installation_tag)});
     }
 
     hilti_library_paths = util::toVector(
-        library_paths | std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(library_paths, [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     runtime_cxx_include_paths =
-        util::toVector(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)) |
-                       std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        util::toVector(std::ranges::transform_view(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}",
+                                                                             "", installation_tag)),
+                                                   [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     runtime_cxx_library_paths =
-        util::toVector(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)) |
-                       std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        util::toVector(std::ranges::transform_view(hilti::util::split(prefix("${HILTI_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}",
+                                                                             "", installation_tag)),
+                                                   [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
-    toolchain_cxx_include_paths =
-        util::toVector(hilti::util::split(prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)) |
-                       std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+    toolchain_cxx_include_paths = util::toVector(
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
-    toolchain_cxx_library_paths =
-        util::toVector(hilti::util::split(prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)) |
-                       std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+    toolchain_cxx_library_paths = util::toVector(
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     // We hardcode the main compiler flags here instead of injecting them from
     // CMake to make it clear that they are really independent on what CMake

--- a/spicy/runtime/src/init.cc
+++ b/spicy/runtime/src/init.cc
@@ -69,17 +69,17 @@ void spicy::rt::init() {
 
     HILTI_RT_DEBUG("libspicy", "registered parsers (w/ aliases):");
     for ( const auto& i : globalState()->parsers_by_name ) {
-        auto names = i.second | std::views::transform([](const auto& p) {
-                         return fmt("%s (scope 0x%" PRIx64 ")", p->name, p->linker_scope);
-                     });
+        auto names = std::ranges::transform_view(i.second, [](const auto& p) {
+            return fmt("%s (scope 0x%" PRIx64 ")", p->name, p->linker_scope);
+        });
         HILTI_RT_DEBUG("libspicy", hilti::rt::fmt("  %s -> %s", i.first, hilti::rt::join(names, ", ")));
     }
 
     HILTI_RT_DEBUG("libspicy", "registered parsers for MIME types:");
     for ( const auto& i : globalState()->parsers_by_mime_type ) {
-        auto names = i.second | std::views::transform([](const auto& p) {
-                         return fmt("%s (scope 0x%" PRIx64 ")", p->name, p->linker_scope);
-                     });
+        auto names = std::ranges::transform_view(i.second, [](const auto& p) {
+            return fmt("%s (scope 0x%" PRIx64 ")", p->name, p->linker_scope);
+        });
         HILTI_RT_DEBUG("libspicy", hilti::rt::fmt("  %s -> %s", i.first, hilti::rt::join(names, ", ")));
     }
 

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -279,8 +279,8 @@ int main(int argc, char** argv) try {
         driver.fatalError(x.error());
 
     for ( const auto& parser : driver.opt_parser_aliases ) {
-        auto m =
-            hilti::util::split(parser, "=") | std::views::transform([](const auto& x) { return hilti::util::trim(x); });
+        auto m = std::ranges::transform_view(hilti::util::split(parser, "="),
+                                             [](const auto& x) { return hilti::util::trim(x); });
 
         if ( m.size() != 2 )
             driver.fatalError("invalid alias specification: must be of form '<alias>=<parser-name>'");

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/block.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/block.h
@@ -46,19 +46,20 @@ public:
 
     std::vector<std::vector<Production*>> rhss() const final {
         std::vector<std::vector<Production*>> rhss = {
-            hilti::util::toVector(_prods | std::views::transform([](const auto& p) { return p.get(); }))};
+            hilti::util::toVector(std::ranges::transform_view(_prods, [](const auto& p) { return p.get(); }))};
 
         if ( ! _else_prods.empty() )
             rhss.emplace_back(
-                hilti::util::toVector(_else_prods | std::views::transform([](const auto& p) { return p.get(); })));
+                hilti::util::toVector(std::ranges::transform_view(_else_prods, [](const auto& p) { return p.get(); })));
 
         return rhss;
     }
 
     std::string dump() const final {
-        auto true_ = hilti::util::join(_prods | std::views::transform([](const auto& p) { return p->symbol(); }), " ");
+        auto true_ =
+            hilti::util::join(std::ranges::transform_view(_prods, [](const auto& p) { return p->symbol(); }), " ");
         auto false_ =
-            hilti::util::join(_else_prods | std::views::transform([](const auto& p) { return p->symbol(); }), " ");
+            hilti::util::join(std::ranges::transform_view(_else_prods, [](const auto& p) { return p->symbol(); }), " ");
 
         if ( false_.empty() )
             return true_;

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/sequence.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/sequence.h
@@ -33,11 +33,11 @@ public:
     bool isTerminal() const final { return false; };
 
     std::vector<std::vector<Production*>> rhss() const final {
-        return {hilti::util::toVector(_prods | std::views::transform([](const auto& p) { return p.get(); }))};
+        return {hilti::util::toVector(std::ranges::transform_view(_prods, [](const auto& p) { return p.get(); }))};
     }
 
     std::string dump() const final {
-        return hilti::util::join(_prods | std::views::transform([](const auto& p) { return p->symbol(); }), " ");
+        return hilti::util::join(std::ranges::transform_view(_prods, [](const auto& p) { return p->symbol(); }), " ");
     }
 
     SPICY_PRODUCTION

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/unit.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/unit.h
@@ -44,13 +44,13 @@ public:
     bool isTerminal() const final { return false; };
 
     std::vector<std::vector<Production*>> rhss() const final {
-        return {hilti::util::toVector(_fields | std::views::transform([](const auto& p) { return p.get(); }))};
+        return {hilti::util::toVector(std::ranges::transform_view(_fields, [](const auto& p) { return p.get(); }))};
     }
 
     QualifiedType* type() const final { return _type; };
 
     std::string dump() const final {
-        return hilti::util::join(_fields | std::views::transform([](const auto& p) { return p->symbol(); }), " ");
+        return hilti::util::join(std::ranges::transform_view(_fields, [](const auto& p) { return p->symbol(); }), " ");
     }
 
     SPICY_PRODUCTION

--- a/spicy/toolchain/src/compiler/codegen/productions/look-ahead.cc
+++ b/spicy/toolchain/src/compiler/codegen/productions/look-ahead.cc
@@ -18,7 +18,7 @@ static std::string fmtAlt(const codegen::Production* alt, const spicy::detail::c
             return hilti::util::fmt("%s (not a literal)", str);
     };
 
-    return hilti::util::fmt("{%s}: %s", hilti::util::join(lahs | std::views::transform(fmt), ", "), alt->symbol());
+    return hilti::util::fmt("{%s}: %s", hilti::util::join(std::ranges::transform_view(lahs, fmt), ", "), alt->symbol());
 }
 
 std::string codegen::production::LookAhead::dump() const {

--- a/spicy/toolchain/src/config.cc.in
+++ b/spicy/toolchain/src/config.cc.in
@@ -106,23 +106,27 @@ void Configuration::init(bool use_build_directory) {
         library_paths = flatten({".", prefix("${SPICY_CONFIG_LIBRARY_DIRS}", "", installation_tag)});
 
     spicy_library_paths = hilti::util::toVector(
-        library_paths | std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(library_paths, [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     runtime_cxx_include_paths = hilti::util::toVector(
-        hilti::util::split(prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)) |
-        std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     runtime_cxx_library_paths = hilti::util::toVector(
-        hilti::util::split(prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)) |
-        std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${SPICY_CONFIG_RUNTIME_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     toolchain_cxx_include_paths = hilti::util::toVector(
-        hilti::util::split(prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)) |
-        std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_INCLUDE_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     toolchain_cxx_library_paths = hilti::util::toVector(
-        hilti::util::split(prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)) |
-        std::views::transform([](const auto& s) { return hilti::rt::filesystem::path(s); }));
+        std::ranges::transform_view(hilti::util::split(
+                                        prefix("${SPICY_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS}", "", installation_tag)),
+                                    [](const auto& s) { return hilti::rt::filesystem::path(s); }));
 
     runtime_cxx_flags_debug = flatten({prefix("${SPICY_CONFIG_RUNTIME_CXX_INCLUDE_DIRS}", "-I", installation_tag),
                                        prefix("${SPICY_CONFIG_RUNTIME_CXX_FLAGS_DEBUG}", "", installation_tag)});


### PR DESCRIPTION
gcc-11 seems to have poor or no support for this, so remove it for now. Once we bump the minimum support version to e.g., gcc-12 we could undo this change by looking for all instances which use a `std::ranges::.*_view`.

This PR implements an alternative to bumping the minimum required GCC version implemented in #2206.