### PR TITLE
Avoid `and` in favor of `&&`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,3 +76,7 @@ Checks: '
 
 HeaderFilterRegex: '(hilti|spicy)/[a-zA-Z-]+/include/([a-zA-Z-]+/)*[a-zA-Z-]+\.h'
 WarningsAsErrors: '*'
+
+CheckOptions:
+  readability-operators-representation.BinaryOperators: '&&;&=;&;|;~;!;!=;||;|=;^;^='
+  readability-operators-representation.OverloadedOperators: '&&;&=;&;|;~;!;!=;||;|=;^;^='

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -349,7 +349,7 @@ std::list<std::pair<A, B>> zip2(const std::list<A>& lhs, const std::list<B>& rhs
     for ( std::pair<typename std::list<A>::const_iterator, typename std::list<B>::const_iterator> iter =
               std::pair<typename std::list<A>::const_iterator, typename std::list<B>::const_iterator>(lhs.cbegin(),
                                                                                                       rhs.cbegin());
-          iter.first != lhs.end() and iter.second != rhs.end(); ++iter.first, ++iter.second )
+          iter.first != lhs.end() && iter.second != rhs.end(); ++iter.first, ++iter.second )
         result.emplace_back(*iter.first, *iter.second);
     return result;
 }
@@ -365,7 +365,7 @@ std::vector<std::pair<A, B>> zip2(const std::vector<A>& lhs, const std::vector<B
     for ( std::pair<typename std::vector<A>::const_iterator, typename std::vector<B>::const_iterator> iter =
               std::pair<typename std::vector<A>::const_iterator, typename std::vector<B>::const_iterator>(lhs.cbegin(),
                                                                                                           rhs.cbegin());
-          iter.first != lhs.end() and iter.second != rhs.end(); ++iter.first, ++iter.second )
+          iter.first != lhs.end() && iter.second != rhs.end(); ++iter.first, ++iter.second )
         result.emplace_back(*iter.first, *iter.second);
     return result;
 }

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -463,7 +463,7 @@ Result<Nothing> Driver::parseOptions(int argc, char** argv) {
             return error("must use --debug with --cgdebug");
     }
 
-    if ( _driver_options.execute_code and ! _driver_options.output_path.empty() ) {
+    if ( _driver_options.execute_code && ! _driver_options.output_path.empty() ) {
         if ( ! util::endsWith(_driver_options.output_path, ".hlto") )
             return error("output will be a precompiled object file and must have '.hlto' extension");
     }


### PR DESCRIPTION
I noticed earlier that some operator names were used (`and`, `not`, etc.), figured I would see if there are more. There are 3 here, found via clang-tidy [`readability-operators-representation`](https://clang.llvm.org/extra/clang-tidy/checks/readability/operators-representation.html)

it's not just that I don't like them, I think it's confusing to use them so sparingly. And some compilers default to allowing operator names as default (though we don't support it, eg MSVC). Compilers translate them to be the same exact thing as `&&` just with a different spelling

we could also add flags like `-fno-operator-names`, but I don't think they should be used as identifiers, that's also confusing