### PR TITLE
Require GCC 12 for C++20 builds

### DIFF
--- a/cmake/CheckCompiler.cmake
+++ b/cmake/CheckCompiler.cmake
@@ -9,10 +9,9 @@ set(clang_minimum_version "9.0")
 # 11.0 comes with 10.15 (Catalina) and works
 set(apple_clang_minimum_version "11.0")
 
-# 7.x is not compiling HILTI/Spicy, although the standard library seems to be recent enough.
-# 8.x is untested.
-# 9.1.1 works.
-set(gcc_minimum_version "8.3")
+# C++20 support in GCC 11 is incomplete, including range adapters.
+# GCC 12 works and is available on all supported platforms.
+set(gcc_minimum_version "12")
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
The documented GCC 12 requirement was added after GCC 11 proved to have incomplete C++20 ranges support, but `CheckCompiler.cmake` still accepted GCC 8.3.

This updates the configure-time GCC guard to the documented, supported minimum. The existing C++20 feature probe remains in place for all compilers.

Validation:
- `pre-commit run cmake-format --files cmake/CheckCompiler.cmake`
- `pre-commit run cmake-lint --files cmake/CheckCompiler.cmake`
- `git diff --check`

I did not run a configure build locally because this Windows environment has no CMake or C++ compiler installed.