### PR TITLE
Automatically cancel exisiting GH CI workflows on PR update

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   GIT_CONFIG_PARAMETERS: "'safe.directory=*'"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
   GIT_CONFIG_PARAMETERS: "'safe.directory=*'"


### PR DESCRIPTION
Previously we would run all GH actions CI workflows to completion, even if the PR was updated and another run was started. Since we only have a limited number of workers available this causes contention across the whole GH org. It is also inconsistent with how Cirrus CI behaved, so people are not at all concious about cancelling outdated jobs.

This PR changes the configuration of all workflows which trigger for pull requests to automatically cancel existing jobs on updates, mirroring the behavior of Cirrus CI.