### PR TITLE
Do not assume `assert` performs C++26 contextual conversions

### DIFF
--- a/hilti/runtime/include/configuration.h
+++ b/hilti/runtime/include/configuration.h
@@ -83,7 +83,7 @@ extern HILTI_JIT_IMPORT std::unique_ptr<hilti::rt::Configuration> __configuratio
  * matters.
  */
 inline const Configuration& unsafeGet() {
-    assert(detail::__configuration);
+    assert(detail::__configuration.get());
     return *detail::__configuration;
 }
 

--- a/hilti/toolchain/include/compiler/printer.h
+++ b/hilti/toolchain/include/compiler/printer.h
@@ -59,7 +59,7 @@ public:
     Stream(std::ostream& s) : _stream(s) {}
 
     auto& state() const {
-        assert(detail::State::current);
+        assert(detail::State::current.get());
         return *detail::State::current;
     }
 

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -347,7 +347,7 @@ void ASTContext::garbageCollect() {
         changed = false;
 
         for ( auto& n : _nodes ) {
-            assert(n);
+            assert(n.get());
 
             if ( n->isRetained() ) {
                 ++retained;

--- a/hilti/toolchain/src/compiler/driver.cc
+++ b/hilti/toolchain/src/compiler/driver.cc
@@ -772,7 +772,7 @@ Result<Nothing> Driver::_codegenUnits() {
 }
 
 Result<Nothing> Driver::compileUnits() {
-    assert(_builder);
+    assert(_builder.get());
 
     if ( auto rc = context()->astContext()->processAST(_builder.get(), this); ! rc ) {
         // hilti::detail::printer::print(std::cerr, context()->astContext()->root());
@@ -813,7 +813,7 @@ Result<Nothing> Driver::compileUnits() {
 Result<Nothing> Driver::run() {
     assert(! _builder);
     initialize();
-    assert(_builder);
+    assert(_builder.get());
 
     for ( const auto& i : _driver_options.inputs ) {
         if ( auto rc = addInput(i); ! rc )

--- a/spicy/runtime/include/configuration.h
+++ b/spicy/runtime/include/configuration.h
@@ -43,7 +43,7 @@ namespace detail {
  * matters.
  */
 inline const Configuration& unsafeGet() {
-    assert(rt::detail::globalState()->configuration);
+    assert(rt::detail::globalState()->configuration.get());
     return *rt::detail::globalState()->configuration;
 }
 

--- a/spicy/toolchain/include/compiler/detail/codegen/productions/while.h
+++ b/spicy/toolchain/include/compiler/detail/codegen/productions/while.h
@@ -58,7 +58,7 @@ public:
      * loop body. This method must be called only after `preprocessLookAhead()`.
      */
     const production::LookAhead* lookAheadProduction() const {
-        assert(_body_for_grammar); // set by preprocessLookAhead() return
+        assert(_body_for_grammar.get()); // set by preprocessLookAhead() return
         return _body_for_grammar->as<production::LookAhead>();
     }
 

--- a/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
@@ -384,7 +384,7 @@ hilti::Result<hilti::Nothing> GrammarBuilder::run(type::Unit* unit) {
     Grammar g(id.str(), unit->location());
     auto pf = ProductionFactory(cg(), this, &g);
     auto root = pf.createProduction(unit);
-    assert(root);
+    assert(root.get());
 
     if ( auto rc = g.setRoot(std::move(root)); ! rc )
         return rc.error();


### PR DESCRIPTION
In C++20 `assert` is standardized to take a scalar type, and the assertion triggers if the passed value is zero. Our uses of requiring set `std::unique_ptr` values conflicted with that, e.g., in

```
assert(some_unique_ptr_value);
```

the argument is not a scalar and since `std::unique_ptr`'s `operator bool` is `explicit` also not implicitly convertible to a `bool` which would be a scalar value. That this worked at all likely came from the fact that most implementations of `assert` perform explicit conversions to `bool`, but this is not required until C++26, see P2264R7 which for `assert` introduced the notion of "contextually convertible" which would apply here for `std::unique_ptr`. The concrete case were our current code was failing were implementations of `assert` on freebsd-16 could be defined in a way which performed no explicit conversion.

```
#define __assert_sanitize(...)  (void)sizeof(((bool(*)(bool))0)(__VA_ARGS__))
```

This patch updates uses of `assert` with `std::unique_ptr` to explicitly convert to a scalar value via `get` where we previously passed the `std::unique_ptr` directly. We do not need to touch instances where we already converted the argument to `assert` to `bool`, either contextually or explicitly.