### PR TITLE
Consistently use underlying `Node` when hashing `GraphNode`.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/cfg.h
+++ b/hilti/toolchain/include/compiler/detail/cfg.h
@@ -101,7 +101,7 @@ public:
     Node* value() const { return _node; }
 
     friend bool operator==(const GraphNode& a, const GraphNode& b) { return a._node == b._node; }
-    friend bool operator!=(const GraphNode& a, const GraphNode& b) { return ! (a._node == b._node); }
+    friend bool operator!=(const GraphNode& a, const GraphNode& b) { return ! (a == b); }
 
     friend bool operator<(const GraphNode& a, const GraphNode& b) { return a._node < b._node; }
 
@@ -118,7 +118,10 @@ void dump(logging::DebugStream stream, ASTRoot* root);
 namespace std {
 template<>
 struct hash<hilti::detail::cfg::GraphNode> {
-    auto operator()(const hilti::detail::cfg::GraphNode& n) const { return n.value() ? n->identity() : 0; }
+    auto operator()(const hilti::detail::cfg::GraphNode& n) const {
+        assert(n.value());
+        return reinterpret_cast<std::uintptr_t>(n.value());
+    }
 };
 } // namespace std
 


### PR DESCRIPTION
This is a follow-up for #2202. I was initially hoping that the inconsistency between `GraphNode` equality and hash operators was a cause for the behavior seen in #2199, but this seems to be unrelated. It is still something which we should fix.