### PR TITLE
Fix RTD build broken by uv 0.12 relative path bug [skip ci]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,16 @@ build:
   tools:
     python: "3.11"
 
+  # Workaround for https://github.com/readthedocs/readthedocs.org/issues/13213.
+  jobs:
+    create_environment:
+      - uv venv --project $READTHEDOCS_REPOSITORY_PATH/doc $READTHEDOCS_VIRTUALENV_PATH
+    build:
+      html:
+        - cd $READTHEDOCS_REPOSITORY_PATH/doc &&
+          uv run --project $READTHEDOCS_REPOSITORY_PATH/doc --no-sync --no-dev
+          sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+
 sphinx:
   fail_on_warning: false
   configuration: doc/conf.py


### PR DESCRIPTION
RTD's uv 0.12 integration passes `UV_PROJECT` as a relative path but runs commands from a different CWD, causing "Project directory does not exist" errors (readthedocs/readthedocs.org#13213).

Work around by overriding `create_environment` and `build.html` with absolute paths.

> [!NOTE]
> All code changes in this PR were generated with Claude Sonnet 4.6. I reviewed all changes and am accountable.