### PR TITLE
Skip leak tests unless running on Linux

### DIFF
--- a/tests/Scripts/is-linux
+++ b/tests/Scripts/is-linux
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+# Returns true if running on Linux.
+
+test "$(uname -o 2>/dev/null)" = "Linux"

--- a/tests/hilti/hiltic/cc/leak.cc
+++ b/tests/hilti/hiltic/cc/leak.cc
@@ -1,4 +1,5 @@
 // @TEST-REQUIRES: have-sanitizer
+// @TEST-REQUIRES: is-linux
 // @TEST-REQUIRES: test -z "${ASAN_OPTIONS}"
 // @TEST-GROUP: no-jit
 // @TEST-EXEC: cxx-compile-and-link %INPUT

--- a/tests/hilti/hiltic/jit/leak.cc
+++ b/tests/hilti/hiltic/jit/leak.cc
@@ -1,4 +1,5 @@
 // @TEST-REQUIRES: have-sanitizer
+// @TEST-REQUIRES: is-linux
 // @TEST-REQUIRES: test -z "${ASAN_OPTIONS}"
 // @TEST-EXEC-FAIL: ${HILTIC} -j %INPUT >output 2>&1
 // @TEST-EXEC: grep -q 'detected memory leaks' output


### PR DESCRIPTION
Clang's leak sanitizer is only supported on Linux at the moment, so skip tests relying on it on all other platforms.