### PR TITLE
Remove reduction of entropy when computing unique IDs.

### DIFF
--- a/hilti/toolchain/include/compiler/detail/codegen/codegen.h
+++ b/hilti/toolchain/include/compiler/detail/codegen/codegen.h
@@ -127,7 +127,7 @@ public:
      * @param n node to generate the ID for
      *
      */
-    cxx::ID uniqueID(const std::string& prefix, Node* n);
+    cxx::ID uniqueID(std::string_view prefix, Node* n);
 
     cxx::Expression self() const { return _self.back(); }
     void pushSelf(detail::cxx::Expression e) { _self.push_back(std::move(e)); }

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -1,5 +1,6 @@
 // Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
 
+#include <cinttypes>
 #include <ranges>
 
 #include <hilti/ast/ast-context.h>
@@ -972,5 +973,5 @@ cxx::ID CodeGen::uniqueID(const std::string& prefix, Node* n) {
         // the offending node.
         logger().internalError("attempt to create unique codegen ID for node without location");
 
-    return {fmt("%s_%x", prefix, util::hash(n->location()) % 0xffff)};
+    return {fmt("%s_%" PRIu64, prefix, util::hash(n->location()))};
 }

--- a/hilti/toolchain/src/compiler/codegen/codegen.cc
+++ b/hilti/toolchain/src/compiler/codegen/codegen.cc
@@ -2,6 +2,7 @@
 
 #include <cinttypes>
 #include <ranges>
+#include <string_view>
 
 #include <hilti/ast/ast-context.h>
 #include <hilti/ast/builder/builder.h>
@@ -966,7 +967,7 @@ std::pair<std::string, std::string> CodeGen::cxxTypeForVector(QualifiedType* ele
         return std::make_pair(fmt("::hilti::rt::Vector<%s>%s", etype, type_addl), std::string(""));
 }
 
-cxx::ID CodeGen::uniqueID(const std::string& prefix, Node* n) {
+cxx::ID CodeGen::uniqueID(std::string_view prefix, Node* n) {
     if ( ! n->location() )
         // We rely on the location for creating a unique ID. If we ever arrive
         // here, it shouldn't be too difficult to get location information into


### PR DESCRIPTION
When computing unique IDs we were internally hashing locations to
`uint64_t`, but then reducing to `uint16_t`'s range for more readable
identifiers in generated code. This removes reduces entropy by about
75%.

Given how much of a reduction this was it still seems to have worked
surprisingly well up until de8db50 where we now suddenly see
deterministic hash collisions for a single test in the
`validate_release_tarball` task; in that case it manifests as two
distint hooks being generated with identical C++ identifier. Since this
seemed so obscure I initially though this to be some memory corruption
bug, but it turned out mundane in the end.