### PR TITLE
Update CI to llvm-22

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@
 ---
 Checks: '
   bugprone-*,
+  -bugprone-derived-method-shadowing-base-method,
   -bugprone-throwing-static-initialization,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
@@ -32,6 +33,7 @@ Checks: '
   -clang-analyzer-core.StackAddressEscape,
 
   misc-*,
+  -misc-override-with-different-visibility,
   -misc-macro-parentheses,
   -misc-non-private-member-variables-in-classes,
   -misc-suspicious-semicolon,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@
 ---
 Checks: '
   bugprone-*,
+  -bugprone-throwing-static-initialization,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-reserved-identifier,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,30 +46,24 @@ jobs:
         include:
         - id: lint
           file: ci/Dockerfile
-          env:
-            LD_LIBRARY_PATH: /usr/lib/llvm-21/lib/clang/21/lib/linux/
           run: |
-            ./ci/run-ci -b build -j "$NPROCS" configure debug --cxx-compiler clang++-21 --clang-tidy /usr/bin/clang-tidy-21
+            ./ci/run-ci -b build -j "$NPROCS" configure debug --cxx-compiler clang++ --clang-tidy `which clang-tidy`
             ./ci/run-ci -b build -j "$NPROCS" build
             ./ci/run-ci -b build -j "$NPROCS" test-code
 
-        - id: clang21-ubuntu-debug
+        - id: clang-ubuntu-debug
           file: ci/Dockerfile
-          env:
-            LD_LIBRARY_PATH: /usr/lib/llvm-21/lib/clang/21/lib/linux/
           run: |
-            ./ci/run-ci -b build -j "$NPROCS" configure debug --cxx-compiler clang++-21
+            ./ci/run-ci -b build -j "$NPROCS" configure debug --cxx-compiler clang++
             ./ci/run-ci -b build -j "$NPROCS" build
             ./ci/run-ci -b build -j "$NPROCS" test-build
             ./ci/run-ci -b build -j "$NPROCS" install
             ninja -C build package
 
-        - id: clang21-lts-ubuntu-release
+        - id: clang-lts-ubuntu-release
           file: ci/Dockerfile
-          env:
-            LD_LIBRARY_PATH: /usr/lib/llvm-21/lib/clang/21/lib/linux/
           run: |
-            ./ci/run-ci -b build -j "$NPROCS" configure release --cxx-compiler clang++-21
+            ./ci/run-ci -b build -j "$NPROCS" configure release --cxx-compiler clang++
             ./ci/run-ci -b build -j "$NPROCS" build
             ./ci/run-ci -b build -j "$NPROCS" test-build
             ./ci/run-ci -b build -j "$NPROCS" install
@@ -77,12 +71,10 @@ jobs:
             ./ci/run-ci -b build -j "$NPROCS" test-install
             ninja -C build package
 
-        - id: clang21-lts-ubuntu-release-static
+        - id: clang-lts-ubuntu-release-static
           file: ci/Dockerfile
-          env:
-            LD_LIBRARY_PATH: /usr/lib/llvm-21/lib/clang/21/lib/linux/
           run: |
-            ./ci/run-ci -b build -j "$NPROCS" configure release --cxx-compiler clang++-21
+            ./ci/run-ci -b build -j "$NPROCS" configure release --cxx-compiler clang++
             ./ci/run-ci -b build -j "$NPROCS" build
             ./ci/run-ci -b build -j "$NPROCS" test-build
             ./ci/run-ci -b build -j "$NPROCS" install

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -40,17 +40,17 @@ RUN apt-get update \
  && pipx install pygments \
  # LLVM toolchain.
  && curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main' >> /etc/apt/sources.list.d/llvm21.list \
- && echo 'deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main' >> /etc/apt/sources.list.d/llvm21.list \
+ && echo 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' >> /etc/apt/sources.list.d/llvm22.list \
+ && echo 'deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' >> /etc/apt/sources.list.d/llvm22.list \
  && curl https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/llvm.asc \
  && apt-get update \
- && apt-get install -y --no-install-recommends llvm-21-dev clang-21 libclang-21-dev clang-tidy-21 libclang-rt-21-dev \
- && update-alternatives --install /usr/bin/clang clang $(which clang-21) 100 \
- && update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-21) 100 \
- && update-alternatives --install /usr/bin/clang-tidy clang-tidy $(which clang-tidy-21) 100 \
- && update-alternatives --install /usr/bin/FileCheck FileCheck $(which FileCheck-21) 100 \
+ && apt-get install -y --no-install-recommends llvm-22-dev clang-22 libclang-22-dev clang-tidy-22 libclang-rt-22-dev \
+ && update-alternatives --install /usr/bin/clang clang $(which clang-22) 100 \
+ && update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-22) 100 \
+ && update-alternatives --install /usr/bin/clang-tidy clang-tidy $(which clang-tidy-22) 100 \
+ && update-alternatives --install /usr/bin/FileCheck FileCheck $(which FileCheck-22) 100 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/root/.local/bin/:$PATH
-ENV LD_LIBRARY_PATH=/usr/lib/llvm-21/lib/clang/21/lib/linux
+ENV LD_LIBRARY_PATH=/usr/lib/llvm-22/lib/clang/22/lib/linux

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -45,8 +45,12 @@ RUN apt-get update \
  && curl https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/llvm.asc \
  && apt-get update \
  && apt-get install -y --no-install-recommends llvm-21-dev clang-21 libclang-21-dev clang-tidy-21 libclang-rt-21-dev \
+ && update-alternatives --install /usr/bin/clang clang $(which clang-21) 100 \
+ && update-alternatives --install /usr/bin/clang++ clang++ $(which clang++-21) 100 \
+ && update-alternatives --install /usr/bin/clang-tidy clang-tidy $(which clang-tidy-21) 100 \
  && update-alternatives --install /usr/bin/FileCheck FileCheck $(which FileCheck-21) 100 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/root/.local/bin/:$PATH
+ENV LD_LIBRARY_PATH=/usr/lib/llvm-21/lib/clang/21/lib/linux

