### PR TITLE
Mark `public` unit alias parser struct with `&always-emit`

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/unit-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/unit-builder.cc
@@ -440,7 +440,8 @@ void CodeGen::compilePublicUnitAlias(hilti::declaration::Module* module, const I
     auto* attrs = builder()->attributeSet(
         {builder()->attribute(hilti::attribute::kind::Static),
          builder()->attribute(hilti::attribute::kind::Internal),
-         builder()->attribute(hilti::attribute::kind::NeededByFeature, builder()->stringLiteral("supports_filters"))});
+         builder()->attribute(hilti::attribute::kind::NeededByFeature, builder()->stringLiteral("supports_filters")),
+         builder()->attribute(hilti::attribute::kind::AlwaysEmit)});
 
     auto* parser_field = builder()->declarationField(ID(HILTI_INTERNAL_ID("parser")),
                                                      builder()->qualifiedType(builder()->typeName("spicy_rt::Parser"),
@@ -448,11 +449,13 @@ void CodeGen::compilePublicUnitAlias(hilti::declaration::Module* module, const I
                                                      attrs);
 
     auto struct_id = ID(alias_id.namespace_(), HILTI_INTERNAL_ID("parser_") + alias_id.local().str());
-    auto* struct_decl = builder()->declarationType(struct_id.local(),
-                                                   builder()->qualifiedType(builder()->typeStruct({parser_field}),
-                                                                            hilti::Constness::Mutable),
-                                                   hilti::declaration::Linkage::Public,
-                                                   unit->meta());
+    auto* struct_decl =
+        builder()->declarationType(struct_id.local(),
+                                   builder()->qualifiedType(builder()->typeStruct({parser_field}),
+                                                            hilti::Constness::Mutable),
+                                   builder()->attributeSet({builder()->attribute(hilti::attribute::kind::AlwaysEmit)}),
+                                   hilti::declaration::Linkage::Public,
+                                   unit->meta());
     module->add(context(), struct_decl);
 
     _compileParserRegistration(alias_id, struct_id, unit);

--- a/tests/spicy/types/unit/alias-public.spicy
+++ b/tests/spicy/types/unit/alias-public.spicy
@@ -1,0 +1,14 @@
+# @TEST-DOC: Validate that public unit aliases do not get optimized away incorrectly. Regression test for #2447.
+#
+# NOTE: We do not pass `-d` here since it would enable strict public
+# API mode which would prevent possible removal of the public alias.
+#
+# @TEST-EXEC: echo 123 | spicy-driver %INPUT -p foo::X2
+
+module foo;
+
+public type X2 = X;
+
+public type X = unit {
+    x: bytes &eod;
+};


### PR DESCRIPTION
The way we annotated `public` type aliases was inconsistent with how we treated `public` units, in particular `public` units are `&always-emit` while `public` type aliases were not. The absence of `&always-emit` allowed the dead code removal pass to remove the type alias, even though we'd still register a parser from the alias which would then fail to compile.

With this patch we declare `public` aliases `&always-emit`, consistent with how we already treat `public` unit types.

Closes #2447.