### PR TITLE
Avoid underflow in `atoi_n`

### DIFF
--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -462,7 +462,7 @@ class OutOfRange;
  */
 template<class Iter, typename Result>
 inline Iter atoi_n(Iter s, Iter e, uint8_t base, Result* result)
-    requires std::is_integral_v<Result> && std::contiguous_iterator<Iter>
+    requires std::is_integral_v<Result> && (sizeof(Result) <= sizeof(uint64_t)) && std::contiguous_iterator<Iter>
 {
     if ( base < 2 || base > 36 )
         throw OutOfRange("base for numerical conversion must be between 2 and 36");
@@ -531,7 +531,7 @@ inline Iter atoi_n(Iter s, Iter e, uint8_t base, Result* result)
 
     // Convert to and store in target value. We have already checked the range above.
     if ( neg )
-        *result = -static_cast<Result>(n);
+        *result = static_cast<Result>(0ULL - n);
     else
         *result = static_cast<Result>(n);
 

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <limits>
 #include <locale>
 #include <string>
 #include <vector>
@@ -84,9 +85,6 @@ TEST_CASE("atoi_n") {
         }
 
         CHECK_EQ(x, -42);
-
-        // Parsing an a signed value into an unsigned type underflows.
-        CHECK_EQ(atoi_n_<uint8_t>("-1", 10, 2), 255);
     }
 
     SUBCASE("parse something") {
@@ -136,6 +134,19 @@ TEST_CASE("atoi_n") {
                  std::numeric_limits<uint8_t>::min());
         CHECK_EQ(atoi_n_<uint8_t>(std::to_string(std::numeric_limits<uint8_t>::max()), 10, 3),
                  std::numeric_limits<uint8_t>::max());
+
+        CHECK_EQ(atoi_n_<int64_t>(std::to_string(std::numeric_limits<int64_t>::min()), 10, 20),
+                 std::numeric_limits<int64_t>::min());
+        CHECK_EQ(atoi_n_<int64_t>(std::to_string(std::numeric_limits<int64_t>::max()), 10, 19),
+                 std::numeric_limits<int64_t>::max());
+
+        CHECK_EQ(atoi_n_<uint64_t>(std::to_string(std::numeric_limits<uint64_t>::min()), 10, 1),
+                 std::numeric_limits<uint64_t>::min());
+        CHECK_EQ(atoi_n_<uint64_t>(std::to_string(std::numeric_limits<uint64_t>::max()), 10, 20),
+                 std::numeric_limits<uint64_t>::max());
+
+        // Parsing an a signed value into an unsigned type underflows.
+        CHECK_EQ(atoi_n_<uint8_t>("-1", 10, 2), 255);
     }
 
     SUBCASE("overflow") {


### PR DESCRIPTION
We had previously fixed some overflows in this function, but missed a case when extracting `INT64_MIN`. We were already parsing the absolute value with enough range, but could underflow when negating it for the final result since the negation was done in the target type which did not have enough range.

With this patch we instead perform the negation in the unsigned type which has enough range, and only cast to the target type after.