### PR TITLE
Fix regression causing removal of used fields

### DIFF
--- a/hilti/toolchain/src/compiler/optimizer/passes/remove-unused-fields.cc
+++ b/hilti/toolchain/src/compiler/optimizer/passes/remove-unused-fields.cc
@@ -97,7 +97,7 @@ struct Collector : public optimizer::visitor::Collector {
             return nullptr; // might have been removed already elsewhere
 
         if ( considerField(sfield) )
-            return &fields[optimizer()->functionID(sfield)];
+            return &fields[sfield->fullyQualifiedID()];
         else
             return nullptr;
     }
@@ -111,7 +111,7 @@ struct Collector : public optimizer::visitor::Collector {
         if ( ! considerField(sfield) )
             return;
 
-        auto& field = fields[optimizer()->functionID(sfield)];
+        auto& field = fields[sfield->fullyQualifiedID()];
         field.writes.push_back(n);
     }
 
@@ -120,7 +120,7 @@ struct Collector : public optimizer::visitor::Collector {
             return;
 
         if ( auto* struct_ = n->parent()->tryAs<type::Struct>() ) {
-            auto& field = fields[optimizer()->functionID(n)];
+            auto& field = fields[n->fullyQualifiedID()];
             field.decl = n;
             field.struct_ = struct_;
 


### PR DESCRIPTION
In 09c092a9733 from #2336 we changed how a number of optimizer passes reference functions. A cleanup there caused a regression in the `RemoveUnusedFields` pass so that we now remove fields even though they are used. This leads to compilation failures, e.g., in Zeek's builtin PostgreSQL parser.

Since that pass works on fields instead of general functions this patch simply reverts the cleanup in that pass.