### PR TITLE
Fix potential memory leak splitting strings

### DIFF
--- a/hilti/toolchain/src/base/util.cc
+++ b/hilti/toolchain/src/base/util.cc
@@ -148,17 +148,13 @@ Result<std::vector<std::string>> util::splitShellUnsafe(std::string_view s) {
     if ( s.empty() )
         return {std::vector<std::string>{}};
 
-    wordexp_t we;
+    wordexp_t we{};
+    auto _ = util::scope_exit([&]() { wordfree(&we); });
 
-    switch ( wordexp(std::string(s).c_str(), &we, WRDE_UNDEF) ) {
-        case 0: break;
-        // WRDE_NOSPACE may allocate part of the result.
-        case WRDE_NOSPACE: wordfree(&we); [[fallthrough]];
-        default: return result::Error("could not split string");
-    }
+    if ( wordexp(std::string(s).c_str(), &we, WRDE_UNDEF) != 0 )
+        return result::Error("could not split string");
 
     std::vector<std::string> result{we.we_wordv, we.we_wordv + we.we_wordc};
-    wordfree(&we);
 
     return {std::move(result)};
 #endif


### PR DESCRIPTION
In practice I don't think this happens, the code was technically correct. But, Coverity is right that there is a case where `wordfree` is not called. Just always call it on scope exit for safety.

Technically this could be suppressed since only `WRDE_NOSPACE` allocates of the error conditions from what I can tell. But, this code is cleaner IMO so probably worth it. Before it was ripped straight from the manual