### PR TITLE
Fix codegen to emit missing `goto` labels.

### DIFF
--- a/hilti/toolchain/include/ast/statements/break.h
+++ b/hilti/toolchain/include/ast/statements/break.h
@@ -30,7 +30,7 @@ public:
         node::Properties properties;
 
         if ( _loop )
-            properties = {{"loop", _loop->identity()}};
+            properties = {{"loop", util::fmt("%p", _loop->identity())}};
 
         return properties + Statement::properties();
     }

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -996,18 +996,18 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
     }
 
     void operator()(statement::Break* n) final {
-        if ( ! n->linkedLoop() ) {
-            for ( auto* loop = n->parent(); loop; loop = loop->parent() ) {
-                if ( loop->isA<statement::For>() || loop->isA<statement::While>() ) {
+        for ( auto* loop = n->parent(); loop; loop = loop->parent() ) {
+            if ( loop->isA<statement::For>() || loop->isA<statement::While>() ) {
+                if ( loop != n->linkedLoop() ) {
                     recordChange(n, "recording the loop for break statement");
                     n->setLinkedLoop(loop->as<Statement>());
-                    break;
                 }
-            }
 
-            if ( ! n->linkedLoop() )
-                n->addError("break statement outside of loop");
+                return;
+            }
         }
+
+        n->addError("break statement outside of loop");
     }
 
     void operator()(statement::If* n) final {

--- a/tests/spicy/statements/for-with-break.spicy
+++ b/tests/spicy/statements/for-with-break.spicy
@@ -1,0 +1,15 @@
+# @TEST-EXEC: spicyc -j %INPUT
+#
+# @TEST-DOC: Ensure a `break` inside a loop codegens to something C++ can compile; regression test for #2337.
+
+module Test;
+
+global v: vector<uint32>;
+
+public type Root = unit {
+    on %done {
+        for (item in v) {
+            break;
+        }
+    }
+};


### PR DESCRIPTION
If loop statements changed during AST resolving, we wouldn't update
any linked break statements.

Also render linked loop statements' identities in debug output in hex,
for easier comparison to node identities.
