### PR TITLE
Remove workaround for readthedocs/readthedocs.org#13213 [skip ci]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,16 +7,6 @@ build:
   tools:
     python: "3.11"
 
-  # Workaround for https://github.com/readthedocs/readthedocs.org/issues/13213.
-  jobs:
-    create_environment:
-      - uv venv --project $READTHEDOCS_REPOSITORY_PATH/doc $READTHEDOCS_VIRTUALENV_PATH
-    build:
-      html:
-        - cd $READTHEDOCS_REPOSITORY_PATH/doc &&
-          uv run --project $READTHEDOCS_REPOSITORY_PATH/doc --no-sync --no-dev
-          sphinx-build -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
-
 sphinx:
   fail_on_warning: false
   configuration: doc/conf.py


### PR DESCRIPTION
An upstream fix for the issue has landed and we can remove our workaround again.