### PR TITLE
Separate lookahead and size benchmarks.

### DIFF
--- a/spicy/runtime/tests/benchmarks/parsers.spicy
+++ b/spicy/runtime/tests/benchmarks/parsers.spicy
@@ -3,13 +3,13 @@
 module Benchmark;
 
 type InnerSize = unit {
-    b: b"A";
+    b: uint8;
 };
 
 public type UnitVectorSize = unit {
     length: uint64;
     inner: InnerSize[] &size=self.length;
-    end_: b"END";
+    end_: bytes &size=3;
 };
 
 type InnerLookahead = unit {


### PR DESCRIPTION
Since the two benchmarks used the same `Inner`, they would get the same interprocedural optimizations. This doesn't give the full picture about how something changes, so separate them so that we can get a better picture.

This definitely makes the benchmarks more "micro," but I believe that we see more people using *either* lookahead *or* size, not both on the same unit.

I added a second commit that completely eliminates the need for lookahead in the size benchmark, but I'm not entirely sure that it's fair. I actually think it might be. The problem is that even if lookahead wasn't obviously used, having the literals triggers lookahead. I want it to not use lookahead so that I can have different optimizations for each, but I also understand it's kind of forcing benchmarks to say what I want them to say. My preference would be the lookahead and size benchmarks actually test different things, though, so I don't really mind it - just take the initial results with a grain of salt if we keep it!!

EDIT: And I just looked through Zeek's parsers before/after #2228, there are plenty of hot paths that get their lookaheads removed. I'd like that expressed in some of our benchmarks.