### PR TITLE
Fix Clang-23 RC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,22 @@ add_subdirectory(spicy)
 add_subdirectory(scripts)
 add_subdirectory(3rdparty)
 
+if (MSVC)
+    set_property(TARGET fiber APPEND PROPERTY COMPILE_OPTIONS "/w")
+else ()
+    set_property(TARGET fiber APPEND PROPERTY COMPILE_OPTIONS "-w")
+endif ()
+
+# Suppress warnings from bundled headers when their targets are consumed.
+foreach (target benchmark fiber header-utils jrx-objects reproc reproc++)
+    if (TARGET ${target})
+        set_property(
+            TARGET ${target} APPEND
+            PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                     "$<TARGET_PROPERTY:${target},INTERFACE_INCLUDE_DIRECTORIES>")
+    endif ()
+endforeach ()
+
 ## Print build summary
 string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
 

--- a/hilti/runtime/CMakeLists.txt
+++ b/hilti/runtime/CMakeLists.txt
@@ -71,16 +71,17 @@ foreach (lib hilti-rt hilti-rt-debug)
     target_include_directories(${lib}-objects BEFORE
                                PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
     target_include_directories(
-        ${lib}-objects BEFORE PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty>
-                                     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/json/include>)
+        ${lib}-objects SYSTEM BEFORE
+        PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty>
+               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/json/include>)
 
     add_dependencies(${lib}-objects jrx-objects)
