### PR TITLE
Do not include debug info in non-debug HLTO files

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,11 @@ Version 1.17 (in progress)
 
 .. rubric:: Changed Functionality
 
+- GH-62, GH-1102: Release builds no longer include debug information in
+  JIT-compiled code and the hilti-rt library which significantly reduces
+  the size of ``.hlto`` files. Users who need debug information in JIT-compiled
+  code can use ``spicyc -d``, which retains full debug symbols.
+
 .. rubric:: Bug fixes
 
 .. rubric:: Documentation

--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -105,7 +105,7 @@ if (NOT MSVC)
         string(REPLACE " " ";" cxx_flags_release ${CMAKE_CXX_FLAGS_RELEASE})
     endif ()
     target_compile_options(hilti-rt-objects PRIVATE ${cxx_flags_release})
-    target_compile_options(hilti-rt-objects PRIVATE "-g;-O3;-DNDEBUG;-Wall")
+    target_compile_options(hilti-rt-objects PRIVATE "-O3;-DNDEBUG;-Wall")
 endif ()
 target_compile_definitions(hilti-rt-objects PRIVATE "HILTI_RT_BUILD_TYPE_RELEASE")
 

--- a/hilti/toolchain/src/config.cc.in
+++ b/hilti/toolchain/src/config.cc.in
@@ -201,7 +201,6 @@ void Configuration::init(bool use_build_directory) {
     runtime_cxx_flags_release = flatten({
         "-fPIC",
         "-std=c++20",
-        "-g",
         "-O3",
         "-DNDEBUG",
         "-fvisibility=hidden",


### PR DESCRIPTION
Including debug information significantly increases the size of these artifacts, something users have often complained about. Additionally, compiling with both `-O3` and `-g` can make release builds even slower.

Since no user-visible feature depends on this, codegen is mostly identical between between, and I do not recall ever being unable to debug an issue which required debug symbols in release HLTO files, simply drop the flag. If this is really needed, we could always patch it back in temporarily while debugging without affecting all users.

Closes #62.
Closes #1102.