### PR TITLE
Fix namespace for type code emission during C++ codegen

### DIFF
--- a/hilti/toolchain/src/ast/ast-context.cc
+++ b/hilti/toolchain/src/ast/ast-context.cc
@@ -142,8 +142,17 @@ public:
     void operator()(declaration::Type* n) final { insert(n); }
 
     void operator()(QualifiedType* n) final {
-        if ( n->isExternal() )
-            follow(n->type());
+        if ( n->isExternal() ) {
+            auto* t = n->type();
+            if ( auto* decl = t->typeDeclaration() ) {
+                // Skip self-references, e.g., a unit's parse methods referencing its own type.
+                if ( ! cd.haveSeen(decl) )
+                    insert(decl);
+                follow(decl);
+            }
+            else
+                follow(t);
+        }
     }
 
     void operator()(expression::Name* n) final {

--- a/hilti/toolchain/src/compiler/cxx/unit.cc
+++ b/hilti/toolchain/src/compiler/cxx/unit.cc
@@ -186,6 +186,7 @@ void Unit::_emitDeclarations(const cxxDeclaration& decl,
 
             else if ( phase == Phase::Functions ) {
                 if ( d.code.size() && ! prototypes_only ) {
+                    f.enterNamespace(d.id.namespace_());
                     f << d.code << eol();
                 }
             }

--- a/tests/spicy/types/unit/convert-field-to-ref.spicy
+++ b/tests/spicy/types/unit/convert-field-to-ref.spicy
@@ -4,7 +4,14 @@
 # introduced the issue, validate tests still reproduce the issue before
 # changing names.
 #
+# Single module with `&convert` to a non-public type.
 # @TEST-EXEC: spicyc -dj %INPUT
+#
+# Cross-module import of a unit with `&convert` to a non-public type.
+# @TEST-EXEC: spicyc -dj proto.spicy consumer.spicy
+#
+# External hook on a unit with `&convert` to a non-public type.
+# @TEST-EXEC: spicyc -dj hook.spicy proto.spicy
 
 module Consumer;
 
@@ -17,3 +24,39 @@ type Outer = unit {
 };
 
 type Foo = unit {};
+
+# @TEST-START-FILE proto.spicy
+
+module Proto;
+
+public type Outer = unit {
+    a: Foo &convert=new Foo($$);
+};
+
+type Foo = unit {
+    a: uint8;
+};
+
+# @TEST-END-FILE
+
+# @TEST-START-FILE consumer.spicy
+
+module Consumer2;
+
+import Proto;
+
+public type Bar = unit {
+    a: Proto::Outer;
+};
+
+# @TEST-END-FILE
+
+# @TEST-START-FILE hook.spicy
+
+module Hook;
+
+import Proto;
+
+on Proto::Outer::%done { }
+
+# @TEST-END-FILE

--- a/tests/spicy/types/unit/convert-field-to-ref.spicy
+++ b/tests/spicy/types/unit/convert-field-to-ref.spicy
@@ -1,0 +1,19 @@
+# @TEST-DOC: Converting a field value to a reference compiles correctly. Regression test for #2456.
+#
+# NOTE: Since the order of node traversal depends on e.g., module names
+# introduced the issue, validate tests still reproduce the issue before
+# changing names.
+#
+# @TEST-EXEC: spicyc -dj %INPUT
+
+module Consumer;
+
+public type Bar = unit {
+    a: Outer;
+};
+
+type Outer = unit {
+    a: Foo &convert=new Foo($$);
+};
+
+type Foo = unit {};


### PR DESCRIPTION
We now enter the correct namespace before emitting a type declaration's implementation code during `Phase::Functions`. Previously the formatter stayed in whatever namespace the previous declaration left active, causing C++ compilation failures when declaration ordering placed a type's code after an unrelated namespace block.

The sensitivity to module naming (e.g., "Consumer" failing while "foo" works) comes from declaration insertion order: the dependency graph traversal places different declarations between a type's struct code and its implementation depending on names, which changes whether an intervening declaration switches the formatter's active namespace away.

Closes #2456.

> [!NOTE]
> All code changes in this PR were generated with Claude Sonnet 4.6. I reviewed all changes and am accountable.