-    target_include_directories(${lib}-objects BEFORE
+    target_include_directories(${lib}-objects SYSTEM BEFORE
                                PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/justrx/include)
 
     add_dependencies(${lib}-objects fiber)
     target_include_directories(
-        ${lib}-objects
+        ${lib}-objects SYSTEM BEFORE
         PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/fiber/include
                 ${PROJECT_SOURCE_DIR}/3rdparty/fiber/deps/cxx-header-utils/include
                 ${PROJECT_SOURCE_DIR}/3rdparty/utfcpp/source)

--- a/hilti/runtime/include/backtrace.h
+++ b/hilti/runtime/include/backtrace.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <array>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <vector>

--- a/hilti/runtime/include/json-fwd.h
+++ b/hilti/runtime/include/json-fwd.h
@@ -2,22 +2,8 @@
 
 #pragma once
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
-#elif defined(__GNUC__)
-// Note that clang #defines __GNUC__ as well.
-#pragma GCC diagnostic push
-#endif
-
 // `3rdparty/json/include` is on the build-time include path, and post-install
 // `nlohmann/` is installed under the include prefix, so this bare path
 // resolves in both cases without relying on the `hilti/rt/3rdparty/nlohmann`
 // directory symlink which does not work on Windows.
 #include <nlohmann/json_fwd.hpp>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif

--- a/hilti/runtime/include/json.h
+++ b/hilti/runtime/include/json.h
@@ -2,20 +2,5 @@
 
 #pragma once
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
-#pragma clang diagnostic ignored "-Wdeprecated-literal-operator"
-#elif defined(__GNUC__)
-// Note that clang #defines __GNUC__ as well.
-#pragma GCC diagnostic push
-#endif
-
 // See `json-fwd.h` for why we use the bare `<nlohmann/json.hpp>` path here.
 #include <nlohmann/json.hpp>
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -205,9 +205,15 @@ set_config_val(
     "!INSTALL!${CMAKE_INSTALL_FULL_INCLUDEDIR} !BUILD!${PROJECT_SOURCE_DIR}/hilti/toolchain/include !BUILD!${PROJECT_BINARY_DIR}/include"
 )
 
-# CXX flags — use dash-prefixed form (-D, -EHsc, …) so MSYS2/Git-Bash
-# does not mistake slash-prefixed flags for POSIX paths.
-string(REGEX REPLACE "(^| )/" "\\1-" _cxx_flags "${CMAKE_CXX_FLAGS}")
+# CXX flags — with MSVC use dash-prefixed form (-D, -EHsc, …) so MSYS2/Git-Bash
+# does not mistake slash-prefixed flags for POSIX paths. Do not do this
+# elsewhere: there slash-prefixed tokens are absolute paths (e.g. the argument
+# of `-isystem`), not flags.
+if (MSVC)
+    string(REGEX REPLACE "(^| )/" "\\1-" _cxx_flags "${CMAKE_CXX_FLAGS}")
+else ()
+    set(_cxx_flags "${CMAKE_CXX_FLAGS}")
+endif ()
 set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_DEBUG
                "${addl_cxx_flags} ${EXTRA_CXX_FLAGS} ${_cxx_flags}")
 set_config_val(HILTI_CONFIG_RUNTIME_CXX_FLAGS_RELEASE
@@ -241,8 +247,12 @@ endif ()
 set_config_val(HILTI_CONFIG_TOOLCHAIN_CXX_LIBRARY_DIRS
                "!BUILD!${CMAKE_LIBRARY_OUTPUT_DIRECTORY} !INSTALL!${CMAKE_INSTALL_FULL_LIBDIR}")
 
-# LD flags
-string(REGEX REPLACE "(^| )/" "\\1-" _ld_flags "${CMAKE_EXE_LINKER_FLAGS_INIT}")
+# LD flags (see the CXX flags above for why this is MSVC-only)
+if (MSVC)
+    string(REGEX REPLACE "(^| )/" "\\1-" _ld_flags "${CMAKE_EXE_LINKER_FLAGS_INIT}")
+else ()
+    set(_ld_flags "${CMAKE_EXE_LINKER_FLAGS_INIT}")
+endif ()
 set_config_val(HILTI_CONFIG_RUNTIME_LD_FLAGS_DEBUG
                "${addl_ld_flags} ${EXTRA_LD_FLAGS} ${_ld_flags}")
 set_config_val(HILTI_CONFIG_RUNTIME_LD_FLAGS_RELEASE

--- a/hilti/toolchain/CMakeLists.txt
+++ b/hilti/toolchain/CMakeLists.txt
@@ -162,7 +162,7 @@ target_link_libraries(hilti-objects
 target_link_libraries(hilti-objects PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
 add_dependencies(hilti-objects reproc++)
-target_include_directories(hilti-objects BEFORE
+target_include_directories(hilti-objects SYSTEM BEFORE
                            PRIVATE ${PROJECT_SOURCE_DIR}/3rdparty/reproc/reproc++/include)
 
 add_library(hilti)

--- a/hilti/toolchain/tests/id-base.cc
+++ b/hilti/toolchain/tests/id-base.cc
@@ -36,10 +36,6 @@ public:
     ID(std::string_view s, AlreadyNormalized n) : Base(s, n) {}
 
     /** Concatenates multiple strings into a single ID, separating them with `::`. */
-    template<typename... T, typename enable = std::enable_if_t<(... && std::is_convertible_v<T, std::string_view>)>>
-    explicit ID(const T&... s) : Base(s...) {}
-
-    /** Concatenates multiple strings into a single ID, separating them with `::`. */
     ID(std::initializer_list<std::string_view> x) : Base(x) {}
 
     ID(const Base& other) : Base(other) {}

--- a/spicy/runtime/CMakeLists.txt
+++ b/spicy/runtime/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach (lib spicy-rt spicy-rt-debug)
     target_include_directories(${lib}-objects BEFORE
                                PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
     target_include_directories(
-        ${lib}-objects BEFORE
+        ${lib}-objects SYSTEM BEFORE
         PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/3rdparty/libb64/include>)
 
     add_library(${lib} STATIC)

--- a/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/literals.cc
@@ -51,7 +51,7 @@ struct Visitor : public visitor::PreOrder {
     auto pushBuilder(std::shared_ptr<Builder> b) { return pb()->pushBuilder(std::move(b)); }
     auto pushBuilder() { return pb()->pushBuilder(); }
     template<typename Func>
-    auto pushBuilder(std::shared_ptr<Builder> b, Func&& func) {
+    [[maybe_unused]] auto pushBuilder(std::shared_ptr<Builder> b, Func&& func) {
         return pb()->pushBuilder(std::move(b), std::forward(func));
     }
     auto popBuilder() { return pb()->popBuilder(); }

--- a/spicy/toolchain/src/compiler/codegen/parsers/types.cc
+++ b/spicy/toolchain/src/compiler/codegen/parsers/types.cc
@@ -38,7 +38,7 @@ struct TypeParser {
     auto pushBuilder(std::shared_ptr<Builder> b) { return pb->pushBuilder(std::move(b)); }
     auto pushBuilder() { return pb->pushBuilder(); }
     template<typename Func>
-    auto pushBuilder(std::shared_ptr<Builder> b, Func&& func) {
+    [[maybe_unused]] auto pushBuilder(std::shared_ptr<Builder> b, Func&& func) {
         return pb->pushBuilder(std::move(b), std::forward(func));
     }
     auto popBuilder() { return pb->popBuilder(); }


### PR DESCRIPTION
draft since I'm going to look at other stuff too (and so I make sure to come back to this), this isn't urgent.

Just tested Clang 23 RC3 and hit an error building Zeek:

```
In file included from /Users/etyp/src/zeek/auxil/spicy/hilti/runtime/src/backtrace.cc:6:
/Users/etyp/src/zeek/auxil/spicy/hilti/runtime/include/hilti/rt/backtrace.h:57:9: error: use of undeclared identifier 'free'
   57 |         free(dname); // NOLINT
      |         ^~~~
1 error generated.
```

Also changed this to fix some warnings, as well.

Note this fixes warnings in fiber/ - I did that as patches (see https://github.com/zeek/fiber/pull/1). Unless they respond upstream to the other patch, I don't see much reason to not mildly maintain it ourselves.