### PR TITLE
Additional fixes for #2399

### DIFF
--- a/hilti/runtime/include/types/stream.h
+++ b/hilti/runtime/include/types/stream.h
@@ -691,7 +691,7 @@ private:
 
     void _ensureValidChain() const {
         // This must have been checked at this point already.
-        assert(_chain);
+        assert(_chain.get());
 
         if ( ! _chain->isValid() )
             throw InvalidIterator("stream object no longer available");
@@ -1765,7 +1765,7 @@ public:
 
     /** Destructor. */
     ~Stream() {
-        assert(_chain);
+        assert(_chain.get());
         _chain->invalidate();
     }
 

--- a/spicy/runtime/src/sink.cc
+++ b/spicy/runtime/src/sink.cc
@@ -447,7 +447,7 @@ void Sink::_close(bool orderly) {
                         fmt("error in connected unit %s during close (%s)", s->parser->name, err.what()));
                 }
 
-                assert(s->resumable); // must have conluded after freezing/aborting
+                assert(static_cast<bool>(s->resumable)); // must have conluded after freezing/aborting
             }
         }
 


### PR DESCRIPTION
Here are more changes needed to compile spicy (zeek) on FreeBSD 16 current after 86326398b73b. Thanks to @bbannier.