### PR TITLE
Fix build for GH actions windows runner updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -369,7 +369,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        choco install -y --no-progress winflexbison3 ccache msysgit python ccache
+        choco install -y --no-progress winflexbison3 ccache msysgit python
 
     - name: Set up environment
       run: |

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -5,7 +5,7 @@
 
 :: Import the MSVC compiler environment. The path is hard-coded to the CI
 :: Docker image; adjust if running builds locally.
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 mkdir build

--- a/ci/windows/prepare.cmd
+++ b/ci/windows/prepare.cmd
@@ -3,7 +3,7 @@
 
 :: Import the MSVC compiler environment. The path is hard-coded to the CI
 :: Docker image; adjust if running builds locally.
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo === System Information ===

--- a/ci/windows/test.cmd
+++ b/ci/windows/test.cmd
@@ -4,7 +4,7 @@
 :: Run Spicy unit tests on Windows.
 
 :: Import the MSVC compiler environment.
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+call "%VSINSTALLDIR%VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 cd build


### PR DESCRIPTION
On 2026-06-15 [Github switched the `windows-2025` runner to mean instead `windows-2025-vs2026`](actions/runner-images#14017). This caused our Windows CI job to break since it hardcoded the path to the Visual Studio installation.

Since this migration working automatically in https://github.com/zeek/zeek bring this CI in line with the status there.