### PR TITLE
Allow disabling of building of benchmarks

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -40,6 +40,7 @@ set(FIBER_SHARED OFF)
 set(FIBER_OBJECT ON)
 add_subdirectory(fiber)
 
+if (SPICY_ENABLE_BENCHMARKS)
 # We use codspeed.io for benchmarking in CI. Pull in
 # their patched google-benchmark if we are running there.
 if (CODSPEED_MODE)
@@ -60,6 +61,7 @@ else()
     add_subdirectory(benchmark)
     set_target_properties(benchmark PROPERTIES EXCLUDE_FROM_ALL ON)
     set_target_properties(benchmark_main PROPERTIES EXCLUDE_FROM_ALL ON)
+endif()
 endif()
 
 set(REPROC++ ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,16 @@ require_version("Bison" BISON_FOUND BISON_VERSION "${bison_minimum_version}" tru
 find_package(GoldLinker)
 find_package(Threads)
 
+# By default test targets are built since we want them to be build as part
+# of the default dev experience. Projects using Spicy can still disable them
+# when bundling Spicy by setting the option.
+option(SPICY_ENABLE_TESTS "Build Spicy unit tests and benchmarks" ON)
+
+# By default benchmark targets are built since we want them to be build as part
+# of the default dev experience. Projects using Spicy can still disable them
+# when bundling Spicy by setting the option.
+option(SPICY_ENABLE_BENCHMARKS "Build Spicy benchmarks" ON)
+
 option(BUILD_TOOLCHAIN "Build the Spicy compiler toolchain" ON)
 option(HILTI_SKIP_EXPENSIVE_DEBUG_CHECKS
        "In debug builds, skip particularly expensive consistency checks inside the compiler" OFF)
@@ -372,10 +382,6 @@ add_custom_target(
 add_custom_target(tests COMMENT "Building test targets")
 add_dependencies(tests hilti-tests spicy-tests)
 
-# By default Test targets are built since we want them to be build as part
-# of the default dev experience. Projects using Spicy can still disable them
-# when bundling Spicy by setting the the option.
-option(SPICY_ENABLE_TESTS "Build Spicy unit tests and benchmarks" ON)
 if (SPICY_ENABLE_TESTS)
     add_custom_target(tests-build ALL DEPENDS tests COMMENT "Forcing test build")
 endif ()

--- a/configure
+++ b/configure
@@ -22,6 +22,7 @@ cmake_clang_tidy=""
 cmake_flex_root=""
 cmake_generator=""
 cmake_install_prefix="/usr/local"
+cmake_build_benchmarks="yes"
 cmake_use_ccache="no"
 cmake_use_gold="yes"
 cmake_use_precompiled_headers="yes"
@@ -60,6 +61,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --build-static-libs                   Build static libraries instead [default: shared]
     --build-toolchain={yes,no}            Build the Spicy compiler toolchain [default: ${cmake_build_toolchain}]
     --build-type=TYPE                     Set build type (Debug,Release,RelWithDebInfo) [default: ${cmake_build_type}]
+    --disable-benchmarks                  Do not build benchmarks
     --disable-gold                        On Linux, do not try to use the gold linker
     --disable-precompiled-headers         Disable use of precompiled headers for developer tests
     --disable-tests                       Disable building of tests and benchmarks
@@ -117,6 +119,7 @@ while [ $# -ne 0 ]; do
         --build-static-libs)               cmake_build_shared_libs="no";;
         --build-toolchain=*)               cmake_build_toolchain="${optarg}";;
         --build-type=*)                    cmake_build_type="${optarg}";;
+        --disable-benchmarks)              cmake_build_benchmarks="no";;
         --disable-gold)                    cmake_use_gold="no";;
         --disable-precompiled-headers)     cmake_use_precompiled_headers="no";;
         --disable-tests)                   cmake_spicy_enable_tests="no";;
@@ -181,6 +184,7 @@ append_cache_entry USE_SANITIZERS               STRING "${cmake_use_sanitizers}"
 append_cache_entry HILTI_DEV_PRECOMPILE_HEADERS BOOL   "${cmake_use_precompiled_headers}"
 append_cache_entry USE_WERROR                   BOOL   "${cmake_use_werror}"
 append_cache_entry SPICY_ENABLE_TESTS           BOOL   "${cmake_spicy_enable_tests}"
