### PR TITLE
Fix setting up of return value stack space in fiber stack switcher.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -488,11 +488,11 @@ docker_ubuntu24_task:
     path: ./spicy*.{deb,rpm}
     type: application/gzip
 
-docker_fedora42_task:
+docker_fedora44_task:
   skip: $CIRRUS_BRANCH != 'main' && $CIRRUS_TAG == ''
 
   container:
-    dockerfile: docker/Dockerfile.fedora-42
+    dockerfile: docker/Dockerfile.fedora-44
     cpu: 4
     memory: 12G
 

--- a/docker/Dockerfile.fedora-44
+++ b/docker/Dockerfile.fedora-44
@@ -1,6 +1,6 @@
 # Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
 
-FROM fedora:42
+FROM fedora:44
 
 RUN echo 'LC_CTYPE="C"' >> /etc/locale.conf \
  && echo 'LC_ALL="C"' >> /etc/locale.conf \

--- a/hilti/runtime/include/fiber.h
+++ b/hilti/runtime/include/fiber.h
@@ -243,7 +243,7 @@ private:
     enum class State { Init, Running, Aborting, Yielded, Idle, Finished };
 
     void _yield(const char* tag);
-    void _activate(const char* tag);
+    void _activate(const char* tag, bool init = false);
 
     /** Code to run just before we switch to a fiber. */
     static void _startSwitchFiber(const char* tag, detail::Fiber* to);

--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -121,6 +121,7 @@ struct SwitchArgs {
     detail::Fiber* switcher = nullptr;
     detail::Fiber* from = nullptr;
     detail::Fiber* to = nullptr;
+    bool target_fiber_needs_init = false;
 };
 
 // Fiber entry point for stack switcher trampoline.
@@ -142,6 +143,14 @@ void __fiber_switch_trampoline(void* argsp) {
 
     if ( from->_type == detail::Fiber::Type::SharedStack )
         from->_stack_buffer.save();
+
+    // Since both fibers share the same physical stack we can only initialize
+    // the target fiber's stack one we have performed a `save()` of the stack
+    // of fiber we are coming from.
+    if ( args->target_fiber_needs_init ) {
+        void* dummy_args; // not used, but need a non-null pointer
+        ::fiber_reserve_return(to->_fiber.get(), __fiber_run_trampoline, &dummy_args, 0);
+    }
 
     if ( to->_type == detail::Fiber::Type::SharedStack )
         to->_stack_buffer.restore();
@@ -485,7 +494,7 @@ void ASAN_NO_OPTIMIZE detail::Fiber::_executeSwitch(const char* tag, detail::Fib
     HILTI_RT_FIBER_DEBUG(tag, fmt("resuming after fiber switch returns back to %s", *from));
 }
 
-void detail::Fiber::_activate(const char* tag) {
+void detail::Fiber::_activate(const char* tag, bool init) {
     auto* context = context::detail::get();
     auto* current = context->fiber.current;
     assert(current && current != this);
@@ -503,6 +512,7 @@ void detail::Fiber::_activate(const char* tag) {
         args.switcher = stack_switcher;
         args.from = current;
         args.to = this;
+        args.target_fiber_needs_init = init;
 
         // Reinitialize fiber with same stack.
         auto* fiber = stack_switcher->_fiber.get();
@@ -586,15 +596,7 @@ void detail::Fiber::run() {
     if ( _state != State::Aborting )
         _state = State::Running;
 
-    if ( init ) {
-        // TODO: It would seem reasonable to move into this the constructor
-        // where we initialize the fiber. However, that leads to crashes; not
-        // sure why?
-        void* dummy_args; // not used, but need a non-null pointer
-        ::fiber_reserve_return(_fiber.get(), __fiber_run_trampoline, &dummy_args, 0);
-    }
-
-    _activate("run");
+    _activate("run", init);
 
     switch ( _state ) {
         case State::Yielded:


### PR DESCRIPTION
Usually fiber switching goes through a trampoline function which saves
the stack of the originator fiber and switches to the target fiber.

There was a bug in how we set up stack space for the result of the
target fiber: in a shared stack setup both fibers (well) shared a stack,
and calling `::fiber_push_return` could clobber the stack of the
originator. This patch fixes the order of calls so now the switcher
sets up the stack space on the correct fiber. This required tracking the
state of a fiber across a switch boundary, so we now track whether a
target fiber needs setup in `SwitchArgs`.

Closes zeek/zeek#5434.