### PR TITLE
Fix construction of tuples from map keys.

### DIFF
--- a/hilti/runtime/include/types/tuple.h
+++ b/hilti/runtime/include/types/tuple.h
@@ -143,7 +143,12 @@ public:
     template<typename... Us>
     explicit Tuple(tuple::OptionalTag, Optional<Us>&&... us) : Tuple() {
         [&]<size_t... Is>(std::index_sequence<Is...>) {
-            ((us.hasValue() ? std::get<Is>(*this) = std::forward<Us>(*us), TupleBase::set(Is) : void()), ...);
+            // Use construct_at rather than assignment so this works even when
+            // an element type has a deleted assignment operator (e.g.,
+            // std::map::value_type).
+            ((us.hasValue() ? (std::construct_at(&std::get<Is>(*this), std::move(*us)), TupleBase::set(Is)) :
+                              void()),
+             ...);
         }(std::index_sequence_for<Ts...>{});
     }
 
@@ -159,6 +164,15 @@ public:
      */
     template<typename... Us>
     Tuple(Tuple<Us...>&& other) : TupleBase(other), Base(std::forward<typename std::tuple<Us...>>(other)) {}
+
+    /**
+     * Constructor from a `std::map::value_type` (`std::pair<const K, V>`),
+     * with both elements set. `const_cast` is safe here because `p` is &&.
+     */
+    template<typename K, typename V>
+        requires(sizeof...(Ts) == 2)
+    explicit Tuple(std::pair<const K, V>&& p)
+        : TupleBase(tuple::detail::AllSetTag{}, 2), Base(std::move(const_cast<K&>(p.first)), std::move(p.second)) {}
 
     /**
      * Accessor to retrieve a particular element, assuming it's set.

--- a/tests/Baseline/hilti.types.tuple.ctor/output
+++ b/tests/Baseline/hilti.types.tuple.ctor/output
@@ -7,3 +7,6 @@ Hello!, True
 (False, Enum::Undef)
 [$a="a", $b=(not set)]
 ("a", (not set))
+("a", 1), a, 1
+("b", 2), b, 2
+("c", 1), c, 1

--- a/tests/hilti/types/tuple/ctor.hlt
+++ b/tests/hilti/types/tuple/ctor.hlt
@@ -38,5 +38,12 @@ function void f2() {
 
 f2();
 
+# Regression test for #2300.
+function void f3() {
+    for ( x in map("a": 1, "b": 2, "c": 1) )
+        hilti::printTuple((x, x[0], x[1]));
+}
+
+f3();
 
 }


### PR DESCRIPTION
The previous implementation did not properly handle construction
from `std::map::value_type`, which has a `const` first element.
We need this for iterations over maps.

Closes #2300.
