### PR TITLE
Change `hilti::rt::atoi_n` to take a `string_view`

### DIFF
--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -452,26 +452,24 @@ class OutOfRange;
  * @pre The input sequence must not be empty, i.e., we require `s != e`.
  * @pre Base must be in the inclusive range [2, 36].
  *
- * @par s beginning of the input range.
- * @par e end of the input range.
+ * @par input buffer to parse number from.
  * @par base base of the input range.
  * @par result address of the memory location to used for storing
  *     a possible parsed result.
- * @return iterator to the first character not used in value
- *     extraction.
+ * @return number of bytes consumed in parsing.
  */
-template<class Iter, typename Result>
-inline Iter atoi_n(Iter s, Iter e, uint8_t base, Result* result)
-    requires std::is_integral_v<Result> && (sizeof(Result) <= sizeof(uint64_t)) && std::contiguous_iterator<Iter>
+template<typename Result>
+inline uint8_t atoi_n(std::string_view input, uint8_t base, Result* result)
+    requires std::is_integral_v<Result> && (sizeof(Result) <= sizeof(uint64_t))
 {
     if ( base < 2 || base > 36 )
         throw OutOfRange("base for numerical conversion must be between 2 and 36");
 
-    if ( s == e )
+    if ( input.empty() )
         throw InvalidArgument("cannot decode from empty range");
 
     bool neg = false;
-    auto it = s;
+    const auto* it = input.begin();
 
     if ( *it == '-' ) {
         neg = true;
@@ -504,7 +502,7 @@ inline Iter atoi_n(Iter s, Iter e, uint8_t base, Result* result)
     // enough to handle any type we need to handle.
     static_assert(max_value <= std::numeric_limits<uint64_t>::max());
     uint64_t n = 0;
-    for ( ; it != e; ++it ) {
+    for ( ; it != input.end(); ++it ) {
         auto c = *it;
 
         // `uint8_t` is sufficient to store any digit up to max base 36.
@@ -524,10 +522,10 @@ inline Iter atoi_n(Iter s, Iter e, uint8_t base, Result* result)
         n = (n * base) + d;
     }
 
-    if ( it == s )
-        return s;
+    if ( it == input.begin() )
+        return 0;
 
-    s = it;
+    auto s = std::distance(input.begin(), it);
 
     // Convert to and store in target value. We have already checked the range above.
     if ( neg )

--- a/hilti/runtime/src/benchmarks/iteration.cc
+++ b/hilti/runtime/src/benchmarks/iteration.cc
@@ -1,12 +1,14 @@
 // Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
 
 #include <cstdint>
+#include <string>
 
 #include <hilti/rt/init.h>
 #include <hilti/rt/types/bytes.h>
 #include <hilti/rt/types/map.h>
 #include <hilti/rt/types/set.h>
 #include <hilti/rt/types/vector.h>
+#include <hilti/rt/util.h>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -80,7 +82,19 @@ static void iterate_vector(benchmark::State& state) {
     }
 }
 
+static void atoi_n_uint64_t(benchmark::State& state) {
+    hilti::rt::init();
+
+    std::string data(state.range(), '1');
+
+    uint64_t x = 0;
+    // NOLINTNEXTLINE
+    for ( auto _ : state )
+        hilti::rt::atoi_n(data.begin(), data.end(), 10, &x);
+}
+
 BENCHMARK(iterate_bytes)->ArgName("len")->RangeMultiplier(100)->Range(1, 1'000'000);
 BENCHMARK(iterate_map)->ArgName("len")->RangeMultiplier(100)->Range(1, 1'000'000);
 BENCHMARK(iterate_set)->ArgName("len")->RangeMultiplier(100)->Range(1, 1'000'000);
 BENCHMARK(iterate_vector)->ArgName("len")->RangeMultiplier(100)->Range(1, 1'000'000);
+BENCHMARK(atoi_n_uint64_t)->ArgName("digits")->Range(1, 20);

--- a/hilti/runtime/src/benchmarks/iteration.cc
+++ b/hilti/runtime/src/benchmarks/iteration.cc
@@ -90,7 +90,7 @@ static void atoi_n_uint64_t(benchmark::State& state) {
     uint64_t x = 0;
     // NOLINTNEXTLINE
     for ( auto _ : state )
-        hilti::rt::atoi_n(data.begin(), data.end(), 10, &x);
+        hilti::rt::atoi_n(data, 10, &x);
 }
 
 BENCHMARK(iterate_bytes)->ArgName("len")->RangeMultiplier(100)->Range(1, 1'000'000);

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -55,15 +55,15 @@ T atoi_n_(const std::string_view& input, int base, unsigned num_parsed) {
     CAPTURE(base);
 
     auto result = T();
-    std::string_view::iterator it;
+    unsigned n = 0;
 
     try {
-        it = atoi_n(input.cbegin(), input.cend(), base, &result);
+        n = atoi_n(input, base, &result);
     } catch ( ... ) {
         throw;
     }
 
-    CHECK_EQ(it - input.begin(), num_parsed);
+    CHECK_EQ(n, num_parsed);
     return result;
 };
 
@@ -73,16 +73,10 @@ TEST_CASE("atoi_n") {
 
         SUBCASE("empty range") {
             std::string_view s;
-            CHECK_THROWS_WITH_AS(atoi_n(s.begin(), s.end(), 10, &x),
-                                 "cannot decode from empty range",
-                                 const InvalidArgument&);
+            CHECK_THROWS_WITH_AS(atoi_n(s, 10, &x), "cannot decode from empty range", const InvalidArgument&);
         }
 
-        SUBCASE("invalid chars") {
-            std::string_view s = "abc";
-            const auto it = atoi_n(s.data(), s.data() + s.size(), 10, &x);
-            CHECK_EQ(it, s.data());
-        }
+        SUBCASE("invalid chars") { CHECK_EQ(atoi_n("abc", 10, &x), 0); }
 
         CHECK_EQ(x, -42);
     }

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -253,7 +253,7 @@ Bytes Bytes::upper(unicode::Charset cs, unicode::DecodeErrorStrategy errors) con
 
 integer::safe<int64_t> Bytes::toInt(uint64_t base) const {
     int64_t x = 0;
-    if ( hilti::rt::atoi_n(str().begin(), str().end(), base, &x) == str().end() )
+    if ( hilti::rt::atoi_n(str(), base, &x) == str().size() )
         return x;
 
     throw RuntimeError("cannot parse bytes as signed integer");
@@ -261,7 +261,7 @@ integer::safe<int64_t> Bytes::toInt(uint64_t base) const {
 
 integer::safe<uint64_t> Bytes::toUInt(uint64_t base) const {
     int64_t x = 0;
-    if ( hilti::rt::atoi_n(str().begin(), str().end(), base, &x) == str().end() )
+    if ( hilti::rt::atoi_n(str(), base, &x) == str().size() )
         return x;
 
     throw RuntimeError("cannot parse bytes as unsigned integer");

--- a/hilti/runtime/src/util.cc
+++ b/hilti/runtime/src/util.cc
@@ -228,7 +228,7 @@ std::string hilti::rt::expandUTF8Escapes(std::string s) {
                     throw UnicodeError("incomplete unicode \\u");
                 auto end = c + 4;
                 utf8proc_int32_t val = 0;
-                c = atoi_n(c, end, 16, &val);
+                c += atoi_n(std::string_view{c, end}, 16, &val);
 
                 if ( c != end )
                     throw UnicodeError("cannot decode character");
@@ -248,7 +248,7 @@ std::string hilti::rt::expandUTF8Escapes(std::string s) {
                     throw UnicodeError("incomplete unicode \\U");
                 auto end = c + 8;
                 utf8proc_int32_t val = 0;
-                c = atoi_n(c, end, 16, &val);
+                c += atoi_n(std::string_view{c, end}, 16, &val);
 
                 if ( c != end )
                     throw UnicodeError("cannot decode character");
@@ -269,7 +269,7 @@ std::string hilti::rt::expandUTF8Escapes(std::string s) {
                 auto remaining = s.end() - c;
                 auto end = c + std::min(static_cast<decltype(remaining)>(2), remaining);
                 char val = 0;
-                c = atoi_n(c, end, 16, &val);
+                c += atoi_n(std::string_view{c, end}, 16, &val);
 
                 if ( c != end )
                     throw FormattingError("cannot decode character");

--- a/hilti/toolchain/include/base/util.h
+++ b/hilti/toolchain/include/base/util.h
@@ -334,12 +334,6 @@ hilti::rt::filesystem::path currentExecutable();
 /** Dumps a backtrace to stderr and then aborts execution. */
 [[noreturn]] extern void abortWithBacktrace();
 
-/** Parses an string into an integer value. */
-template<class Iter, typename Result>
-inline auto atoi_n(Iter s, Iter e, int base, Result* result) {
-    return hilti::rt::atoi_n(s, e, base, result);
-}
-
 /**
  * Pairs up the elements of two lists.
  *

--- a/hilti/toolchain/src/base/preprocessor.cc
+++ b/hilti/toolchain/src/base/preprocessor.cc
@@ -74,8 +74,7 @@ hilti::Result<bool> hilti::util::SourceCodePreprocessor::_parseIf(const std::str
         op = std::string(m[1]);
         want = 0;
 
-        if ( const auto* x = hilti::rt::atoi_n(m[2].data(), m[2].data() + m[2].size(), 10, &want);
-             x != m[2].data() + m[2].size() )
+        if ( auto n = hilti::rt::atoi_n(m[2], 10, &want); n != m[2].size() )
             return result::Error("cannot parse integer value");
     }
     else {


### PR DESCRIPTION
This function previously accepted and returned generic iterators. This
not only made calling it potentially error prone, but also lead to some
awkwardness in using its return value (e.g., use of iterator math to
decide whether anything was consumed). On the implementation side, it
also restricted what operations were possible on the passed iterators
which would make e.g., rewriting the function in terms of
`std::from_chars` harder than needed.

This patch changes the function to instead accept `std::string_view`
instead, and return the number of consumed bytes.