### PR TITLE
Require GCC 12 for C++20 builds

### DIFF
--- a/cmake/CheckCompiler.cmake
+++ b/cmake/CheckCompiler.cmake
@@ -9,10 +9,8 @@ set(clang_minimum_version "9.0")
 # 11.0 comes with 10.15 (Catalina) and works
 set(apple_clang_minimum_version "11.0")
 
-# 7.x is not compiling HILTI/Spicy, although the standard library seems to be recent enough.
-# 8.x is untested.
-# 9.1.1 works.
-set(gcc_minimum_version "8.3")
+# GCC 12 is the minimum supported version for compiling HILTI/Spicy with C++20.
+set(gcc_minimum_version "12.0")
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
## what changed

the docs and ci already say gcc 12 is the supported gcc baseline, but the cmake guard still allowed gcc 8.3. this updates the guard to 12.0 and removes the old 9.1.1 note.

## why

with the old check, an unsupported gcc version could get past configure and fail later while compiling c++20 code.

## checks

- git diff --check passes.
- the local machine does not have cmake or a c++ toolchain installed, so the native build is left to repository ci.

fixes #2428