### PR TITLE
safe-int: Ignore -Wpedantic for SafeInt.hpp

### DIFF
--- a/hilti/runtime/include/safe-int.h
+++ b/hilti/runtime/include/safe-int.h
@@ -2,8 +2,18 @@
 
 #pragma once
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #define SAFEINT_DISABLE_ADDRESS_OPERATOR
 #include <hilti/rt/3rdparty/SafeInt/SafeInt.hpp>
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <hilti/rt/exception.h>
 #include <hilti/rt/macros.h>
 

--- a/hilti/runtime/src/safe-math.cc
+++ b/hilti/runtime/src/safe-math.cc
@@ -7,9 +7,18 @@ using namespace hilti::rt;
 
 [[noreturn]] inline static void safe_math_fail(const char* /*msg*/) { throw OutOfRange("integer value out of range"); }
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #define SAFE_MATH_FAIL_DEFINED
 extern "C" {
 #include <hilti/rt/3rdparty/SafeInt/safe_math_impl.h>
 }
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 int64_t integer::safe_negate(uint64_t x) { return safe_sub_int64_uint64(0, x); }


### PR DESCRIPTION
Compiling Zeek with -Wpedantic produces a lot of the following warnings whenever safe-int.h is included.

    SafeInt.hpp:1999:54: warning: ISO C++ does not support ‘__int128’ for ‘type name’ [-Wpedantic]

Skip passing -Wpedantic to SafeInt.hpp, didn't seem like there's anything more specific.