### PR TITLE
Actually implement `enum` coercion to `bool`.

### DIFF
--- a/hilti/toolchain/src/compiler/codegen/coercions.cc
+++ b/hilti/toolchain/src/compiler/codegen/coercions.cc
@@ -47,10 +47,8 @@ struct Visitor : public hilti::visitor::PreOrder {
     }
 
     void operator()(type::Enum* n) final {
-        if ( dst->type()->isA<type::Bool>() ) {
-            auto id = cg->compile(src, codegen::TypeUsage::Storage);
-            result = fmt("(%s != %s(%s::Undef))", expr, id, id);
-        }
+        if ( dst->type()->isA<type::Bool>() )
+            result = fmt("::hilti::rt::enum_::has_label(%s, %s)", expr, cg->typeInfo(src));
 
         else
             logger().internalError(fmt("codegen: unexpected type coercion from enum to %s", dst->type()->typename_()));

--- a/tests/hilti/types/enum/basic.hlt
+++ b/tests/hilti/types/enum/basic.hlt
@@ -36,7 +36,14 @@ assert x;
 assert !y;
 assert X::A1;
 assert !X::Undef;
+assert !X(4711);
 assert x && X::A1 ;
+
+# Different undef values only compare equal if they hold the same integer
+# value, so equality comparison against undef should not be used to coerce
+# to bool.
+assert X(4711) == X(4711);
+assert X(4711) != X(67);
 
 # has_label()
 global X no_label = X(42);


### PR DESCRIPTION
Previously we implemented `enum` coercion to `bool` as a comparison against the `Undef` label. While `Undef` values coerce to `false`, different `Undef` values only compare equal if they map to the exact same underlying integer value, so our implementation was not correct.

This patch implements coercion in terms of `has_label`. While this is unlikely to be the most performant implementation a better impl would likely require to change how we declare runtime enums so we could have the macro generate code which explicitly checks against all know labels. Given that `HILTI_RT_ENUM..` allows declaring values both with and without values that is currently hard to implement.

Closes #2251.