### PR TITLE
Fix regression with val prop names and coercions

### DIFF
--- a/hilti/toolchain/src/compiler/optimizer/passes/value-propagation.cc
+++ b/hilti/toolchain/src/compiler/optimizer/passes/value-propagation.cc
@@ -225,8 +225,11 @@ struct Replacer : optimizer::visitor::Mutator {
 
         if ( source_expr.propagate ) {
             Node* to_replace = n;
-            // Replace the coercion, too, so that the coercer reruns.
-            if ( auto* coerced = n->parent()->tryAs<expression::Coerced>() )
+
+            // Only replace the coercion for ctors, since that gets different handling.
+            // Names (and anything else possibly propagated) can keep the coercion.
+            if ( auto* coerced = n->parent()->tryAs<expression::Coerced>();
+                 coerced && source_expr.expr->isA<expression::Ctor>() )
                 to_replace = coerced;
 
             replaceNode(to_replace, source_expr.expr, "propagating constant value");

--- a/tests/spicy/optimization/name-coercions.spicy
+++ b/tests/spicy/optimization/name-coercions.spicy
@@ -1,0 +1,14 @@
+# @TEST-DOC: Ensures coerced names from value propagation can compile. Regression test for #2327
+#
+# @TEST-EXEC: spicyc -j %INPUT
+
+module Test;
+
+type Inner = unit(data: bytes) {
+    val: uint8 &parse-from=data;
+};
+
+public type Outer = unit {
+    raw: bytes &size=1;
+    parsed: Inner(self.raw);
+};


### PR DESCRIPTION
Fixes #2327

(this is not in a release so no need for patch releases or anything)

Constant propagation added special handling to replace coercions if the given expression was coerced. This helps for cases that will then need further "work" after constant propagation in order to trigger another coerceion cycle.

But, when value propagation gained more abilities, this became a liability. Coercions no longer go through the same path and end up missing cases. These cases are necessary to stay the same, and we get no value in replacing the coercion (eg for `! Null` coercions, those are only possible with `Ctor`).

We need to be a bit pickier about replacing coercions when propagating.