### PR TITLE
Add missing `operator<<` for a bunch of runtime enum types

### DIFF
--- a/hilti/runtime/include/types/bytes.h
+++ b/hilti/runtime/include/types/bytes.h
@@ -224,6 +224,8 @@ inline std::ostream& operator<<(std::ostream& out, const UnsafeConstIterator& /*
 
 } // namespace detail
 
+inline std::ostream& operator<<(std::ostream& out, const Side& x) { return out << hilti::rt::to_string(x); }
+
 } // namespace bytes
 
 /** HILTI's `Bytes` is a `std::string`-like type for wrapping raw bytes with

--- a/hilti/runtime/include/types/integer.h
+++ b/hilti/runtime/include/types/integer.h
@@ -355,6 +355,8 @@ inline hilti::rt::integer::safe<UINT> noop(hilti::rt::integer::safe<UINT> v) {
     return v;
 }
 
+inline std::ostream& operator<<(std::ostream& out, const BitOrder& x) { return out << to_string(x); }
+
 } // namespace integer
 
 namespace detail::adl {

--- a/hilti/runtime/include/types/real.h
+++ b/hilti/runtime/include/types/real.h
@@ -24,6 +24,8 @@ extern Result<Tuple<double, Bytes>> unpack(const Bytes& data, Type type, ByteOrd
 /** Unpacks a floatingpoint value from a binary representation, following the protocol for `unpack` operator. */
 extern Result<Tuple<double, stream::View>> unpack(const stream::View& data, Type type, ByteOrder fmt);
 
+inline std::ostream& operator<<(std::ostream& out, const Type& x) { return out << to_string(x); }
+
 } // namespace real
 
 namespace detail::adl {

--- a/hilti/runtime/include/unicode.h
+++ b/hilti/runtime/include/unicode.h
@@ -29,6 +29,9 @@ HILTI_RT_ENUM(Charset, UTF8, UTF16LE, UTF16BE, ASCII);
 
 constexpr uint32_t REPLACEMENT_CHARACTER = 0x0000FFFD;
 
+inline std::ostream& operator<<(std::ostream& out, const DecodeErrorStrategy& x) { return out << to_string(x); }
+inline std::ostream& operator<<(std::ostream& out, const Charset& x) { return out << to_string(x); }
+
 } // namespace unicode
 
 namespace detail::adl {

--- a/hilti/runtime/include/util.h
+++ b/hilti/runtime/include/util.h
@@ -599,6 +599,8 @@ namespace detail::adl {
 std::string to_string(const ByteOrder& x, tag /*unused*/);
 }
 
+inline std::ostream& operator<<(std::ostream& out, const ByteOrder& x) { return out << to_string(x); }
+
 /** Parse time from string.
  *
  * This function uses the currently active locale and timezone to parse values.

--- a/hilti/runtime/src/tests/to_string.cc
+++ b/hilti/runtime/src/tests/to_string.cc
@@ -105,6 +105,10 @@ TEST_CASE("integer::BitOrder") {
     CHECK_EQ(to_string(Enum(integer::BitOrder::LSB0)), "BitOrder::LSB0");
     CHECK_EQ(to_string(Enum(integer::BitOrder::MSB0)), "BitOrder::MSB0");
     CHECK_EQ(to_string(Enum(integer::BitOrder::Undef)), "BitOrder::Undef");
+
+    CHECK_EQ(fmt("%s", Enum(integer::BitOrder::LSB0)), "BitOrder::LSB0");
+    CHECK_EQ(fmt("%s", Enum(integer::BitOrder::MSB0)), "BitOrder::MSB0");
+    CHECK_EQ(fmt("%s", Enum(integer::BitOrder::Undef)), "BitOrder::Undef");
 }
 
 TEST_CASE("bytes::Charset") {
@@ -113,18 +117,32 @@ TEST_CASE("bytes::Charset") {
     CHECK_EQ(to_string(Enum(unicode::Charset::UTF16BE)), "Charset::UTF16BE");
     CHECK_EQ(to_string(Enum(unicode::Charset::UTF16LE)), "Charset::UTF16LE");
     CHECK_EQ(to_string(Enum(unicode::Charset::Undef)), "Charset::Undef");
+
+    CHECK_EQ(fmt("%s", Enum(unicode::Charset::ASCII)), "Charset::ASCII");
+    CHECK_EQ(fmt("%s", Enum(unicode::Charset::UTF8)), "Charset::UTF8");
+    CHECK_EQ(fmt("%s", Enum(unicode::Charset::UTF16BE)), "Charset::UTF16BE");
+    CHECK_EQ(fmt("%s", Enum(unicode::Charset::UTF16LE)), "Charset::UTF16LE");
+    CHECK_EQ(fmt("%s", Enum(unicode::Charset::Undef)), "Charset::Undef");
 }
 
 TEST_CASE("unicode::DecodeErrorStrategy") {
     CHECK_EQ(to_string(Enum(unicode::DecodeErrorStrategy::IGNORE)), "DecodeErrorStrategy::IGNORE");
     CHECK_EQ(to_string(Enum(unicode::DecodeErrorStrategy::REPLACE)), "DecodeErrorStrategy::REPLACE");
     CHECK_EQ(to_string(Enum(unicode::DecodeErrorStrategy::STRICT)), "DecodeErrorStrategy::STRICT");
+
+    CHECK_EQ(fmt("%s", Enum(unicode::DecodeErrorStrategy::IGNORE)), "DecodeErrorStrategy::IGNORE");
+    CHECK_EQ(fmt("%s", Enum(unicode::DecodeErrorStrategy::REPLACE)), "DecodeErrorStrategy::REPLACE");
+    CHECK_EQ(fmt("%s", Enum(unicode::DecodeErrorStrategy::STRICT)), "DecodeErrorStrategy::STRICT");
 }
 
 TEST_CASE("bytes::Side") {
     CHECK_EQ(to_string(Enum(bytes::Side::Left)), "Side::Left");
     CHECK_EQ(to_string(Enum(bytes::Side::Right)), "Side::Right");
     CHECK_EQ(to_string(Enum(bytes::Side::Both)), "Side::Both");
+
+    CHECK_EQ(fmt("%s", Enum(bytes::Side::Left)), "Side::Left");
+    CHECK_EQ(fmt("%s", Enum(bytes::Side::Right)), "Side::Right");
+    CHECK_EQ(fmt("%s", Enum(bytes::Side::Both)), "Side::Both");
 }
 
 TEST_CASE("ByteOrder") {
@@ -133,6 +151,12 @@ TEST_CASE("ByteOrder") {
     CHECK_EQ(to_string(Enum(ByteOrder::Network)), "ByteOrder::Network");
     CHECK_EQ(to_string(Enum(ByteOrder::Host)), "ByteOrder::Host");
     CHECK_EQ(to_string(Enum(ByteOrder::Undef)), "ByteOrder::Undef");
+
+    CHECK_EQ(fmt("%s", Enum(ByteOrder::Little)), "ByteOrder::Little");
+    CHECK_EQ(fmt("%s", Enum(ByteOrder::Big)), "ByteOrder::Big");
+    CHECK_EQ(fmt("%s", Enum(ByteOrder::Network)), "ByteOrder::Network");
+    CHECK_EQ(fmt("%s", Enum(ByteOrder::Host)), "ByteOrder::Host");
+    CHECK_EQ(fmt("%s", Enum(ByteOrder::Undef)), "ByteOrder::Undef");
 }
 
 TEST_CASE("Bytes") {
@@ -241,6 +265,10 @@ TEST_CASE("real::Type") {
     CHECK_EQ(to_string(Enum(real::Type::IEEE754_Double)), "Type::IEEE754_Double");
     CHECK_EQ(to_string(Enum(real::Type::IEEE754_Single)), "Type::IEEE754_Single");
     CHECK_EQ(to_string(Enum(real::Type::Undef)), "Type::Undef");
+
+    CHECK_EQ(fmt("%s", Enum(real::Type::IEEE754_Double)), "Type::IEEE754_Double");
+    CHECK_EQ(fmt("%s", Enum(real::Type::IEEE754_Single)), "Type::IEEE754_Single");
+    CHECK_EQ(fmt("%s", Enum(real::Type::Undef)), "Type::Undef");
 }
 
 TEST_CASE("RegExp") {


### PR DESCRIPTION
These had implementations of `to_string` so we could e.g., use them with `print`, but were missing `operator<<` which is required for formatting with `"..." % ..`, so this commits adds them.

Closes #2439.