--- a/ci/run-ci
+++ b/ci/run-ci
@@ -94,8 +94,6 @@ function run_configure {
     mkdir -p ${install}
     configure="./configure --builddir=${build} --prefix=${install} --generator=Ninja --enable-werror --enable-ccache --with-hilti-compiler-launcher=ccache"
 
-    clang_tidy=$(which clang-tidy 2>/dev/null)
-
     if [ "${build_type}" == "release" ]; then
         :
     elif [ "${build_type}" == "debug" ]; then

--- a/hilti/runtime/include/intrusive-ptr.h
+++ b/hilti/runtime/include/intrusive-ptr.h
@@ -40,8 +40,21 @@ inline void Ref(const T* m) {
 
 template<typename T>
 inline void Unref(const T* m) {
+    // The GCC-12 series introduced `-Wuse-after-free` which while useful still
+    // triggers false positives, see e.g.,
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106119. The code below is
+    // also affected by that bug, so locally disable the diagnostic.
+#if defined(__GNUC__) and not defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
+
     if ( m && --m->_references == 0 )
         delete m;
+
+#if defined(__GNUC__) and not defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 } // namespace intrusive_ptr

--- a/hilti/runtime/include/safe-int.h
+++ b/hilti/runtime/include/safe-int.h
@@ -28,9 +28,9 @@ template<typename O, typename T>
 inline auto operator<<(O& out, const hilti::rt::integer::safe<T>& x) -> O&
     requires(std::is_base_of_v<std::ostream, O>)
 {
-    if ( std::is_same<T, int8_t>() )
+    if constexpr ( std::is_same<T, int8_t>() )
         out << static_cast<int16_t>(x);
-    else if ( std::is_same<T, uint8_t>() )
+    else if constexpr ( std::is_same<T, uint8_t>() )
         out << static_cast<uint16_t>(x);
     else
         out << x.Ref();

--- a/hilti/runtime/include/test/utils.h
+++ b/hilti/runtime/include/test/utils.h
@@ -63,7 +63,7 @@ public:
     auto str() const { return _buffer.str(); }
 
 private:
-    std::stringstream _buffer = std::stringstream{};
+    std::stringstream _buffer;
     std::streambuf* _old = nullptr;
     std::ostream* _stream = nullptr;
 };

--- a/hilti/runtime/include/types/bitfield.h
+++ b/hilti/runtime/include/types/bitfield.h
@@ -143,13 +143,9 @@ inline std::string to_string_for_print(const Bitfield<Ts...>& x, adl::tag /*unus
 }
 } // namespace detail::adl
 
-} // namespace hilti::rt
-
-namespace std {
-
 template<typename... Ts>
 inline std::ostream& operator<<(std::ostream& out, const hilti::rt::Bitfield<Ts...>& x) {
     return out << hilti::rt::to_string_for_print(x);
 }
 
-} // namespace std
+} // namespace hilti::rt

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -369,7 +369,7 @@ public:
         if ( from._control != to._control )
             throw InvalidArgument("start and end iterator cannot belong to different bytes");
 
-        return sub(Offset(from - begin()), to._index);
+        return sub(static_cast<Offset>(from - begin()), to._index);
     }
 
     /**

--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -57,12 +57,12 @@ class SafeIterator {
 
     using Control = control::Reference<B, InvalidIterator>;
     Control _control;
-    typename integer::safe<std::uint64_t> _index = 0;
+    integer::safe<std::uint64_t> _index = 0;
 
 public:
     SafeIterator() = default;
 
-    SafeIterator(typename B::size_type index, Control control) : _control(std::move(control)), _index(index) {}
+    SafeIterator(B::size_type index, Control control) : _control(std::move(control)), _index(index) {}
 
     integer::safe<uint8_t> operator*() const {
         auto&& data = _control.get();

--- a/hilti/runtime/include/types/enum.h
+++ b/hilti/runtime/include/types/enum.h
@@ -41,7 +41,7 @@ bool has_label(const T& t, const TypeInfo* ti) {
  */
 template<typename T>
 T from_int(int64_t n) {
-    using Value = typename T::Value;
+    using Value = T::Value;
     static_assert(std::is_enum_v<Value>);
     static_assert(std::is_same_v<std::underlying_type_t<Value>, int64_t>);
     return static_cast<T>(n);
@@ -61,7 +61,7 @@ T from_int(int64_t n) {
  */
 template<typename T>
 T from_uint(uint64_t n) {
-    using Value = typename T::Value;
+    using Value = T::Value;
     static_assert(std::is_enum_v<Value>);
     static_assert(std::is_same_v<std::underlying_type_t<Value>, int64_t>);
 

--- a/hilti/runtime/include/types/integer.h
+++ b/hilti/runtime/include/types/integer.h
@@ -286,7 +286,7 @@ inline int64_t flip(int64_t v, uint64_t n) {
     if ( n == 0 )
         return v;
     auto i = static_cast<uint64_t>(v);
-    i = flip64(i) >> (64 - n * 8);
+    i = flip64(i) >> (64 - (n * 8));
     return static_cast<int64_t>(i);
 }
 
@@ -300,7 +300,7 @@ inline int64_t flip(int64_t v, uint64_t n) {
 inline uint64_t flip(uint64_t v, uint64_t n) {
     if ( n == 0 )
         return v;
-    return (flip64(v) >> (64 - n * 8));
+    return (flip64(v) >> (64 - (n * 8)));
 }
 
 /** Available bit orders. */

--- a/hilti/runtime/include/types/map.h
+++ b/hilti/runtime/include/types/map.h
@@ -37,9 +37,9 @@ template<typename K, typename V>
 class Iterator {
     using M = Map<K, V>;
 
-    using Control = typename M::Control::Ref;
+    using Control = M::Control::Ref;
     Control _control;
-    typename M::M::iterator _iterator;
+    M::M::iterator _iterator;
 
 public:
     Iterator() = default;
@@ -60,7 +60,7 @@ public:
             throw IndexError("iterator is invalid");
         }
 
-        if ( _iterator == static_cast<const typename M::M&>(_control.get()).end() )
+        if ( _iterator == static_cast<const M::M&>(_control.get()).end() )
             throw IndexError("iterator is invalid");
 
         ++_iterator;
@@ -73,11 +73,11 @@ public:
         return ret;
     }
 
-    const typename M::M::value_type* operator->() const { return &operator*(); }
+    const M::value_type* operator->() const { return &operator*(); }
 
-    typename M::M::const_reference operator*() const {
+    M::M::const_reference operator*() const {
         // Iterators to `end` cannot be dereferenced.
-        if ( _iterator == static_cast<const typename M::M&>(_control.get()).cend() )
+        if ( _iterator == static_cast<const M::M&>(_control.get()).cend() )
             throw IndexError("iterator is invalid");
 
         return *_iterator;
@@ -86,17 +86,16 @@ public:
 private:
     friend class Map<K, V>;
 
-    Iterator(typename M::M::iterator iterator, Control control)
-        : _control(std::move(control)), _iterator(std::move(iterator)) {}
+    Iterator(M::M::iterator iterator, Control control) : _control(std::move(control)), _iterator(std::move(iterator)) {}
 };
 
 template<typename K, typename V>
 class ConstIterator {
     using M = Map<K, V>;
 
-    using Control = typename M::Control::Ref;
+    using Control = M::Control::Ref;
     Control _control;
-    typename M::M::const_iterator _iterator;
+    M::M::const_iterator _iterator;
 
 public:
     ConstIterator() = default;
@@ -124,13 +123,13 @@ public:
         return ret;
     }
 
-    const typename M::M::value_type* operator->() const { return &operator*(); }
+    const M::value_type* operator->() const { return &operator*(); }
 
-    typename M::M::const_reference operator*() const {
+    M::M::const_reference operator*() const {
         auto&& data = _control.get();
 
         // Iterators to `end` cannot be dereferenced.
-        if ( _iterator == static_cast<const typename M::M&>(data).cend() )
+        if ( _iterator == static_cast<const M::M&>(data).cend() )
             throw IndexError("iterator is invalid");
 
         return *_iterator;
@@ -139,7 +138,7 @@ public:
 private:
     friend class Map<K, V>;
 
-    ConstIterator(typename M::M::const_iterator iterator, Control control)
+    ConstIterator(M::M::const_iterator iterator, Control control)
         : _control(std::move(control)), _iterator(std::move(iterator)) {}
 };
 
@@ -174,12 +173,12 @@ public:
     using Control = control::Block<Map<K, V>, InvalidIterator>;
     Control _control{this};
 
-    using key_type = typename M::key_type;
-    using value_type = typename M::value_type;
+    using key_type = M::key_type;
+    using value_type = M::value_type;
     using size_type = integer::safe<uint64_t>;
 
-    using iterator = typename map::Iterator<K, V>;
-    using const_iterator = typename map::ConstIterator<K, V>;
+    using iterator = map::Iterator<K, V>;
+    using const_iterator = map::ConstIterator<K, V>;
 
     Map() = default;
     Map(std::initializer_list<value_type> init) : M(std::move(init)) {}

--- a/hilti/runtime/include/types/optional.h
+++ b/hilti/runtime/include/types/optional.h
@@ -363,17 +363,16 @@ inline std::string detail::to_string_for_print<Optional<std::string_view>>(const
     return x ? std::string(*x) : "(not set)";
 }
 
-} // namespace hilti::rt
-
-namespace std {
-
 template<typename T>
 std::ostream& operator<<(std::ostream& out, const hilti::rt::Optional<T>& x) {
     return out << ::hilti::rt::to_string(x);
 }
 
+} // namespace hilti::rt
+
+namespace std {
 template<typename T>
-struct hash<hilti::rt::Optional<T>> {
+struct hash<hilti::rt::Optional<T>> { // NOLINT(bugprone-std-namespace-modification)
     size_t operator()(const hilti::rt::Optional<T>& opt) const noexcept {
         if ( opt.hasValue() )
             return std::hash<T>{}(opt.value());
@@ -381,5 +380,4 @@ struct hash<hilti::rt::Optional<T>> {
             return 0;
     }
 };
-
 } // namespace std

--- a/hilti/runtime/include/types/reference.h
+++ b/hilti/runtime/include/types/reference.h
@@ -415,6 +415,7 @@ public:
      *
      * @param t initialization value
      */
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     explicit StrongReference(T t) : Base(std::make_shared<T>(std::move(t))) {}
 
     /** Instantiate an unset reference. */

--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -34,20 +34,20 @@ template<typename T>
 class Iterator {
     using S = Set<T>;
 
-    using Control = typename S::Control::Ref;
+    using Control = S::Control::Ref;
     Control _control;
-    typename S::S::iterator _iterator;
+    S::S::iterator _iterator;
 
 public:
-    using iterator_category = typename S::S::iterator::iterator_category;
-    using value_type = typename S::S::value_type;
-    using difference_type = typename S::S::difference_type;
-    using pointer = typename S::S::pointer;
-    using reference = typename S::S::reference;
+    using iterator_category = S::S::iterator::iterator_category;
+    using value_type = S::S::value_type;
+    using difference_type = S::S::difference_type;
+    using pointer = S::S::pointer;
+    using reference = S::S::reference;
 
     Iterator() = default;
 
-    typename S::reference operator*() const {
+    S::reference operator*() const {
         // Iterators to `end` cannot be dereferenced.
         if ( _iterator == static_cast<const std::set<T>&>(_control.get()).end() )
             throw IndexError("iterator is invalid");
@@ -84,8 +84,7 @@ public:
 protected:
     friend class Set<T>;
 
-    Iterator(typename S::S::iterator iterator, Control control)
-        : _control(std::move(control)), _iterator(std::move(iterator)) {}
+    Iterator(S::S::iterator iterator, Control control) : _control(std::move(control)), _iterator(std::move(iterator)) {}
 };
 
 } // namespace set
@@ -122,8 +121,8 @@ public:
     using reference = const T&;
     using const_reference = const T&;
 
-    using iterator = typename set::Iterator<T>;
-    using const_iterator = typename set::Iterator<T>;
+    using iterator = set::Iterator<T>;
+    using const_iterator = set::Iterator<T>;
 
     using key_type = T;
     using value_type = T;

--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -196,7 +196,7 @@ public:
      * @param value value to insert
      * @return iterator pointing to the inserted element
      * */
-    iterator insert(iterator hint, const T& value) {
+    iterator insert(const iterator& hint, const T& value) {
         auto it = S::insert(hint._iterator, value);
         return iterator(it, _control);
     }

--- a/hilti/runtime/include/types/set.h
+++ b/hilti/runtime/include/types/set.h
@@ -157,7 +157,7 @@ public:
      * @param `t` the element to check for
      * @return `true` if the element is part of the set.
      */
-    bool contains(const T& t) const { return this->count(t); }
+    bool contains(const T& t) const { return S::contains(t); }
 
     auto begin() const { return iterator(static_cast<const S&>(*this).begin(), _control); }
 

--- a/hilti/runtime/include/types/tuple.h
+++ b/hilti/runtime/include/types/tuple.h
@@ -243,7 +243,7 @@ private:
     static auto _defaultStorage() {
         return Base{[]() {
             if constexpr ( tuple::detail::IsValueReference<Ts>::value ) {
-                using element_type = typename tuple::detail::IsValueReference<Ts>::element_type;
+                using element_type = tuple::detail::IsValueReference<Ts>::element_type;
                 return Ts(std::shared_ptr<element_type>(nullptr));
             }
             else

--- a/hilti/runtime/include/types/tuple.h
+++ b/hilti/runtime/include/types/tuple.h
@@ -112,7 +112,7 @@ private:
  * @tparam Ts types of the tuple elements
  **/
 template<typename... Ts>
-class Tuple : public TupleBase, protected std::tuple<Ts...> {
+class Tuple : public TupleBase, protected std::tuple<Ts...> { // NOLINT(misc-multiple-inheritance)
 public:
     using Base = std::tuple<Ts...>;
     static_assert(sizeof...(Ts) <= MaxElements, "tuples with more than 64 elements are not supported");

--- a/hilti/runtime/include/types/tuple.h
+++ b/hilti/runtime/include/types/tuple.h
@@ -396,22 +396,21 @@ inline std::string to_string(const Tuple<Ts...>& x, adl::tag /*unused*/) {
 }
 
 } // namespace detail::adl
-} // namespace hilti::rt
 
-namespace std {
 template<typename... Ts>
 inline std::ostream& operator<<(std::ostream& out, const hilti::rt::Tuple<Ts...>& x) {
     out << hilti::rt::to_string_for_print(x);
     return out;
 }
-
-} // namespace std
+} // namespace hilti::rt
 
 // Add support for structured binding for Tuple.
 template<typename... Ts>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_size<hilti::rt::Tuple<Ts...>> : std::integral_constant<std::size_t, sizeof...(Ts)> {};
 
 template<std::size_t I, typename... Ts>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_element<I, hilti::rt::Tuple<Ts...>> {
     using type = std::tuple_element_t<I, std::tuple<Ts...>>;
 };

--- a/hilti/runtime/include/types/vector.h
+++ b/hilti/runtime/include/types/vector.h
@@ -123,20 +123,20 @@ class Iterator {
     using V = Vector<T, Allocator>;
     friend V;
 
-    using Control = typename V::Control::Ref;
+    using Control = V::Control::Ref;
     Control _control;
-    typename V::size_type _index = 0;
+    V::size_type _index = 0;
 
 public:
-    using difference_type = typename V::V::iterator::difference_type;
-    using value_type = typename V::V::iterator::value_type;
-    using pointer = typename V::V::iterator::pointer;
-    using reference = typename V::V::iterator::reference;
-    using const_reference = typename V::V::const_reference;
-    using iterator_category = typename V::V::iterator::iterator_category;
+    using difference_type = V::V::iterator::difference_type;
+    using value_type = V::V::iterator::value_type;
+    using pointer = V::V::iterator::pointer;
+    using reference = V::V::iterator::reference;
+    using const_reference = V::V::const_reference;
+    using iterator_category = V::V::iterator::iterator_category;
 
     Iterator() = default;
-    Iterator(typename V::size_type&& index, Control control) : _control(std::move(control)), _index(std::move(index)) {}
+    Iterator(V::size_type&& index, Control control) : _control(std::move(control)), _index(std::move(index)) {}
 
     reference operator*();
     const_reference operator*() const;
@@ -195,21 +195,20 @@ template<typename T, typename Allocator>
 class ConstIterator {
     using V = Vector<T, Allocator>;
 
-    using Control = typename V::Control::Ref;
+    using Control = V::Control::Ref;
     Control _control;
-    typename V::size_type _index = 0;
+    V::size_type _index = 0;
 
 public:
-    using difference_type = typename V::V::const_iterator::difference_type;
-    using value_type = typename V::V::const_iterator::value_type;
-    using pointer = typename V::V::const_iterator::pointer;
-    using reference = typename V::V::const_iterator::reference;
-    using const_reference = typename V::V::const_iterator::reference;
-    using iterator_category = typename V::V::const_iterator::iterator_category;
+    using difference_type = V::V::const_iterator::difference_type;
+    using value_type = V::V::const_iterator::value_type;
+    using pointer = V::V::const_iterator::pointer;
+    using reference = V::V::const_iterator::reference;
+    using const_reference = V::V::const_iterator::reference;
+    using iterator_category = V::V::const_iterator::iterator_category;
 
     ConstIterator() = default;
-    ConstIterator(typename V::size_type&& index, Control control)
-        : _control(std::move(control)), _index(std::move(index)) {}
+    ConstIterator(V::size_type&& index, Control control) : _control(std::move(control)), _index(std::move(index)) {}
 
     const_reference operator*() const;
 
@@ -634,7 +633,7 @@ bool operator!=(const Vector<T, Allocator>& a, const Vector<T, Allocator>& b) {
 }
 
 template<typename T, typename Allocator>
-typename vector::Iterator<T, Allocator>::reference vector::Iterator<T, Allocator>::operator*() {
+vector::Iterator<T, Allocator>::reference vector::Iterator<T, Allocator>::operator*() {
     auto&& data = _control.get();
 
     if ( _index >= data.size() ) {
@@ -645,7 +644,7 @@ typename vector::Iterator<T, Allocator>::reference vector::Iterator<T, Allocator
 }
 
 template<typename T, typename Allocator>
-typename vector::Iterator<T, Allocator>::const_reference vector::Iterator<T, Allocator>::operator*() const {
+vector::Iterator<T, Allocator>::const_reference vector::Iterator<T, Allocator>::operator*() const {
     auto&& data = _control.get();
 
     if ( _index >= data.size() ) {
@@ -670,7 +669,7 @@ inline std::ostream& operator<<(std::ostream& out, const vector::ConstIterator<T
 } // namespace vector
 
 template<typename T, typename Allocator>
-typename vector::ConstIterator<T, Allocator>::const_reference vector::ConstIterator<T, Allocator>::operator*() const {
+vector::ConstIterator<T, Allocator>::const_reference vector::ConstIterator<T, Allocator>::operator*() const {
     auto&& data = _control.get();
 
     if ( _index >= data.size() ) {

--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -415,7 +415,7 @@ struct is_Vector<Vector<T, Allocator>> : std::true_type {};
  * container of the same type class as `C` but with element type `Y`. */
 template<typename C, typename Y>
 constexpr auto transform_result_value(const C&) {
-    using X = typename C::value_type;
+    using X = C::value_type;
 
     if constexpr ( std::is_same_v<C, std::vector<X>> ) {
         return std::vector<Y>();

--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -563,6 +563,7 @@ inline I1 pow(I1 base, I2 exp) {
 namespace detail {
 template<typename T, typename F, std::size_t... Is>
 constexpr auto map_tuple(T&& tup, F& f, std::index_sequence<Is...> /*unused*/) {
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     return std::make_tuple(f(std::get<Is>(std::forward<T>(tup)))...);
 }
 } // namespace detail

--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -59,7 +59,7 @@ static const auto FiberGuardFlags = 0; // leak sanitizer may abort with "Tracer 
 // Pre-allocate this so that we don't need to create a std::string on the fly
 // when HILTI_RT_FIBER_DEBUG executes. That avoids a false positive with
 // ASAN during fiber switching when using GCC/libc++.
-static const std::string debug_stream_fibers = "fibers";
+static const std::string_view debug_stream_fibers = "fibers";
 
 // Wrapper similar to HILTI_RT_DEBUG that adds the current fiber to the message.
 #define HILTI_RT_FIBER_DEBUG(tag, msg)                                                                                 \

--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -351,7 +351,9 @@ detail::Fiber::Fiber(Type type) : _type(type), _fiber(std::make_unique<::Fiber>(
 // in the meantime. This must not be derived from `std::exception` to guarantee
 // that it will bubble back up to the fiber code, without being caught by any
 // intermediary catch handlers.
+namespace {
 struct AbortException {};
+} // namespace
 
 detail::Fiber::~Fiber() {
 #ifndef NDEBUG

--- a/hilti/runtime/src/tests/.clang-tidy
+++ b/hilti/runtime/src/tests/.clang-tidy
@@ -1,6 +1,8 @@
 # Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
 
 ---
+InheritParentConfig:          true
+
 Checks: '
   -clang-analyzer-optin.core.EnumCastOutOfRange,
   -modernize-type-traits,

--- a/hilti/runtime/src/tests/address.cc
+++ b/hilti/runtime/src/tests/address.cc
@@ -16,7 +16,7 @@ using namespace hilti::rt::bytes::literals;
 
 namespace hilti::rt {
 template<typename T>
-std::ostream& operator<<(std::ostream& out, const Result<T>& x) {
+static std::ostream& operator<<(std::ostream& out, const Result<T>& x) {
     if ( x.hasValue() )
         return out << fmt("Ok(%s)", *x);
     else
@@ -24,9 +24,9 @@ std::ostream& operator<<(std::ostream& out, const Result<T>& x) {
 }
 } // namespace hilti::rt
 
-std::ostream& operator<<(std::ostream& out, const in_addr& addr) { return out << Address(addr); }
+static std::ostream& operator<<(std::ostream& out, const in_addr& addr) { return out << Address(addr); }
 
-std::ostream& operator<<(std::ostream& out, const in6_addr& addr) { return out << Address(addr); }
+static std::ostream& operator<<(std::ostream& out, const in6_addr& addr) { return out << Address(addr); }
 
 static auto make_in6_addr(const char* d) {
     auto addr = std::make_unique<::in6_addr>();

--- a/hilti/runtime/src/tests/backtrace.cc
+++ b/hilti/runtime/src/tests/backtrace.cc
@@ -24,6 +24,7 @@ TEST_CASE("backtrace") {
 #endif
 }
 
+namespace {
 // Helper function to create a backtrace with one more frame as the caller.
 //
 // NOTE: Some compilers remove this function even if `noinline` is given via
@@ -35,6 +36,7 @@ HILTI_NOINLINE __attribute__((optimize(0))) auto make_backtrace() { return Backt
 #else
 HILTI_NOINLINE auto make_backtrace() { return Backtrace(); }
 #endif
+} // namespace
 
 TEST_CASE("comparison") {
     const auto bt1 = Backtrace();      // Backtrace to this call site.

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -536,9 +536,9 @@ TEST_CASE("toReal") {
         std::string old_locale(saved ? saved : "C");
 
 #ifdef _WIN32
-        auto de_locale = "de-DE";
+        const auto* de_locale = "de-DE";
 #else
-        auto de_locale = "de_DE.UTF-8";
+        const auto* de_locale = "de_DE.UTF-8";
 #endif
 
         if ( ! std::setlocale(LC_ALL, de_locale) )

--- a/hilti/runtime/src/tests/bytes.cc
+++ b/hilti/runtime/src/tests/bytes.cc
@@ -78,12 +78,6 @@ TEST_CASE("decode") {
     CHECK_EQ(Bytes("\0a\0b\0"s).decode(unicode::Charset::UTF16BE, unicode::DecodeErrorStrategy::REPLACE),
              "ab\ufffd"_hs);
 
-    // Our UTF16 implementation seems to differ in what it considers invalid encodings, e.g., `\x00\xd8` is rejected by
-    // python-3.1[1-3], but accepted by us.
-    //
-    // TODO(bbannier): Test rejection of invalid UTF16 (but with even length).
-    CHECK_EQ(Bytes("\x00\xd8").decode(unicode::Charset::UTF16LE, unicode::DecodeErrorStrategy::STRICT), ""_hs);
-
     CHECK_THROWS_WITH_AS("123"_b.decode(unicode::Charset::Undef),
                          "unknown character set for decoding",
                          const RuntimeError&);

--- a/hilti/runtime/src/tests/context.cc
+++ b/hilti/runtime/src/tests/context.cc
@@ -21,7 +21,7 @@ TEST_CASE("cookie") {
 
     CHECK_EQ(context::cookie(), nullptr);
 
-    void* const cookie = reinterpret_cast<void*>(std::uintptr_t(0xDEADBEEF));
+    void* const cookie = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0xDEADBEEF));
 
     context.cookie = cookie;
     CHECK_EQ(context::cookie(), cookie);
@@ -40,7 +40,7 @@ TEST_CASE("CookieSetter") {
     REQUIRE_EQ(context::cookie(), nullptr);
 
     {
-        void* const cookie = reinterpret_cast<void*>(std::uintptr_t(0xDEADBEEF));
+        void* const cookie = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0xDEADBEEF));
         context::CookieSetter _(cookie);
         CHECK_EQ(context::cookie(), cookie);
     }

--- a/hilti/runtime/src/tests/context.cc
+++ b/hilti/runtime/src/tests/context.cc
@@ -21,6 +21,7 @@ TEST_CASE("cookie") {
 
     CHECK_EQ(context::cookie(), nullptr);
 
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
     void* const cookie = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0xDEADBEEF));
 
     context.cookie = cookie;
@@ -40,6 +41,7 @@ TEST_CASE("CookieSetter") {
     REQUIRE_EQ(context::cookie(), nullptr);
 
     {
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
         void* const cookie = reinterpret_cast<void*>(static_cast<std::uintptr_t>(0xDEADBEEF));
         context::CookieSetter _(cookie);
         CHECK_EQ(context::cookie(), cookie);

--- a/hilti/runtime/src/tests/debug-logger.cc
+++ b/hilti/runtime/src/tests/debug-logger.cc
@@ -16,7 +16,7 @@ using namespace hilti::rt;
 using namespace hilti::rt::test;
 
 namespace std {
-ostream& operator<<(ostream& stream, const std::vector<std::string>& xs) {
+static ostream& operator<<(ostream& stream, const std::vector<std::string>& xs) {
     return stream << "[" << join(xs, ", ") << "]";
 }
 } // namespace std

--- a/hilti/runtime/src/tests/debug-logger.cc
+++ b/hilti/runtime/src/tests/debug-logger.cc
@@ -15,12 +15,6 @@
 using namespace hilti::rt;
 using namespace hilti::rt::test;
 
-namespace std {
-static ostream& operator<<(ostream& stream, const std::vector<std::string>& xs) {
-    return stream << "[" << join(xs, ", ") << "]";
-}
-} // namespace std
-
 TEST_SUITE_BEGIN("DebugLogger");
 
 TEST_CASE("enable") {

--- a/hilti/runtime/src/tests/enum.cc
+++ b/hilti/runtime/src/tests/enum.cc
@@ -10,6 +10,7 @@ using namespace hilti::rt;
 
 TEST_SUITE_BEGIN("Enum");
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 HILTI_RT_ENUM(X, A1 = 1, A2 = 2, A3 = -2);
 
 TEST_CASE("from_int") {

--- a/hilti/runtime/src/tests/exception.cc
+++ b/hilti/runtime/src/tests/exception.cc
@@ -16,6 +16,7 @@ using namespace hilti::rt;
 
 TEST_SUITE_BEGIN("Exception");
 
+namespace {
 // RAII helper to set a context with a location in tests.
 class TestLocation {
 public:
@@ -36,6 +37,7 @@ private:
     Context* _prev = nullptr;
     Context _current = Context(0);
 };
+} // namespace
 
 TEST_CASE("construct") {
     exception::DisableAbortOnExceptions _;

--- a/hilti/runtime/src/tests/fiber.cc
+++ b/hilti/runtime/src/tests/fiber.cc
@@ -311,7 +311,7 @@ TEST_CASE("copy-arg") {
     CHECK_EQ(std::get<1>(*args_on_heap)->str(), s2->str());
 }
 
-void X() {}
+static void X() {}
 
 static int fibo(int i) {
     hilti::rt::detail::checkStack(); // this will eventually throw
@@ -330,7 +330,7 @@ static int fibo(int i) {
     return x;
 }
 
-bool isMacosAsan() {
+static bool isMacosAsan() {
 #if defined(HILTI_HAVE_ASAN) && defined(__APPLE__)
     return true;
 #else

--- a/hilti/runtime/src/tests/hilti.cc
+++ b/hilti/runtime/src/tests/hilti.cc
@@ -14,6 +14,7 @@
 using namespace hilti::rt;
 using namespace hilti::rt::bytes::literals;
 
+namespace {
 // RAII helper to set the global `Configuration`'s `cout` stream.
 class TestCout {
 public:
@@ -30,6 +31,7 @@ private:
     std::stringstream _cout;
     std::unique_ptr<Configuration> _prev;
 };
+} // namespace
 
 TEST_SUITE_BEGIN("hilti");
 

--- a/hilti/runtime/src/tests/integer.cc
+++ b/hilti/runtime/src/tests/integer.cc
@@ -202,9 +202,15 @@ TEST_CASE("unpack") {
     using Result64 = Result<Tuple<integer::safe<uint64_t>, Bytes>>;
 
     // TODO: Can we make this nicer, ideally without the lambdas?
-    static auto make_result16 = [](integer::safe<uint16_t> i, Bytes b) -> Result16 { return tuple::make(i, b); };
-    static auto make_result32 = [](integer::safe<uint32_t> i, Bytes b) -> Result32 { return tuple::make(i, b); };
-    static auto make_result64 = [](integer::safe<uint64_t> i, Bytes b) -> Result64 { return tuple::make(i, b); };
+    static auto make_result16 = [](integer::safe<uint16_t> i, Bytes b) -> Result16 {
+        return tuple::make(i, std::move(b));
+    };
+    static auto make_result32 = [](integer::safe<uint32_t> i, Bytes b) -> Result32 {
+        return tuple::make(i, std::move(b));
+    };
+    static auto make_result64 = [](integer::safe<uint64_t> i, Bytes b) -> Result64 {
+        return tuple::make(i, std::move(b));
+    };
 
     CHECK_EQ(integer::unpack<uint16_t>(""_b, ByteOrder::Little),
              Result16(result::Error("insufficient data to unpack integer")));

--- a/hilti/runtime/src/tests/integer.cc
+++ b/hilti/runtime/src/tests/integer.cc
@@ -17,7 +17,7 @@ using namespace hilti::rt;
 using namespace hilti::rt::bytes::literals;
 
 template<typename T>
-std::ostream& operator<<(std::ostream& stream, const Result<T>& x) {
+static std::ostream& operator<<(std::ostream& stream, const Result<T>& x) {
     if ( x.hasValue() )
         return stream << "Ok(" << *x << ')';
     else

--- a/hilti/runtime/src/tests/integer.cc
+++ b/hilti/runtime/src/tests/integer.cc
@@ -35,12 +35,12 @@ TEST_CASE("flip16") {
     const auto max = std::numeric_limits<uint16_t>::max();
 
     // NOLINTNEXTLINE(bugprone-integer-division)
-    CHECK_EQ(integer::flip16(max / 2), std::pow(256, 2) - 256 / 2 - 1);
+    CHECK_EQ(integer::flip16(max / 2), std::pow(256, 2) - (256 / 2) - 1);
 
-    CHECK_EQ(integer::flip16(max - 3), std::pow(256, 2) - 256 * 3 - 1);
-    CHECK_EQ(integer::flip16(max - 2), std::pow(256, 2) - 256 * 2 - 1);
-    CHECK_EQ(integer::flip16(max - 1), std::pow(256, 2) - 256 * 1 - 1);
-    CHECK_EQ(integer::flip16(max - 0), std::pow(256, 2) - 256 * 0 - 1);
+    CHECK_EQ(integer::flip16(max - 3), std::pow(256, 2) - (256 * 3) - 1);
+    CHECK_EQ(integer::flip16(max - 2), std::pow(256, 2) - (256 * 2) - 1);
+    CHECK_EQ(integer::flip16(max - 1), std::pow(256, 2) - (256 * 1) - 1);
+    CHECK_EQ(integer::flip16(max - 0), std::pow(256, 2) - (256 * 0) - 1);
 }
 
 TEST_CASE("flip32") {
@@ -52,12 +52,12 @@ TEST_CASE("flip32") {
     const auto max = std::numeric_limits<uint32_t>::max();
 
     // NOLINTNEXTLINE(bugprone-integer-division)
-    CHECK_EQ(integer::flip32(max / 2), std::pow(static_cast<uint64_t>(256), 4) - 256 / 2 - 1);
+    CHECK_EQ(integer::flip32(max / 2), std::pow(static_cast<uint64_t>(256), 4) - (256 / 2) - 1);
 
-    CHECK_EQ(integer::flip32(max - 3), std::pow(static_cast<uint64_t>(256), 4) - std::pow(256, 3) * 3 - 1);
-    CHECK_EQ(integer::flip32(max - 2), std::pow(static_cast<uint64_t>(256), 4) - std::pow(256, 3) * 2 - 1);
-    CHECK_EQ(integer::flip32(max - 1), std::pow(static_cast<uint64_t>(256), 4) - std::pow(256, 3) * 1 - 1);
-    CHECK_EQ(integer::flip32(max - 0), std::pow(static_cast<uint64_t>(256), 4) - std::pow(256, 3) * 0 - 1);
+    CHECK_EQ(integer::flip32(max - 3), std::pow(static_cast<uint64_t>(256), 4) - (std::pow(256, 3) * 3) - 1);
+    CHECK_EQ(integer::flip32(max - 2), std::pow(static_cast<uint64_t>(256), 4) - (std::pow(256, 3) * 2) - 1);
+    CHECK_EQ(integer::flip32(max - 1), std::pow(static_cast<uint64_t>(256), 4) - (std::pow(256, 3) * 1) - 1);
+    CHECK_EQ(integer::flip32(max - 0), std::pow(static_cast<uint64_t>(256), 4) - (std::pow(256, 3) * 0) - 1);
 }
 
 TEST_CASE("flip64") {

--- a/hilti/runtime/src/tests/intrusive-ptr.cc
+++ b/hilti/runtime/src/tests/intrusive-ptr.cc
@@ -23,6 +23,7 @@ using namespace hilti::rt;
 
 TEST_SUITE_BEGIN("IntrusivePtr");
 
+namespace {
 class Managed : public intrusive_ptr::ManagedObject {
 public:
     Managed() { ++instances; }
@@ -31,6 +32,7 @@ public:
 };
 
 using ManagedPtr = IntrusivePtr<Managed>;
+} // namespace
 
 TEST_CASE("managed objects") {
     CHECK_EQ(Managed::instances, 0);
@@ -48,6 +50,7 @@ TEST_CASE("managed objects") {
     CHECK_EQ(Managed::instances, 0);
 }
 
+namespace {
 struct TestObject : intrusive_ptr::ManagedObject {
     static uint64_t instances;
     TestObject() { ++instances; }
@@ -63,6 +66,7 @@ uint64_t TestObject::instances = 0;
 struct TestObject2 : TestObject {
     using TestObject::TestObject;
 };
+} // namespace
 
 TEST_CASE("ManagedObject") {
     SUBCASE("valid object") {

--- a/hilti/runtime/src/tests/library.cc
+++ b/hilti/runtime/src/tests/library.cc
@@ -61,6 +61,7 @@ const hilti::rt::filesystem::path dummy2 =
     config::lib_directory /
     (config::shared_library_prefix + "hilti-rt-tests-library-dummy2" + config::shared_library_suffix);
 
+namespace {
 // RAII helper to set an environment variable.
 class Env {
 public:
@@ -88,6 +89,7 @@ public:
 private:
     std::pair<std::string, std::optional<std::string>> _prev;
 };
+} // namespace
 
 TEST_SUITE_BEGIN("Library");
 

--- a/hilti/runtime/src/tests/library.cc
+++ b/hilti/runtime/src/tests/library.cc
@@ -135,7 +135,7 @@ TEST_CASE("save" * doctest::skip(is_elevated_user())) {
 
     SUBCASE("success") {
         hilti::rt::TemporaryDirectory tmp;
-        Env _("TMPDIR", tmp.path().string().c_str());
+        Env _("TMPDIR", tmp.path().string());
         CHECK_EQ(library.save(tmp.path()), Nothing());
 
         SUBCASE("overwrite existing") { CHECK_EQ(library.save(tmp.path()), Nothing()); }

--- a/hilti/runtime/src/tests/library.cc
+++ b/hilti/runtime/src/tests/library.cc
@@ -65,7 +65,7 @@ namespace {
 // RAII helper to set an environment variable.
 class Env {
 public:
-    Env(std::string k, const std::string_view& v) {
+    Env(const std::string& k, const std::string& v) {
         if ( auto* prev = ::getenv(k.data()) )
             _prev = {k, prev};
         else

--- a/hilti/runtime/src/tests/logging.cc
+++ b/hilti/runtime/src/tests/logging.cc
@@ -18,6 +18,7 @@ using namespace hilti::rt::test;
 
 TEST_SUITE_BEGIN("Logging");
 
+namespace {
 // RAII helper to maintain global debug logger.
 class TestLogger {
 public:
@@ -34,6 +35,7 @@ private:
     TemporaryFile _file;
     std::unique_ptr<detail::DebugLogger> _prev;
 };
+} // namespace
 
 TEST_CASE("debug::isEnabled") {
     TestLogger log;

--- a/hilti/runtime/src/tests/main.cc
+++ b/hilti/runtime/src/tests/main.cc
@@ -5,9 +5,11 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+namespace {
 struct RuntimeWrapper {
     ~RuntimeWrapper() { hilti::rt::done(); }
 };
+} // namespace
 
 int main(int argc, char** argv) {
     doctest::Context context;

--- a/hilti/runtime/src/tests/optional.cc
+++ b/hilti/runtime/src/tests/optional.cc
@@ -58,7 +58,7 @@ TEST_CASE("tryValue") {
     CHECK_EQ(Optional<int8_t>(42).tryValue(), 42);
 }
 
-Optional<std::string> foo(Optional<std::string> s) { return s; }
+static Optional<std::string> foo(Optional<std::string> s) { return s; }
 
 TEST_CASE("null") {
     Optional<int8_t> x;

--- a/hilti/runtime/src/tests/real.cc
+++ b/hilti/runtime/src/tests/real.cc
@@ -12,15 +12,15 @@
 using namespace hilti::rt;
 using namespace hilti::rt::bytes::literals;
 
-namespace std {
+namespace hilti::rt {
 template<typename T>
-static ostream& operator<<(ostream& stream, const Result<T>& x) {
+static std::ostream& operator<<(std::ostream& stream, const Result<T>& x) {
     if ( x.hasValue() )
         return stream << fmt("Ok(%s)", x.value());
     else
         return stream << fmt("Error(%s)", x.error());
 }
-} // namespace std
+} // namespace hilti::rt
 
 TEST_SUITE_BEGIN("real");
 

--- a/hilti/runtime/src/tests/real.cc
+++ b/hilti/runtime/src/tests/real.cc
@@ -14,7 +14,7 @@ using namespace hilti::rt::bytes::literals;
 
 namespace std {
 template<typename T>
-ostream& operator<<(ostream& stream, const Result<T>& x) {
+static ostream& operator<<(ostream& stream, const Result<T>& x) {
     if ( x.hasValue() )
         return stream << fmt("Ok(%s)", x.value());
     else

--- a/hilti/runtime/src/tests/reference.cc
+++ b/hilti/runtime/src/tests/reference.cc
@@ -19,6 +19,7 @@ using namespace hilti::rt;
 using namespace bytes::literals;
 using namespace string::literals;
 
+namespace {
 struct T : public hilti::rt::trait::isStruct, hilti::rt::Controllable<T> {
     /*implicit*/ T(int x = 0) : _x(x) {}
     int _x;
@@ -32,6 +33,7 @@ struct T : public hilti::rt::trait::isStruct, hilti::rt::Controllable<T> {
 
     friend bool operator==(const T& a, const T& b) { return a._x == b._x; }
 };
+} // namespace
 
 TEST_SUITE_BEGIN("ValueReference");
 
@@ -204,6 +206,8 @@ TEST_CASE("self") {
     CHECK_THROWS_WITH_AS(WeakReference<T>{self}, "reference to non-heap instance", const IllegalReference&);
 }
 
+namespace {
+
 struct Foo;
 
 struct Test : hilti::rt::Controllable<Test> {
@@ -213,6 +217,8 @@ struct Test : hilti::rt::Controllable<Test> {
 struct Foo : hilti::rt::Controllable<Foo> {
     hilti::rt::WeakReference<Test> t;
 };
+
+} // namespace
 
 TEST_CASE("cyclic") {
     hilti::rt::ValueReference<Test> test;

--- a/hilti/runtime/src/tests/regexp.cc
+++ b/hilti/runtime/src/tests/regexp.cc
@@ -16,7 +16,9 @@ using namespace hilti::rt::bytes::literals;
 
 TEST_SUITE_BEGIN("RegExp");
 
-inline auto operator""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
+static inline auto operator""_p(const char* str, size_t size) {
+    return hilti::rt::regexp::Pattern(std::string(str, size));
+}
 
 TEST_CASE("match") {
     SUBCASE("min-matcher") {

--- a/hilti/runtime/src/tests/stream.cc
+++ b/hilti/runtime/src/tests/stream.cc
@@ -16,7 +16,7 @@ using hilti::rt::to_string;
 
 TEST_SUITE_BEGIN("Stream");
 
-auto make_stream(std::initializer_list<Bytes> xs) {
+static auto make_stream(std::initializer_list<Bytes> xs) {
     Stream s;
     for ( auto&& x : xs )
         s.append(x);
@@ -912,7 +912,7 @@ TEST_CASE("to_string") {
 }
 
 template<typename T, int N>
-std::vector<T> vec(T (&xs)[N]) {
+static std::vector<T> vec(T (&xs)[N]) {
     std::vector<T> ys;
     ys.assign(xs, xs + N);
     return ys;

--- a/hilti/runtime/src/tests/struct.cc
+++ b/hilti/runtime/src/tests/struct.cc
@@ -23,6 +23,7 @@ TEST_CASE("value_or_exception") {
     debug::setLocation(nullptr);
 }
 
+namespace {
 struct Test : trait::isStruct {
     Test(int x) : _x(x), _y(x + 1) {}
 
@@ -37,7 +38,6 @@ struct Test : trait::isStruct {
     int _y;
 };
 
-namespace {
 struct TestWithCustomStr : public Test {
     using Test::Test;
     std::optional<std::string> HILTI_INTERNAL(hook_to_string)() { return HILTI_INTERNAL_ID("hook_to_string"); }

--- a/hilti/runtime/src/tests/struct.cc
+++ b/hilti/runtime/src/tests/struct.cc
@@ -37,10 +37,12 @@ struct Test : trait::isStruct {
     int _y;
 };
 
+namespace {
 struct TestWithCustomStr : public Test {
     using Test::Test;
     std::optional<std::string> HILTI_INTERNAL(hook_to_string)() { return HILTI_INTERNAL_ID("hook_to_string"); }
 };
+} // namespace
 
 TEST_CASE("to_string") { CHECK_EQ(to_string(Test(42)), "[$_x=42, $_y=43]"); }
 TEST_CASE("to_string_custom") { CHECK_EQ(to_string(TestWithCustomStr(42)), HILTI_INTERNAL_ID("hook_to_string")); }

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -27,8 +27,6 @@
 
 using namespace hilti::rt;
 
-inline auto operator""_p(const char* str, size_t size) { return hilti::rt::regexp::Pattern(std::string(str, size)); }
-
 TEST_SUITE_BEGIN("to_string");
 
 TEST_CASE("any") { CHECK_EQ(to_string(hilti::rt::any()), "<any value>"); }

--- a/hilti/runtime/src/tests/tuple.cc
+++ b/hilti/runtime/src/tests/tuple.cc
@@ -10,6 +10,7 @@
 using namespace hilti::rt;
 using namespace hilti::rt::bytes::literals;
 
+namespace {
 // RAII helper to set the global `Configuration`'s `cout` stream.
 class TestCout {
 public:
@@ -26,6 +27,7 @@ private:
     std::stringstream _cout;
     std::unique_ptr<Configuration> _prev;
 };
+} // namespace
 
 TEST_SUITE_BEGIN("Tuple");
 

--- a/hilti/runtime/src/tests/type-info.cc
+++ b/hilti/runtime/src/tests/type-info.cc
@@ -244,7 +244,7 @@ TEST_CASE("no-emit fields") {
     CHECK(! s->fields()[0].get().isEmitted());
 
     // We shouldn't see this field when iterating.
-    int count =
+    auto count =
         std::ranges::distance(hilti::rt::type_info::value::auxType<hilti::rt::type_info::Struct>(v)->iterate(v));
     CHECK_EQ(count, 0);
 }

--- a/hilti/runtime/src/tests/type-info.cc
+++ b/hilti/runtime/src/tests/type-info.cc
@@ -88,7 +88,7 @@ const hilti::rt::TypeInfo __ti_Test_Y = {"Test::Y",
 TEST_CASE("traverse structs") {
     // Check that we can traverse the structs and get expected values.
 
-    auto sx = StrongReference<Test::X>({42, "foo", Test::Y{true, 3.14}});
+    auto sx = StrongReference<Test::X>({.i = 42, .s = "foo", .y = Test::Y{.b = true, .r = 3.14}});
     auto p = hilti::rt::type_info::value::Parent(sx);
     auto v = hilti::rt::type_info::Value(&*sx, &HILTI_INTERNAL_NS::type_info::__ti_Test_X, p);
 
@@ -123,9 +123,9 @@ TEST_CASE("traverse structs") {
 TEST_CASE("life-time") {
     // Check that we catch when values become inaccessible because of the
     // associated parent going away.
-    Test::Y y{true, 3.14};
+    Test::Y y{.b = true, .r = 3.14};
 
-    auto x = StrongReference<Test::X>({42, "foo", y});
+    auto x = StrongReference<Test::X>({.i = 42, .s = "foo", .y = y});
     auto p = hilti::rt::type_info::value::Parent(x);
     auto v = hilti::rt::type_info::Value(&*x, &HILTI_INTERNAL_NS::type_info::__ti_Test_X, p);
 
@@ -139,9 +139,9 @@ TEST_CASE("life-time") {
 }
 
 TEST_CASE("no parent") {
-    Test::Y y{true, 3.14};
+    Test::Y y{.b = true, .r = 3.14};
 
-    auto x = StrongReference<Test::X>({42, "foo", y});
+    auto x = StrongReference<Test::X>({.i = 42, .s = "foo", .y = y});
     auto p = hilti::rt::type_info::value::Parent(x);
     auto v = hilti::rt::type_info::Value(&*x, &HILTI_INTERNAL_NS::type_info::__ti_Test_X); // no parent
 

--- a/hilti/runtime/src/tests/type-info.cc
+++ b/hilti/runtime/src/tests/type-info.cc
@@ -34,6 +34,7 @@ extern const hilti::rt::TypeInfo __ti_Test_Y;
 } // namespace
 } // namespace HILTI_INTERNAL_NS::type_info
 
+namespace {
 namespace Test {
 
 // Reduced declaration of the struct types, trusting that ours will match the
@@ -49,6 +50,7 @@ struct X {
     Y y;
 };
 } // namespace Test
+} // namespace
 
 // Copied from output of hiltic.
 namespace HILTI_INTERNAL_NS::type_info {

--- a/hilti/runtime/src/tests/union.cc
+++ b/hilti/runtime/src/tests/union.cc
@@ -103,6 +103,7 @@ TEST_CASE("index") {
     CHECK_EQ(Union<int, String>("abc"_hs).index(), 2U);
 }
 
+namespace {
 struct TestUnion : Union<int, String> {
     TestUnion() = default;
 
@@ -119,6 +120,7 @@ struct TestUnion : Union<int, String> {
             return "<unset>";
     }
 };
+} // namespace
 
 TEST_CASE("to_string") {
     CHECK_EQ(to_string(TestUnion()), "<unset>");

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -27,7 +27,7 @@ using namespace hilti::rt;
 using namespace hilti::rt::string::literals;
 
 namespace std {
-ostream& operator<<(ostream& stream, const vector<string_view>& xs) {
+static ostream& operator<<(ostream& stream, const vector<string_view>& xs) {
     stream << '[';
 
     for ( size_t i = 0; i < xs.size(); ++i ) {
@@ -41,7 +41,7 @@ ostream& operator<<(ostream& stream, const vector<string_view>& xs) {
 }
 
 template<typename U, typename V>
-ostream& operator<<(ostream& stream, const pair<U, V>& p) {
+static ostream& operator<<(ostream& stream, const pair<U, V>& p) {
     return stream << "(" << p.first << ", " << p.second << ")";
 }
 
@@ -50,7 +50,7 @@ ostream& operator<<(ostream& stream, const pair<U, V>& p) {
 TEST_SUITE_BEGIN("util");
 
 template<typename T>
-T atoi_n_(const std::string_view& input, int base, unsigned num_parsed) {
+static T atoi_n_(const std::string_view& input, int base, unsigned num_parsed) {
     CAPTURE(input);
     CAPTURE(base);
 

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -27,24 +27,11 @@ using namespace hilti::rt;
 using namespace hilti::rt::string::literals;
 
 namespace std {
-static ostream& operator<<(ostream& stream, const vector<string_view>& xs) {
-    stream << '[';
-
-    for ( size_t i = 0; i < xs.size(); ++i ) {
-        stream << xs[i];
-
-        if ( i != xs.size() - 1 )
-            stream << ", ";
-    }
-
-    return stream << ']';
-}
-
 template<typename U, typename V>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 static ostream& operator<<(ostream& stream, const pair<U, V>& p) {
     return stream << "(" << p.first << ", " << p.second << ")";
 }
-
 } // namespace std
 
 TEST_SUITE_BEGIN("util");

--- a/hilti/runtime/src/tests/util.cc
+++ b/hilti/runtime/src/tests/util.cc
@@ -67,7 +67,7 @@ TEST_CASE("atoi_n") {
 
         SUBCASE("invalid chars") {
             std::string_view s = "abc";
-            const auto it = atoi_n(s.data(), s.data() + s.size(), 10, &x);
+            const auto* it = atoi_n(s.data(), s.data() + s.size(), 10, &x);
             CHECK_EQ(it, s.data());
         }
 

--- a/hilti/runtime/src/types/bytes.cc
+++ b/hilti/runtime/src/types/bytes.cc
@@ -271,7 +271,7 @@ integer::safe<int64_t> Bytes::toInt(ByteOrder byte_order) const {
     auto i = toUInt(byte_order).Ref(); // throws on size == 0 or size > 8
     auto size_ = static_cast<uint64_t>(size());
 
-    if ( i & (UINT64_C(1) << (size_ * 8 - 1)) ) {
+    if ( i & (UINT64_C(1) << ((size_ * 8) - 1)) ) {
         if ( size() == 8 )
             return static_cast<int64_t>(-(~i + 1));
 

--- a/hilti/toolchain/include/ast/ast-context.h
+++ b/hilti/toolchain/include/ast/ast-context.h
@@ -570,7 +570,7 @@ protected:
 
 namespace std {
 template<char Prefix>
-struct hash<hilti::ast::detail::ContextIndex<Prefix>> {
+struct hash<hilti::ast::detail::ContextIndex<Prefix>> { // NOLINT(bugprone-std-namespace-modification)
     size_t operator()(hilti::ast::detail::ContextIndex<Prefix> x) const { return x.value().Ref(); }
 };
 } // namespace std

--- a/hilti/toolchain/include/ast/ctors/struct.h
+++ b/hilti/toolchain/include/ast/ctors/struct.h
@@ -43,7 +43,7 @@ using Fields = NodeVector<Field>;
 } // namespace struct_
 
 /** AST node for a `struct` ctor. */
-class Struct : public Ctor, public node::WithUniqueID {
+class Struct : public Ctor, public node::WithUniqueID { // NOLINT(misc-multiple-inheritance)
 public:
     auto stype() const { return type()->type()->as<type::Struct>(); }
 

--- a/hilti/toolchain/include/ast/declaration.h
+++ b/hilti/toolchain/include/ast/declaration.h
@@ -50,7 +50,7 @@ constexpr auto from_string(std::string_view s) { return util::enum_::from_string
 } // namespace declaration
 
 /** Base class for implementing declaration nodes. */
-class Declaration : public Node, public node::WithDocString {
+class Declaration : public Node, public node::WithDocString { // NOLINT(misc-multiple-inheritance)
 public:
     ~Declaration() override;
 

--- a/hilti/toolchain/include/ast/node-range.h
+++ b/hilti/toolchain/include/ast/node-range.h
@@ -93,11 +93,10 @@ class Range {
 public:
     using iterator = RangeIterator<T>;
     using const_iterator = RangeIterator<T>;
-    using value_type = typename iterator::value_type;
+    using value_type = iterator::value_type;
 
     explicit Range() {}
-    Range(typename NodeVector<T>::const_iterator begin, typename NodeVector<T>::const_iterator end)
-        : _begin(begin), _end(end) {}
+    Range(NodeVector<T>::const_iterator begin, NodeVector<T>::const_iterator end) : _begin(begin), _end(end) {}
 
     explicit Range(const NodeVector<T>& nodes) : Range(nodes.begin(), nodes.end()) {}
 

--- a/hilti/toolchain/include/ast/node.h
+++ b/hilti/toolchain/include/ast/node.h
@@ -1281,6 +1281,6 @@ inline hilti::node::Properties operator+(hilti::node::Properties p1, hilti::node
 }
 
 template<typename T>
-struct std::hash<hilti::node::RetainedPtr<T>> {
+struct std::hash<hilti::node::RetainedPtr<T>> { // NOLINT(bugprone-std-namespace-modification)
     size_t operator()(const hilti::node::RetainedPtr<T>& p) const { return std::hash<T*>()(p.get()); }
 };

--- a/hilti/toolchain/include/ast/types/bitfield.h
+++ b/hilti/toolchain/include/ast/types/bitfield.h
@@ -136,7 +136,7 @@ using BitRanges = NodeVector<BitRange>;
 } // namespace bitfield
 
 /** AST node for a `bitfield` type. */
-class Bitfield : public UnqualifiedType, public node::WithUniqueID {
+class Bitfield : public UnqualifiedType, public node::WithUniqueID { // NOLINT(misc-multiple-inheritance)
 public:
     auto width() const { return _width; }
     auto attributes() const { return child<AttributeSet>(0); }

--- a/hilti/toolchain/include/ast/visitor.h
+++ b/hilti/toolchain/include/ast/visitor.h
@@ -145,7 +145,7 @@ template<Order order>
 class Range {
 public:
     using iterator_t = Iterator<order>;
-    using value_type = typename Iterator<order>::value_type;
+    using value_type = Iterator<order>::value_type;
     Range(Node* root, std::string_view limit_to_tag) : _root(root), _limit_to_tag(limit_to_tag) {}
 
     auto begin(bool include_empty = false) {

--- a/hilti/toolchain/include/ast/visitor.h
+++ b/hilti/toolchain/include/ast/visitor.h
@@ -375,7 +375,7 @@ using RangePostOrder = visitor::Range<visitor::Order::Post>;
 /** Return a range that iterates over AST, returning each node successively. */
 template<typename Visitor, typename Node>
 auto range(Visitor&& /*visitor*/, Node* root, std::string_view limit_to_tag = {}) {
-    return visitor::Range<std::remove_reference<Visitor>::type::Order_>(root, limit_to_tag);
+    return visitor::Range<std::remove_reference_t<Visitor>::Order_>(root, limit_to_tag);
 }
 
 /** Walks the AST recursively and calls dispatch for each node. */

--- a/hilti/toolchain/include/ast/visitor.h
+++ b/hilti/toolchain/include/ast/visitor.h
@@ -315,6 +315,7 @@ private:
 };
 
 template<Order order, typename Dispatcher, typename Builder>
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 class MutatingVisitor : public Visitor<order, Dispatcher>, public MutatingVisitorBase {
 public:
     /**

--- a/hilti/toolchain/include/base/logger.h
+++ b/hilti/toolchain/include/base/logger.h
@@ -101,7 +101,7 @@ public:
     Stream(logging::Level level) : std::ostream(&_buf), _buf(level) {}
 
     /** Creates a stream that sends output to a given debug stream. */
-    Stream(logging::DebugStream dbg) : std::ostream(&_buf), _buf(std::move(dbg)) {}
+    Stream(logging::DebugStream dbg) : std::ostream(&_buf), _buf(dbg) {}
 
 private:
     Buffer _buf;

--- a/hilti/toolchain/include/base/logger.h
+++ b/hilti/toolchain/include/base/logger.h
@@ -80,7 +80,7 @@ constexpr auto from_string(std::string_view s) { return util::enum_::from_string
 } // namespace level
 
 /** Ostream-variant that forwards output to the central logger. */
-class Stream : public std::ostream {
+class Stream : public std::ostream { // NOLINT(misc-multiple-inheritance)
 private:
     class Buffer : public std::stringbuf {
     public:

--- a/hilti/toolchain/include/base/logger.h
+++ b/hilti/toolchain/include/base/logger.h
@@ -29,22 +29,32 @@ namespace logging {
 class DebugStream {
 public:
     /**
-     * @param name name of the stream, which must be unique across all stream
+     * @param name string literal for name of the stream, which must be unique across all stream
+     *
      */
-    explicit DebugStream(const std::string& name);
+    template<size_t N>
+    explicit DebugStream(const char (&name)[N]) noexcept : _name(name, N - 1) {
+        auto& _all = _streams();
+        if ( auto i = _all.find(name); i != _all.end() )
+            _id = i->second._id;
+        else {
+            _id = _all.size();
+            _all.emplace(name, *this);
+        }
+    }
     bool operator<(const DebugStream& other) const { return _id < other._id; }
     const auto& name() const { return _name; }
 
     /** Returns the names of all available debug streams. */
-    static std::vector<std::string> all();
+    static std::vector<std::string_view> all();
 
     /** Returns the stream for a given name. The stream must exist. */
-    static const auto& streamForName(const std::string& s) { return _streams().at(s); }
+    static const auto& streamForName(std::string_view s) { return _streams().at(s); }
 
 private:
     uint64_t _id;
-    std::string _name;
-    static std::map<std::string, DebugStream>& _streams();
+    std::string_view _name;
+    static std::map<std::string_view, DebugStream>& _streams();
 };
 
 namespace debug {} // namespace debug
@@ -184,9 +194,9 @@ public:
     }
 
     void debugEnable(const logging::DebugStream& dbg);
-    bool debugEnable(const std::string& dbg);
+    bool debugEnable(std::string_view dbg);
     void debugDisable(const logging::DebugStream& dbg) { _debug_streams.erase(dbg); }
-    bool debugDisable(const std::string& dbg);
+    bool debugDisable(std::string_view dbg);
 
     bool isEnabled(const logging::DebugStream& dbg) { return _debug_streams.contains(dbg); }
 

--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -701,6 +701,7 @@ Result<Nothing> ASTContext::processAST(Builder* builder, Driver* driver) {
     return Nothing();
 }
 
+namespace {
 // Visitor double-checking that all declarations have their canonical IDs set.
 struct VisitorCheckIDs : hilti::visitor::PreOrder {
     void operator()(Declaration* n) final {
@@ -710,6 +711,7 @@ struct VisitorCheckIDs : hilti::visitor::PreOrder {
         }
     }
 };
+} // namespace
 
 #ifndef NDEBUG
 void ASTContext::checkAST(bool finished) const {

--- a/hilti/toolchain/src/ast/operator.cc
+++ b/hilti/toolchain/src/ast/operator.cc
@@ -180,6 +180,7 @@ std::string operator_::detail::printSignature(Kind kind, const Expressions& oper
     return printOperator(kind, operands, true, meta);
 }
 
+namespace {
 class OperandResolver : public visitor::PreOrder {
 public:
     OperandResolver(Builder* builder) : builder(builder) {}
@@ -213,6 +214,7 @@ public:
             result = false;
     }
 };
+} // namespace
 
 bool Operator::init(Builder* builder, Node* scope_root) {
     auto sig = signature(builder);

--- a/hilti/toolchain/src/ast/visitor.cc
+++ b/hilti/toolchain/src/ast/visitor.cc
@@ -6,7 +6,7 @@
 using namespace hilti;
 
 visitor::MutatingVisitorBase::MutatingVisitorBase(ASTContext* ctx, logging::DebugStream dbg)
-    : _context(ctx), _dbg(std::move(dbg)) {}
+    : _context(ctx), _dbg(dbg) {}
 
 void visitor::MutatingVisitorBase::replaceNode(Node* old, Node* new_, const std::string& msg) {
     assert(old && old->parent());

--- a/hilti/toolchain/src/base/logger.cc
+++ b/hilti/toolchain/src/base/logger.cc
@@ -7,23 +7,13 @@
 
 using namespace hilti;
 
-std::map<std::string, logging::DebugStream>& logging::DebugStream::_streams() {
-    static std::map<std::string, logging::DebugStream> streams;
+std::map<std::string_view, logging::DebugStream>& logging::DebugStream::_streams() {
+    static std::map<std::string_view, logging::DebugStream> streams;
     return streams;
 }
 
-logging::DebugStream::DebugStream(const std::string& name) : _name(name) {
-    auto& _all = _streams();
-    if ( auto i = _all.find(name); i != _all.end() )
-        _id = i->second._id;
-    else {
-        _id = _all.size();
-        _all.emplace(name, *this);
-    }
-}
-
-std::vector<std::string> logging::DebugStream::all() {
-    std::vector<std::string> keys;
+std::vector<std::string_view> logging::DebugStream::all() {
+    std::vector<std::string_view> keys;
 
     const auto& _all = _streams();
 
@@ -77,7 +67,7 @@ void Logger::debugEnable(const logging::DebugStream& dbg) {
         _debug_streams[dbg] = 0;
 }
 
-bool Logger::debugEnable(const std::string& dbg) {
+bool Logger::debugEnable(std::string_view dbg) {
     try {
         debugEnable(logging::DebugStream::streamForName(dbg));
         return true;
@@ -86,7 +76,7 @@ bool Logger::debugEnable(const std::string& dbg) {
     }
 }
 
-bool Logger::debugDisable(const std::string& dbg) {
+bool Logger::debugDisable(std::string_view dbg) {
     try {
         debugDisable(logging::DebugStream::streamForName(dbg));
         return true;

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -1200,7 +1200,7 @@ class PrintCfgVisitor : public visitor::PreOrder {
     logging::DebugStream _stream;
 
 public:
-    PrintCfgVisitor(ASTContext* context, logging::DebugStream stream) : _context(context), _stream(std::move(stream)) {}
+    PrintCfgVisitor(ASTContext* context, logging::DebugStream stream) : _context(context), _stream(stream) {}
 
     void operator()(declaration::Function* f) override {
         if ( auto* body = f->function()->body() )
@@ -1215,7 +1215,7 @@ public:
 } // namespace
 
 void cfg::dump(ASTContext* context, logging::DebugStream stream, ASTRoot* root) {
-    auto v = PrintCfgVisitor(context, std::move(stream));
+    auto v = PrintCfgVisitor(context, stream);
     visitor::visit(v, root);
 }
 

--- a/hilti/toolchain/src/compiler/cfg.cc
+++ b/hilti/toolchain/src/compiler/cfg.cc
@@ -753,6 +753,7 @@ std::string CFG::dot(bool omit_dataflow) const {
     return ss.str();
 }
 
+namespace {
 struct DataflowVisitor : visitor::PreOrder {
     DataflowVisitor(GraphNode root_) : root(root_) {}
 
@@ -1003,6 +1004,7 @@ struct DataflowVisitor : visitor::PreOrder {
             transfer.keep = true;
     }
 };
+} // namespace
 
 void CFG::_populateDataflow() {
     auto visit_node = [](const GraphNode& n) -> Transfer {
@@ -1191,6 +1193,7 @@ static std::string dataflowDot(ASTContext* context, const hilti::Statement& stmt
     return cfg.dot(omit_dataflow);
 }
 
+namespace {
 // Helper class to print CFGs to a debug stream.
 class PrintCfgVisitor : public visitor::PreOrder {
     ASTContext* _context = nullptr;
@@ -1209,6 +1212,7 @@ public:
             HILTI_DEBUG(_stream, util::fmt("Module '%s'\n%s", m->id(), dataflowDot(_context, *body)));
     }
 };
+} // namespace
 
 void cfg::dump(ASTContext* context, logging::DebugStream stream, ASTRoot* root) {
     auto v = PrintCfgVisitor(context, std::move(stream));

--- a/hilti/toolchain/src/compiler/codegen/coercions.cc
+++ b/hilti/toolchain/src/compiler/codegen/coercions.cc
@@ -74,6 +74,7 @@ struct Visitor : public hilti::visitor::PreOrder {
     }
 
     void operator()(type::List* n) final {
+        (void)n;
         if ( dst->type()->isA<type::Set>() ) {
             assert(type::same(n->elementType(), dst->type()->as<type::Set>()->elementType()));
             result = expr;

--- a/hilti/toolchain/src/compiler/constant-folder.cc
+++ b/hilti/toolchain/src/compiler/constant-folder.cc
@@ -381,6 +381,7 @@ Result<Ctor*> detail::constant_folder::foldExpression(Builder* builder, Expressi
     }
 }
 
+namespace {
 struct VisitorConstantFolderAST : visitor::MutatingPostOrder {
     explicit VisitorConstantFolderAST(Builder* builder, Node* /*root*/, bitmask<Style> style)
         : visitor::MutatingPostOrder(builder, logging::debug::Resolver), style(style) {}
@@ -402,6 +403,7 @@ struct VisitorConstantFolderAST : visitor::MutatingPostOrder {
         }
     }
 };
+} // namespace
 
 bool detail::constant_folder::fold(Builder* builder, Node* node, bitmask<Style> style) {
     bool modified = false;

--- a/hilti/toolchain/src/compiler/optimizer/passes/dead-code-static.cc
+++ b/hilti/toolchain/src/compiler/optimizer/passes/dead-code-static.cc
@@ -66,7 +66,7 @@ struct Collector : public optimizer::visitor::Collector {
     void run(Node* node = nullptr) override {
         // Helper to compute the total number of collected features over all types.
         auto num_features = [&]() {
-            return std::accumulate(features.begin(), features.end(), size_t(0), [](auto acc, auto&& f) {
+            return std::accumulate(features.begin(), features.end(), static_cast<size_t>(0), [](auto acc, auto&& f) {
                 return acc + f.second.size();
             });
         };

--- a/hilti/toolchain/src/compiler/resolver.cc
+++ b/hilti/toolchain/src/compiler/resolver.cc
@@ -642,7 +642,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
                 // We register operators here so that we have the type ID for
                 // the struct available.
                 recordChange(n, "creating member call operator");
-                std::unique_ptr<struct_::MemberCall> op(new struct_::MemberCall(n));
+                auto op = std::make_unique<struct_::MemberCall>(n);
                 n->setOperator(op.get());
                 operator_::registry().register_(std::move(op));
             }
@@ -734,7 +734,7 @@ struct VisitorPass2 : visitor::MutatingPostOrder {
 
         if ( n->linkage() != declaration::Linkage::Struct && ! n->operator_() && n->function()->type()->isResolved() ) {
             recordChange(n, "creating function call operator");
-            std::unique_ptr<function::Call> op(new function::Call(n));
+            auto op = std::make_unique<function::Call>(n);
             n->setOperator(op.get());
             operator_::registry().register_(std::move(op));
         }

--- a/hilti/toolchain/src/compiler/validator.cc
+++ b/hilti/toolchain/src/compiler/validator.cc
@@ -143,10 +143,12 @@ void validator::VisitorMixIn::checkTypeArguments(const node::Range<Expression>& 
 }
 
 namespace {
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct VisitorPre : visitor::PreOrder, public validator::VisitorMixIn {
     using hilti::validator::VisitorMixIn::VisitorMixIn;
 };
 
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
     using hilti::validator::VisitorMixIn::VisitorMixIn;
 
@@ -954,6 +956,7 @@ struct VisitorPost : visitor::PreOrder, public validator::VisitorMixIn {
     }
 };
 
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct VisitorCFG : visitor::PreOrder, public validator::VisitorMixIn {
     VisitorCFG(Builder* builder, cfg::Cache* cfg_cache) : validator::VisitorMixIn(builder), cfg_cache(cfg_cache) {}
 

--- a/hilti/toolchain/tests/id-base.cc
+++ b/hilti/toolchain/tests/id-base.cc
@@ -16,6 +16,7 @@ static std::optional<std::string> normalizeID(std::string_view id) {
     return std::nullopt;
 }
 
+namespace {
 class ID : public detail::IDBase<ID, normalizeID> {
 public:
     using Base = detail::IDBase<ID, normalizeID>;
@@ -45,6 +46,7 @@ public:
 
     ID(Base&& other) noexcept : Base(other) {}
 };
+} // namespace
 
 TEST_SUITE_BEGIN("IDBase");
 

--- a/hilti/toolchain/tests/main.cc
+++ b/hilti/toolchain/tests/main.cc
@@ -5,9 +5,11 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+namespace {
 struct RuntimeWrapper {
     ~RuntimeWrapper() { hilti::rt::done(); }
 };
+} // namespace
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char** argv) {

--- a/hilti/toolchain/tests/util.cc
+++ b/hilti/toolchain/tests/util.cc
@@ -17,6 +17,7 @@
 
 TEST_SUITE_BEGIN("util");
 
+namespace {
 enum class Foo { AAA, BBB, CCC };
 constexpr hilti::util::enum_::Value<Foo> Values[] = {
     {.value = Foo::AAA, .name = "aaa"},
@@ -24,7 +25,8 @@ constexpr hilti::util::enum_::Value<Foo> Values[] = {
     {.value = Foo::CCC, .name = "ccc"},
 };
 
-constexpr static auto from_string(std::string_view s) { return hilti::util::enum_::from_string<Foo>(s, Values); }
+constexpr auto from_string(std::string_view s) { return hilti::util::enum_::from_string<Foo>(s, Values); }
+} // namespace
 
 TEST_SUITE_BEGIN("util");
 

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -469,7 +469,7 @@ inline void registerParser(::spicy::rt::Parser& p, // NOLINT(google-runtime-refe
     p.linker_scope = linker_scope;
     globalState()->parsers.emplace_back(&p);
 
-    using unit_type = typename UnitRef::element_type;
+    using unit_type = UnitRef::element_type;
 
     if constexpr ( sink::detail::supports_sinks<unit_type>::value &&
                    ! std::is_base_of_v<hilti::rt::trait::hasParameters, unit_type> )

--- a/spicy/runtime/include/parser.h
+++ b/spicy/runtime/include/parser.h
@@ -460,7 +460,7 @@ namespace detail {
 template<typename UnitRef>
 inline void registerParser(::spicy::rt::Parser& p, // NOLINT(google-runtime-references)
                            uint64_t linker_scope,
-                           UnitRef /* not used, just for template instantiation */,
+                           const UnitRef& /* not used, just for template instantiation */,
                            const hilti::rt::TypeInfo* /* utype */) {
     // Note: This may may be called before spicy::rt::init(), and during
     // hilti::rt::init(). Cannot rely on any library functionality being

--- a/spicy/runtime/src/driver.cc
+++ b/spicy/runtime/src/driver.cc
@@ -240,8 +240,8 @@ void driver::ParsingStateForDriver::debug(const std::string& msg) {
 }
 
 void driver::ParsingState::debug(const std::string& msg, size_t size, const char* data) {
-    const auto& escaped =
-        data ? hilti::rt::escapeBytes(std::string(data, std::min(size_t(40), size))) : fmt("<gap length=%d>", size);
+    const auto& escaped = data ? hilti::rt::escapeBytes(std::string(data, std::min(static_cast<size_t>(40), size))) :
+                                 fmt("<gap length=%d>", size);
     debug(hilti::rt::fmt("%s: |%s%s|", msg, escaped, size > 40 ? "..." : ""));
 }
 

--- a/spicy/runtime/src/tests/.clang-tidy
+++ b/spicy/runtime/src/tests/.clang-tidy
@@ -1,6 +1,0 @@
-# Copyright (c) 2020-now by the Zeek Project. See LICENSE for details.
-
----
-Checks: '
-  -modernize-type-traits,
-  '

--- a/spicy/runtime/src/tests/global-state.cc
+++ b/spicy/runtime/src/tests/global-state.cc
@@ -10,6 +10,7 @@ using namespace spicy::rt;
 
 TEST_SUITE_BEGIN("GlobalState");
 
+namespace {
 class TestState {
 public:
     TestState() { std::swap(_prev, detail::__global_state); }
@@ -22,6 +23,7 @@ public:
 private:
     detail::GlobalState* _prev{nullptr};
 };
+} // namespace
 
 TEST_CASE("createGlobalState") {
     TestState _;

--- a/spicy/runtime/src/tests/main.cc
+++ b/spicy/runtime/src/tests/main.cc
@@ -7,12 +7,14 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+namespace {
 struct RuntimeWrapper {
     ~RuntimeWrapper() {
         spicy::rt::done();
         hilti::rt::done();
     }
 };
+} // namespace
 
 int main(int argc, char** argv) {
     doctest::Context context;

--- a/spicy/runtime/src/tests/parser.cc
+++ b/spicy/runtime/src/tests/parser.cc
@@ -106,6 +106,7 @@ TEST_CASE("atEod") {
     }
 }
 
+namespace {
 struct UnitWithSinkSupport : std::enable_shared_from_this<UnitWithSinkSupport> {
     static Parser HILTI_INTERNAL(parser);
     std::shared_ptr<sink::detail::State> HILTI_INTERNAL(sink);
@@ -132,6 +133,7 @@ struct UnitWithSinkSupport : std::enable_shared_from_this<UnitWithSinkSupport> {
         return *this;
     }
 };
+} // namespace
 
 Parser UnitWithSinkSupport::HILTI_INTERNAL(parser){};
 

--- a/spicy/runtime/tests/benchmarks/parsing.cc
+++ b/spicy/runtime/tests/benchmarks/parsing.cc
@@ -24,7 +24,7 @@ using namespace hilti::rt::string::literals;
 static std::string bigEndian(std::uint64_t number) {
     char buffer[8];
     for ( int i = 0; i < 8; ++i ) {
-        buffer[i] = static_cast<char>((number >> (56 - 8 * i)) & 0xFF);
+        buffer[i] = static_cast<char>((number >> (56 - (8 * i))) & 0xFF);
     }
     return std::string(buffer, sizeof(buffer));
 }

--- a/spicy/toolchain/bin/spicy-doc.cc
+++ b/spicy/toolchain/bin/spicy-doc.cc
@@ -108,12 +108,14 @@ static json operandToJSON(const hilti::operator_::Operand& o, const std::string&
     return op;
 }
 
+namespace {
 class SpicyDoc : public spicy::Driver {
 public:
     SpicyDoc() : spicy::Driver("spicy-doc", hilti::util::currentExecutable()) {
         spicy::Configuration::extendHiltiConfiguration();
     }
 };
+} // namespace
 
 int main(int argc, char** argv) try {
     hilti::init();

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -56,6 +56,7 @@ static void hookAcceptInput() { accepted = true; }
 static bool declined = false; // set by hook_decline_input()
 static void hookDeclineInput(const std::string& /*reason*/) { declined = true; }
 
+namespace {
 // NOLINTNEXTLINE(misc-multiple-inheritance)
 class SpicyDriver : public spicy::Driver, public spicy::rt::Driver {
 public:
@@ -77,6 +78,7 @@ private:
     void hookInitRuntime() override { spicy::rt::init(); }
     void hookFinishRuntime() override { spicy::rt::done(); }
 };
+} // namespace
 
 void SpicyDriver::usage() {
     auto exts = hilti::util::join(hilti::plugin::registry().supportedExtensions() |

--- a/spicy/toolchain/bin/spicy-driver.cc
+++ b/spicy/toolchain/bin/spicy-driver.cc
@@ -56,6 +56,7 @@ static void hookAcceptInput() { accepted = true; }
 static bool declined = false; // set by hook_decline_input()
 static void hookDeclineInput(const std::string& /*reason*/) { declined = true; }
 
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 class SpicyDriver : public spicy::Driver, public spicy::rt::Driver {
 public:
     explicit SpicyDriver() : spicy::Driver("spicy-driver", hilti::util::currentExecutable()) {

--- a/spicy/toolchain/bin/spicy-dump/main.cc
+++ b/spicy/toolchain/bin/spicy-dump/main.cc
@@ -62,6 +62,8 @@ static void fatalError(std::string_view msg) {
     exit(1);
 }
 
+namespace {
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 class SpicyDump : public spicy::Driver, public spicy::rt::Driver {
 public:
     SpicyDump() : spicy::Driver("spicy-dump", hilti::util::currentExecutable()) {
@@ -82,6 +84,7 @@ private:
     void hookInitRuntime() override { spicy::rt::init(); }
     void hookFinishRuntime() override { spicy::rt::done(); }
 };
+} // namespace
 
 void SpicyDump::usage() {
     auto exts = hilti::util::join(hilti::plugin::registry().supportedExtensions() |

--- a/spicy/toolchain/bin/spicy-dump/printer-text.cc
+++ b/spicy/toolchain/bin/spicy-dump/printer-text.cc
@@ -180,7 +180,7 @@ void TextPrinter::print(const hilti::rt::type_info::Value& v) {
                                 out() << "(unset)";
                         }
                         else
-                            out() << ("(optimized out)");
+                            out() << "(optimized out)";
                     }
 
                     empty = false;

--- a/spicy/toolchain/bin/spicyc.cc
+++ b/spicy/toolchain/bin/spicyc.cc
@@ -9,6 +9,7 @@
 #include <spicy/compiler/driver.h>
 #include <spicy/compiler/init.h>
 
+namespace {
 class Spicyc : public spicy::Driver {
 public:
     Spicyc() : spicy::Driver("spicyc", hilti::util::currentExecutable()) {
@@ -18,6 +19,7 @@ public:
     void hookInitRuntime() override { spicy::rt::init(); }
     void hookFinishRuntime() override { spicy::rt::done(); }
 };
+} // namespace
 
 int main(int argc, char** argv) try {
     hilti::init();

--- a/spicy/toolchain/include/ast/builder/builder.h
+++ b/spicy/toolchain/include/ast/builder/builder.h
@@ -16,6 +16,7 @@ namespace spicy {
  * Base class for extended builder merging the HILTI-side API with the
  * Spicy-side factory methods.
  */
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 class BuilderBase : public hilti::Builder, public spicy::builder::NodeFactory {
 public:
     BuilderBase(ASTContext* ctx) : hilti::Builder(ctx), spicy::builder::NodeFactory(ctx) {}

--- a/spicy/toolchain/src/ast/types/unit-items/field.cc
+++ b/spicy/toolchain/src/ast/types/unit-items/field.cc
@@ -33,6 +33,7 @@ void type::unit::item::Field::setDDType(ASTContext* ctx, QualifiedType* t) {
     setChild(ctx, 0, hilti::expression::Keyword::createDollarDollarDeclaration(ctx, t));
 }
 
+namespace {
 struct SizeVisitor : hilti::visitor::PreOrder {
     SizeVisitor(Builder* builder, const spicy::type::unit::item::Field& field) : builder(builder), field(field) {}
 
@@ -64,6 +65,7 @@ struct SizeVisitor : hilti::visitor::PreOrder {
                              builder->integer(8U));
     }
 };
+} // namespace
 
 Expression* spicy::type::unit::item::Field::size(ASTContext* ctx) const {
     Builder builder(ctx);

--- a/spicy/toolchain/src/compiler/codegen/grammar.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar.cc
@@ -11,10 +11,12 @@ using namespace spicy::detail;
 using namespace spicy::detail::codegen;
 using hilti::util::fmt;
 
+namespace {
 class UnknownReference : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
 };
+} // namespace
 
 std::string Grammar::_productionLocation(const Production* p) const {
     std::string loc;

--- a/spicy/toolchain/src/compiler/validator.cc
+++ b/spicy/toolchain/src/compiler/validator.cc
@@ -281,10 +281,12 @@ Expression* methodArgument(const hilti::expression::ResolvedOperator& o, size_t 
     hilti::util::cannotBeReached();
 }
 
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct VisitorPre : visitor::PreOrder, hilti::validator::VisitorMixIn {
     using hilti::validator::VisitorMixIn::VisitorMixIn;
 };
 
+// NOLINTNEXTLINE(misc-multiple-inheritance)
 struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
     // Ensures that the node represented by tag is allowed to have all of the
     // provided attributes. This does not use any context, if more information

--- a/spicy/toolchain/src/compiler/validator.cc
+++ b/spicy/toolchain/src/compiler/validator.cc
@@ -816,7 +816,7 @@ struct VisitorPost : visitor::PreOrder, hilti::validator::VisitorMixIn {
 
         if ( auto* attrs = n->attributes() ) {
             if ( attrs->find(attribute::kind::Size) && attrs->find(attribute::kind::MaxSize) )
-                error(("attributes cannot be combined: &size, &max-size"), n);
+                error("attributes cannot be combined: &size, &max-size", n);
 
             for ( const auto& a : attrs->attributes() ) {
                 if ( a->kind() == attribute::kind::Size || a->kind() == attribute::kind::MaxSize ) {

--- a/spicy/toolchain/tests/main.cc
+++ b/spicy/toolchain/tests/main.cc
@@ -7,12 +7,14 @@
 #define DOCTEST_CONFIG_IMPLEMENT
 #include <doctest/doctest.h>
 
+namespace {
 struct RuntimeWrapper {
     ~RuntimeWrapper() {
         spicy::rt::done();
         hilti::rt::done();
     }
 };
+} // namespace
 
 // NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char** argv) {


### PR DESCRIPTION
This updates CI to llvm-21. We clean up where we manage LLVM versions, and address or at least mute newly raised clang-tidy diagnostics. The sanitizer CI job reports no new failures which is something new. The benchmark differences appear minor or incidental; they should only be due to code changes since the benchmark job's compiler setup did not change.