### PR TITLE
Fix potential nullptr dereference in remove-unused-fields pass.

### DIFF
--- a/hilti/toolchain/src/compiler/optimizer/passes/remove-unused-fields.cc
+++ b/hilti/toolchain/src/compiler/optimizer/passes/remove-unused-fields.cc
@@ -160,8 +160,8 @@ struct Collector : public optimizer::visitor::Collector {
     }
 
     void operator()(operator_::struct_::Unset* n) final {
-        auto* field = fieldForOperator(n);
-        field->unsets.push_back(n);
+        if ( auto* field = fieldForOperator(n) )
+            field->unsets.push_back(n);
     }
 };
 


### PR DESCRIPTION
This was introduced in 79d44f786c so needs to be backported to release/1.16.