+append_cache_entry SPICY_ENABLE_BENCHMARKS      BOOL   "${cmake_build_benchmarks}"
 
 if [ -n "${cmake_generator}" ]; then
     cmake="${cmake_exe} -G '${cmake_generator}' ${cmake_cache_entries} ${source_dir}"

--- a/hilti/CMakeLists.txt
+++ b/hilti/CMakeLists.txt
@@ -4,7 +4,12 @@ add_subdirectory(lib)
 add_subdirectory(runtime)
 
 add_custom_target(hilti-tests COMMENT "Building unit tests for HILTI"
-                  DEPENDS hilti-rt-tests hilti-rt-configuration-tests hilti-rt-benchmark)
+                  DEPENDS hilti-rt-tests hilti-rt-configuration-tests)
+
+if (SPICY_ENABLE_BENCHMARKS)
+    add_dependencies(hilti-tests hilti-rt-benchmark)
+endif ()
+
 if (HAVE_TOOLCHAIN)
     add_subdirectory(toolchain)
     add_dependencies(hilti-tests hilti-toolchain-tests)

--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -228,8 +228,10 @@ target_link_libraries(hilti-rt-configuration-tests
 add_test(NAME hilti-rt-configuration-tests
          COMMAND ${PROJECT_BINARY_DIR}/bin/hilti-rt-configuration-tests)
 
-add_executable(hilti-rt-benchmark EXCLUDE_FROM_ALL src/benchmarks/fiber.cc
-                                                   src/benchmarks/iteration.cc)
-target_compile_options(hilti-rt-benchmark PRIVATE "-Wall")
-target_link_libraries(hilti-rt-benchmark PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug,hilti-rt>)
-target_link_libraries(hilti-rt-benchmark PRIVATE benchmark)
+if (SPICY_ENABLE_BENCHMARKS)
+    add_executable(hilti-rt-benchmark EXCLUDE_FROM_ALL src/benchmarks/fiber.cc
+                                                       src/benchmarks/iteration.cc)
+    target_compile_options(hilti-rt-benchmark PRIVATE "-Wall")
+    target_link_libraries(hilti-rt-benchmark PRIVATE $<IF:$<CONFIG:Debug>,hilti-rt-debug,hilti-rt>)
+    target_link_libraries(hilti-rt-benchmark PRIVATE benchmark)
+endif ()

--- a/spicy/CMakeLists.txt
+++ b/spicy/CMakeLists.txt
@@ -8,5 +8,9 @@ add_dependencies(spicy-tests spicy-rt-tests)
 
 if (HAVE_TOOLCHAIN)
     add_subdirectory(toolchain)
-    add_dependencies(spicy-tests spicy-toolchain-tests spicy-rt-tests spicy-rt-parsing-benchmark)
+    add_dependencies(spicy-tests spicy-toolchain-tests spicy-rt-tests)
+
+    if (SPICY_ENABLE_BENCHMARKS)
+        add_dependencies(spicy-tests spicy-rt-parsing-benchmark)
+    endif ()
 endif ()

--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -108,4 +108,6 @@ target_link_libraries(spicy-rt-tests
 target_link_libraries(spicy-rt-tests PRIVATE $<IF:$<CONFIG:Debug>,spicy-rt-debug,spicy-rt> doctest)
 add_test(NAME spicy-rt-tests COMMAND ${PROJECT_BINARY_DIR}/bin/spicy-rt-tests)
 
-add_subdirectory(tests/benchmarks/)
+if (SPICY_ENABLE_BENCHMARKS)
+    add_subdirectory(tests/benchmarks/)
+endif ()


### PR DESCRIPTION
We have a reoccurring and hard to diagnose issue with the google/benchmark dependency failing to detect the regex backend, #2414. Since the benchmarks and their dependencies are not needed during regular use, add a configure option `--disable-benchmarks` and a CMake variable `SPICY_ENABLE_BENCHMARKS` to allow turning benchmarks off.