### PR TITLE
Fix transitive aliases

### DIFF
--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -1013,40 +1013,47 @@ void CFG::_populateDataflow() {
 
     { // Encode aliasing information.
 
-        // First make aliasing symmetric: to handle the case of e.g.,
-        // references aliasing is stored symmetrically, i.e., if `a` aliases
-        // `b`, `b` will also alias `a`.
-        bool aliases_changed;
-        do {
-            // Fixed point iteration
-            aliases_changed = false;
-            for ( auto& [n, transfer] : _dataflow ) {
-                for ( const auto& alias : transfer.maybe_alias ) {
-                    const auto* stmt = _graph.getNode(alias->identity());
-                    if ( ! stmt || ! stmt->get() || ! _dataflow.contains(*stmt) )
-                        util::detail::internalError(
-                            util::fmt("could not find CFG node for '%s' aliased in '%s'", alias->print(), n->print()));
+        // Aliases must be symmetric and transitive, i.e., if `a` aliases
+        // `b`, `b` will also alias `a`. If `c` aliases `b`, then `a` also
+        // aliases `c`.
+        auto worklist = postorder();
+        // Reverse postorder will converge quickest for this forward dataflow
+        // analysis. Dependent statements are further down in the ordering.
+        std::ranges::reverse(worklist);
 
-                    // Graph nodes either directly store a `Declaration` (for
-                    // globals), or `statement::Declaration` (for anything else).
-                    const auto* decl = n->tryAs<Declaration>();
-                    if ( ! decl ) {
-                        if ( const auto* d = n->tryAs<const statement::Declaration>() )
-                            decl = d->declaration();
-                    }
-                    if ( ! decl )
-                        util::detail::internalError(
-                            util::fmt("could not get declaration from CFG node '%s'", n->print()));
+        while ( ! worklist.empty() ) {
+            auto n = worklist.front();
+            worklist.pop_front();
 
-                    auto& alias_aliases = _dataflow.at(*stmt).maybe_alias;
-                    aliases_changed |= alias_aliases.insert(const_cast<Declaration*>(decl)).second;
+            auto& transfer = _dataflow.at(n);
+            auto& current_aliases = transfer.maybe_alias;
 
-                    // Now union them for transitive aliases (a->b->c, a also aliases c)
-                    aliases_changed |=
-                        unionAliases(alias_aliases, transfer.maybe_alias, alias, const_cast<Declaration*>(decl));
+            for ( const auto& alias : current_aliases ) {
+                const auto* stmt = _graph.getNode(alias->identity());
+                if ( ! stmt || ! stmt->get() || ! _dataflow.contains(*stmt) )
+                    util::detail::internalError(
+                        util::fmt("could not find CFG node for '%s' aliased in '%s'", alias->print(), n->print()));
+
+                // Graph nodes either directly store a `Declaration` (for
+                // globals), or `statement::Declaration` (for anything else).
+                const auto* decl = n->tryAs<Declaration>();
+                if ( ! decl ) {
+                    if ( const auto* d = n->tryAs<const statement::Declaration>() )
+                        decl = d->declaration();
                 }
+                if ( ! decl )
+                    util::detail::internalError(util::fmt("could not get declaration from CFG node '%s'", n->print()));
+
+                auto& alias_aliases = _dataflow.at(*stmt).maybe_alias;
+                auto changed = alias_aliases.insert(const_cast<Declaration*>(decl)).second;
+
+                // Now union them for transitive aliases (a->b->c, a also aliases c)
+                changed |= unionAliases(alias_aliases, current_aliases, alias, const_cast<Declaration*>(decl));
+
+                if ( changed )
+                    worklist.push_back(*stmt);
             }
-        } while ( aliases_changed );
+        }
 
         // Now copy the usage pattern to the aliased node.
         for ( auto& [n, transfer] : _dataflow ) {

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -131,6 +131,25 @@ bool isConstOperand(const expression::ResolvedOperator* operator_, const Express
 
     return false;
 }
+
+bool unionAliases(std::set<Declaration*>& a, std::set<Declaration*>& b, Declaration* a_decl, Declaration* b_decl) {
+    // Create a merged set first so they can be added in a single operation
+    auto a_size = a.size();
+    auto b_size = b.size();
+
+    std::set<Declaration*> merged;
+    merged.insert(a.begin(), a.end());
+    merged.insert(b.begin(), b.end());
+
+    // Insert all of the merged aliases, except remove their own decls. A decl does not alias itself.
+    a.insert(merged.begin(), merged.end());
+    a.erase(a_decl);
+    b.insert(merged.begin(), merged.end());
+    b.erase(b_decl);
+
+    return a.size() != a_size || b.size() != b_size;
+}
+
 } // namespace
 
 std::deque<GraphNode> CFG::postorder() const {
@@ -997,26 +1016,37 @@ void CFG::_populateDataflow() {
         // First make aliasing symmetric: to handle the case of e.g.,
         // references aliasing is stored symmetrically, i.e., if `a` aliases
         // `b`, `b` will also alias `a`.
-        for ( const auto& [n, transfer] : _dataflow ) {
-            for ( const auto& alias : transfer.maybe_alias ) {
-                const auto* stmt = _graph.getNode(alias->identity());
-                if ( ! stmt || ! stmt->get() || ! _dataflow.contains(*stmt) )
-                    util::detail::internalError(
-                        util::fmt("could not find CFG node for '%s' aliased in '%s'", alias->print(), n->print()));
+        bool aliases_changed;
+        do {
+            // Fixed point iteration
+            aliases_changed = false;
+            for ( auto& [n, transfer] : _dataflow ) {
+                for ( const auto& alias : transfer.maybe_alias ) {
+                    const auto* stmt = _graph.getNode(alias->identity());
+                    if ( ! stmt || ! stmt->get() || ! _dataflow.contains(*stmt) )
+                        util::detail::internalError(
+                            util::fmt("could not find CFG node for '%s' aliased in '%s'", alias->print(), n->print()));
 
-                // Graph nodes either directly store a `Declaration` (for
-                // globals), or `statement::Declaration` (for anything else).
-                const auto* decl = n->tryAs<Declaration>();
-                if ( ! decl ) {
-                    if ( const auto* d = n->tryAs<const statement::Declaration>() )
-                        decl = d->declaration();
+                    // Graph nodes either directly store a `Declaration` (for
+                    // globals), or `statement::Declaration` (for anything else).
+                    const auto* decl = n->tryAs<Declaration>();
+                    if ( ! decl ) {
+                        if ( const auto* d = n->tryAs<const statement::Declaration>() )
+                            decl = d->declaration();
+                    }
+                    if ( ! decl )
+                        util::detail::internalError(
+                            util::fmt("could not get declaration from CFG node '%s'", n->print()));
+
+                    auto& alias_aliases = _dataflow.at(*stmt).maybe_alias;
+                    aliases_changed |= alias_aliases.insert(const_cast<Declaration*>(decl)).second;
+
+                    // Now union them for transitive aliases (a->b->c, a also aliases c)
+                    aliases_changed |=
+                        unionAliases(alias_aliases, transfer.maybe_alias, alias, const_cast<Declaration*>(decl));
                 }
-                if ( ! decl )
-                    util::detail::internalError(util::fmt("could not get declaration from CFG node '%s'", n->print()));
-
-                _dataflow.at(*stmt).maybe_alias.insert(const_cast<Declaration*>(decl));
             }
-        }
+        } while ( aliases_changed );
 
         // Now copy the usage pattern to the aliased node.
         for ( auto& [n, transfer] : _dataflow ) {

--- a/tests/hilti/optimization/alias-transitive.hlt
+++ b/tests/hilti/optimization/alias-transitive.hlt
@@ -1,0 +1,26 @@
+# @TEST-DOC: Ensures transitive aliases prevent dead code elimination. Regression test for #2258
+#
+# @TEST-EXEC: hiltic -j %INPUT
+
+module Test {
+
+import hilti;
+
+function void f() {
+    # Chain a few together to ensure transitive aliases work
+    local a = new 10;
+    local b = a;
+    local c = b;
+    local d = c;
+
+    # Now change an alias to the first in the chain
+    local p = a;
+    *p = 20;
+
+    # The last in the chain should still react to that change
+    assert(d == 20);
+}
+
+f();
+
+}


### PR DESCRIPTION
Fixes #2258

Consider a program where `a` has two direct aliases: `b` and `p`. Then, `b` has an alias `c`. `p` and `c` must alias, or else writes to `p` might be removed. This forces that by unioning alias sets until convergence.

There are other ways to ensure aliases are unioned (see: union-find) but this is the simplest way, albeit a little slow.

Second commit is just for legibility and efficiency: theoretically it should be faster, but I didn't see much change in my test. I'm just scared of an obvious O(n^3) algorithm. It was suggested by Gemini, and I agree since we already have a pass that uses reverse postorder

