### PR TITLE
Treat `void` unit fields as epsilon

### DIFF
--- a/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
+++ b/spicy/toolchain/src/compiler/codegen/grammar-builder.cc
@@ -319,6 +319,8 @@ struct Visitor : public visitor::PreOrder {
 
     void operator()(hilti::declaration::Type* n) final { result = pf->createProduction(n->type()); }
 
+    void operator()(hilti::type::Void*) final { result = std::make_unique<production::Epsilon>(context()); }
+
     void operator()(type::Unit* n) final {
         // Note: We can't use the cache's getOrCreate() here because of the
         // unique_ptr storage semantics.

--- a/tests/spicy/types/unit/void-lahead.spicy
+++ b/tests/spicy/types/unit/void-lahead.spicy
@@ -1,0 +1,21 @@
+# @TEST-DOC: Validate that `void` fields are ignored in lookahead parsing, regression test for #2477.
+
+# @TEST-EXEC: $SCRIPTS/printf "abcd\x00efg" | spicy-dump -d %INPUT
+
+module foo;
+
+public type X = unit {
+    xs: (bytes &size=1)[];
+
+    # This field is `void` and determining the lookahead token
+    # for above parsing should look at the next field.
+    : void {
+        print "foo";
+    }
+
+    lahead_end: skip b"\x00";
+
+    on %done {
+        assert |self.xs| == 4;
+    }
+};


### PR DESCRIPTION
We would previously treat `void` fields as producing normal variables. Since they consume no data this is incorrect and also confuses lookahead parsing.

This patch switches `void` fields to instead generate epsilon productions.

Closes #2477.