### PR TITLE
Stop requiring git commit titles to end in `.` [skip ci]

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -10,7 +10,7 @@
 # used in here for clarity.
 #
 [general]
-ignore=title-trailing-punctuation,body-is-missing,body-min-length
+ignore=body-is-missing,body-min-length
 
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 # verbosity = 2
@@ -55,7 +55,7 @@ ignore=title-trailing-punctuation,body-is-missing,body-min-length
 # commit-msg title must be matched to.
 # Note that the regex can contradict with other rules if not used correctly
 # (e.g. title-must-not-contain-word).
-regex=^[A-Z].*\.
+regex=^[A-Z].*
 
 # [body-max-line-length]
 # line-length=72


### PR DESCRIPTION
This deviated from the convention in all other Zeek projects and always tripped me up. In the past the trailing dot also made downstream use harder, e.g., proper PR titles would have it autoadded which I always tried to remove, or when assembling release notes.