### PR TITLE
Enable the fiber runtime on PowerPC64

### DIFF
--- a/hilti/runtime/src/fiber.cc
+++ b/hilti/runtime/src/fiber.cc
@@ -237,7 +237,7 @@ detail::Fiber::Fiber(Type type) : _type(type), _fiber(std::make_unique<::Fiber>(
             if ( limit.rlim_cur < min_size )
                 throw RuntimeError(fmt("process stack size too small, need at least %zu KB", min_size / 1024));
 
-#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__
+#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__ || __powerpc64__
             // There's a bit of fuzziness here as the current frame won't start
             // exactly at the beginning of the stack---but should be good
             // enough.
@@ -382,7 +382,7 @@ std::pair<char*, char*> detail::StackBuffer::activeRegion() const {
     // The direction in which the stack grows is platform-specific. It's
     // probably gong to be growing downwards pretty much everywhere, but to be
     // safe we whitelist platforms that we have confirmed to do so.
-#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__
+#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__ || __powerpc64__
     auto* lower = reinterpret_cast<char*>(_fiber->regs.sp);
     auto* upper = reinterpret_cast<char*>(_fiber->regs.sp) + fiber_stack_used_size(_fiber);
 #elif defined(_M_X64) || defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
@@ -404,7 +404,7 @@ size_t detail::StackBuffer::liveRemainingSize() const {
     assert(::fiber_is_executing(_fiber)); // must be live
 
     // Whitelist architectures where we know how to do this.
-#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__
+#if __x86_64__ || __arm__ || __arm64__ || __aarch64__ || __i386__ || __powerpc64__
     // See
     // https://stackoverflow.com/questions/20059673/print-out-value-of-stack-pointer
     // for discussion of how to get stack pointer.


### PR DESCRIPTION
The three stack-inspection helpers (Fiber::Fiber, StackBuffer::activeRegion,
StackBuffer::liveRemainingSize) are already portable -- they use
__builtin_frame_address(0) and the fiber's saved stack pointer -- but were
gated behind a fixed architecture whitelist. Add __powerpc64__ so they are
enabled on PowerPC64, whose fiber context switching the bundled fiber library
supports (ELFv2, both endiannesses).

Verified on FreeBSD 15.1/powerpc64 (big-endian, POWER9).
