### PR TITLE
Fix Fiber constructor clobbering shared stack.

### DIFF
--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -143,8 +143,32 @@ void __fiber_switch_trampoline(void* argsp) {
     if ( from->_type == detail::Fiber::Type::SharedStack )
         from->_stack_buffer.save();
 
-    if ( to->_type == detail::Fiber::Type::SharedStack )
-        to->_stack_buffer.restore();
+    // If the destination fiber has type shared stack, but doesn't yet
+    // have the stack set (nullptr), initialize it first. Otherwise,
+    // restore the saved stack form the stack buffer into the shared stack.
+    //
+    // At this point, the fiber being switched to owns the shared stack.
+    if ( to->_type == detail::Fiber::Type::SharedStack ) {
+        if ( ! ::fiber_stack(to->_fiber.get()) ) {
+            auto* shared_stack = context::detail::get()->fiber.shared_stack.get();
+            ::fiber_init(to->_fiber.get(), shared_stack->stack, shared_stack->stack_size, fiber_bottom_abort, to);
+            void* dummy_args; // not used, but need a non-null pointer
+            ::fiber_reserve_return(to->_fiber.get(), __fiber_run_trampoline, &dummy_args, 0);
+
+            // For fibers with their own or shared stacks, set boundaries from the
+            // allocated stack region.
+            //
+            // This is just the same as done in the constructor.
+#ifdef _WIN32
+            to->_teb.stack_base =
+                reinterpret_cast<char*>(::fiber_stack(to->_fiber.get())) + ::fiber_stack_size(to->_fiber.get());
+            to->_teb.stack_limit = ::fiber_stack(to->_fiber.get());
+            to->_teb.deallocation_stack = ::fiber_stack(to->_fiber.get());
+#endif
+        }
+        else
+            to->_stack_buffer.restore();
+    }
 
     detail::Fiber::_executeSwitch("stack-switcher", args->switcher, to);
 
@@ -237,11 +261,20 @@ detail::Fiber::Fiber(Type type) : _type(type), _fiber(std::make_unique<::Fiber>(
             break;
 
         case Type::SharedStack: {
-            auto* shared_stack = context::detail::get()->fiber.shared_stack.get();
-            ::fiber_init(_fiber.get(), shared_stack->stack, shared_stack->stack_size, fiber_bottom_abort, this);
+            // When running with a shared stack, do not use fiber_init() here
+            // with the shared_stack->stack as it would potentially clobber it
+            // while a different fiber is currently using it.
+            //
+            // Ensure fiber_stack(fiber) returns a nullptr, the indicator for
+            // whether the underlying fiber has been initialized or not. This
+            // is checked in __fiber_run_trampoline where the fiber will be
+            // delayed initialized and the __fiber_run_trampoline() placed on
+            // the stack.
+            assert(_fiber.get());
+            _fiber->stack = nullptr;
 
 #ifdef HILTI_HAVE_ASAN
-            _asan.stack = ::fiber_stack(_fiber.get());
+            _asan.stack = context::detail::get()->fiber.shared_stack->stack;
             _asan.stack_size = configuration::get().fiber_shared_stack_size;
 #endif
             break;
@@ -251,6 +284,13 @@ detail::Fiber::Fiber(Type type) : _type(type), _fiber(std::make_unique<::Fiber>(
             if ( ! ::fiber_alloc(_fiber.get(), configuration::detail::unsafeGet().fiber_individual_stack_size,
                                  fiber_bottom_abort, this, FiberGuardFlags) )
                 internalError("could not allocate individual-stack fiber");
+
+            {
+                // For the individual stack case, the fiber owns the stack,
+                // so can push __fiber_run_trampoline directly.
+                void* dummy_args; // not used, but need a non-null pointer
+                ::fiber_reserve_return(_fiber.get(), __fiber_run_trampoline, &dummy_args, 0);
+            }
 
 #ifdef HILTI_HAVE_ASAN
             _asan.stack = ::fiber_stack(_fiber.get());
@@ -581,18 +621,8 @@ std::ostream& operator<<(std::ostream& out, const detail::Fiber& fiber) {
 } // namespace hilti::rt::detail
 
 void detail::Fiber::run() {
-    auto init = (_state == State::Init);
-
     if ( _state != State::Aborting )
         _state = State::Running;
-
-    if ( init ) {
-        // TODO: It would seem reasonable to move into this the constructor
-        // where we initialize the fiber. However, that leads to crashes; not
-        // sure why?
-        void* dummy_args; // not used, but need a non-null pointer
-        ::fiber_reserve_return(_fiber.get(), __fiber_run_trampoline, &dummy_args, 0);
-    }
 
     _activate("run");
 


### PR DESCRIPTION
Previously, when constructing a Fiber with type SharedStack, we'd initialize the underlying fiber with the global shared stack. This isn't safe: The fiber_init() call writes to the shared stack, but there's no guarantee that the shared stack isn't being used by another fiber when this happens.

Circumvent this by moving the underlying fiber initialization into __fiber_switch_trampoline(), where it is guaranteed that the previously executing fiber has saved() the shared stack so that it is now free to be used by a different fiber. Use the nullptr fiber_stack() return as the indicator, that the initialization still needs to happen.

Alternative to #2353 , I think.