### PR TITLE
Use standard-compliant type for `std::string_view` iterator type

### DIFF
--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -469,7 +469,7 @@ inline uint8_t atoi_n(std::string_view input, uint8_t base, Result* result)
         throw InvalidArgument("cannot decode from empty range");
 
     bool neg = false;
-    const auto* it = input.begin();
+    std::string_view::const_iterator it = input.begin();
 
     if ( *it == '-' ) {
         neg = true;


### PR DESCRIPTION
We previously assumed that `std::string_view` used `const char*` as underlying iterator type, but this is not in the standard and in fact msvc deviates. Use a generic iterator type instead.

This fixes a regression introduced in
7c0a1f12cd672dacd28573f974c59eb30b035f69.

fixup! Change `hilti::rt::atoi_n` to take a `string_view`