### PR TITLE
Sychronize minimum GCC version in CMake setup with docs

### DIFF
--- a/cmake/CheckCompiler.cmake
+++ b/cmake/CheckCompiler.cmake
@@ -9,10 +9,7 @@ set(clang_minimum_version "9.0")
 # 11.0 comes with 10.15 (Catalina) and works
 set(apple_clang_minimum_version "11.0")
 
-# 7.x is not compiling HILTI/Spicy, although the standard library seems to be recent enough.
-# 8.x is untested.
-# 9.1.1 works.
-set(gcc_minimum_version "8.3")
+set(gcc_minimum_version "12.0")
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
In 2bcf518c28fa8439e3253d866800eaaa84fa4e07 we bumped the minimum required GCC version in the docs to a version with better support for ranges, but missed updating the CMake version check. This patch fixes the CMake requirements as well.